### PR TITLE
Fixes to build with .Net

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/ContextBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ContextBackendHandler.cs
@@ -237,8 +237,9 @@ namespace Xwt.GtkBackend
 			var ctx = (GtkContext) backend;
 			IDisposable d = (IDisposable) ctx.Context;
 			d.Dispose ();
-			if (ctx.TempSurface != null)
-				ctx.TempSurface.Dispose ();
+            d = (IDisposable)ctx.TempSurface;
+			if (d != null)
+				d.Dispose ();
 		}
 		#endregion
 	}

--- a/Xwt.Gtk/Xwt.GtkBackend/CustomListModel.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CustomListModel.cs
@@ -114,12 +114,12 @@ namespace Xwt.GtkBackend
 		}
 
 		public bool GetIter (out Gtk.TreeIter iter, Gtk.TreePath path)
-		{
+        {
+            iter = Gtk.TreeIter.Zero;
 			if (path.Indices.Length == 0)
 				return false;
 			int row = path.Indices [0];
 			if (row >= source.RowCount) {
-				iter = Gtk.TreeIter.Zero;
 				return false;
 			}
 			iter = IterFromNode (row);
@@ -150,7 +150,8 @@ namespace Xwt.GtkBackend
 		}
 
 		public bool IterChildren (out Gtk.TreeIter iter, Gtk.TreeIter parent)
-		{
+        {
+            iter = Gtk.TreeIter.Zero;
 			return false;
 		}
 

--- a/Xwt.Gtk/Xwt.GtkBackend/CustomTreeModel.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CustomTreeModel.cs
@@ -120,7 +120,8 @@ namespace Xwt.GtkBackend
 		}
 
 		public bool GetIter (out Gtk.TreeIter iter, Gtk.TreePath path)
-		{
+        {
+            iter = Gtk.TreeIter.Zero;
 			TreePosition pos = null;
 			int[] indices = path.Indices;
 			if (indices.Length == 0)
@@ -181,7 +182,8 @@ namespace Xwt.GtkBackend
 		}
 
 		public bool IterChildren (out Gtk.TreeIter iter, Gtk.TreeIter parent)
-		{
+        {
+            iter = Gtk.TreeIter.Zero;
 			TreePosition pos = NodeFromIter (parent);
 			pos = source.GetChild (pos, 0);
 			if (pos != null) {
@@ -204,7 +206,8 @@ namespace Xwt.GtkBackend
 		}
 
 		public bool IterNthChild (out Gtk.TreeIter iter, Gtk.TreeIter parent, int n)
-		{
+        {
+            iter = Gtk.TreeIter.Zero;
 			TreePosition pos = NodeFromIter (parent);
 			pos = source.GetChild (pos, n);
 			if (pos != null) {
@@ -215,7 +218,8 @@ namespace Xwt.GtkBackend
 		}
 
 		public bool IterParent (out Gtk.TreeIter iter, Gtk.TreeIter child)
-		{
+        {
+            iter = Gtk.TreeIter.Zero;
 			TreePosition pos = NodeFromIter (iter);
 			pos = source.GetParent (pos);
 			if (pos != null) {


### PR DESCRIPTION
Lluis, some small fixes to be able to build with .Net. I think all due to mono compiler bugs missing things. I also have a local change to build the Gtk# backend for x86 since the Gtk+ libs are x86. Not sure if that is acceptable or not.
