### PR TITLE
Xwt.Rectangle: refactor to pass standard tests

### DIFF
--- a/Xwt/Xwt/Rectangle.cs
+++ b/Xwt/Xwt/Rectangle.cs
@@ -57,7 +57,7 @@ namespace Xwt
 		
 		public static Rectangle FromLTRB (double left, double top, double right, double bottom)
 		{
-			return new Rectangle (left, top, right - left + 1, bottom - top + 1);
+			return new Rectangle (left, top, right - left, bottom - top);
 		}
 		
 		// Equality
@@ -97,14 +97,14 @@ namespace Xwt
 		
 		public bool Contains (double x, double y)
 		{
-			return ((x >= Left) && (x <= Right) && 
-				(y >= Top) && (y <= Bottom));
+			return ((x >= Left) && (x < Right) && 
+				(y >= Top) && (y < Bottom));
 		}
 		
 		public bool IntersectsWith (Rectangle r)
 		{
-			return !((Left > r.Right) || (Right < r.Left) ||
-			    (Top > r.Bottom) || (Bottom < r.Top));
+			return !((Left >= r.Right) || (Right <= r.Left) ||
+					(Top >= r.Bottom) || (Bottom <= r.Top));
 		}
 		
 		public Rectangle Union (Rectangle r)
@@ -112,7 +112,7 @@ namespace Xwt
 			return Union (this, r);
 		}
 		
-		Rectangle Union (Rectangle r1, Rectangle r2)
+		public static Rectangle Union (Rectangle r1, Rectangle r2)
 		{
 			return FromLTRB (Math.Min (r1.Left, r2.Left),
 					 Math.Min (r1.Top, r2.Top),
@@ -124,15 +124,19 @@ namespace Xwt
 		{
 			return Intersect (this, r);
 		}
-		
-		Rectangle Intersect (Rectangle r1, Rectangle r2)
+
+		public static Rectangle Intersect (Rectangle r1, Rectangle r2)
 		{
-			if (!r1.IntersectsWith (r2))
-				return new Rectangle ();
-			return FromLTRB (Math.Max (r1.Left, r2.Left),
-					 Math.Max (r1.Top, r2.Top),
-					 Math.Min (r1.Right, r2.Right),
-					 Math.Min (r1.Bottom, r2.Bottom));
+			var x = Math.Max (r1.X, r2.X);
+			var y = Math.Max (r1.Y, r2.Y);
+			var width = Math.Min (r1.Right, r2.Right) - x;
+			var height = Math.Min (r1.Bottom, r2.Bottom) - y;
+
+			if (width < 0 || height < 0) 
+			{
+				return Rectangle.Zero;
+			}
+			return new Rectangle (x, y, width, height);
 		}
 		
 		// Position/Size
@@ -141,12 +145,12 @@ namespace Xwt
 			set { Y = value; }
 		}
 		public double Bottom {
-			get { return Y + Height - 1; }
-			set { Height = value - Y + 1; }
+			get { return Y + Height; }
+			set { Height = value - Y; }
 		}
 		public double Right {
-			get { return X + Width - 1; }
-			set { Width = value - X + 1; }
+			get { return X + Width; }
+			set { Width = value - X; }
 		}
 		public double Left {
 			get { return X; }
@@ -154,7 +158,7 @@ namespace Xwt
 		}
 		
 		public bool IsEmpty {
-			get { return (Width == 0) || (Height == 0); }
+			get { return (Width <= 0) || (Height <= 0); }
 		}
 		
 		public Size Size {


### PR DESCRIPTION
Xwt.Rectangle has some different behaviour compared with Rectangles like System.Drawing.RectangleF or System.Windows.Rect.
I guess most people are using System.Drawing.RectangleF or System.Windows.Rect so it would be nice to have the same behaviours.

As far as I can see now the "errors" are in methods that noone uses so far,
as: Right, Bottom, FromLRTB, Union, Intersect, Contains

I refactored
https://github.com/mono/mono/blob/master/mcs/class/System.Drawing/Test/System.Drawing/TestRectangleF.cs
and
https://github.com/mono/mono/blob/master/mcs/class/WindowsBase/Test/System.Windows/RectTest.cs
to work with Xwt.Rectangle.

You can find the tests here, as there is no Xwt.Text-Project, as far as I can see:
http://limada.git.sourceforge.net/git/gitweb.cgi?p=limada/limada;a=blob_plain;f=src/Limaki.Tests/Playground/View/Rectangle/TestRectangle.cs;hb=250dc8d3c45752b438f0d6478a6993927b5b65c4
http://limada.git.sourceforge.net/git/gitweb.cgi?p=limada/limada;a=blob_plain;f=src/Limaki.Tests/Playground/View/Rectangle/RectTest.cs;hb=250dc8d3c45752b438f0d6478a6993927b5b65c4

the results with new Xwt.Rectangle:
24 passed, 0 failed, 0 skipped, took 1,28 seconds (NUnit 2.5.5).

the results with old Xwt.Rectangle:

Test 'Xwt.Test.TestRectangle.Contains' failed: 
  f
  Expected: True
  But was:  False
    Playground\View\Rectangle\TestRectangle.cs(65,0): bei Xwt.Test.TestRectangle.Contains()

Test 'Xwt.Test.TestRectangle.EdgeIntersection' failed: 
  X
  Expected: 20.0d
  But was:  0.0d
    Playground\View\Rectangle\TestRectangle.cs(231,0): bei Xwt.Test.TestRectangle.EdgeIntersection()

Test 'Xwt.Test.TestRectangle.GetContents' failed: 
  Right
  Expected: 34.0d
  But was:  35.0d
    Playground\View\Rectangle\TestRectangle.cs(88,0): bei Xwt.Test.TestRectangle.GetContents()

Test 'Xwt.Test.TestRectangle.IsEmpty' failed: 
  negative w/h
  Expected: True
  But was:  False
    Playground\View\Rectangle\TestRectangle.cs(83,0): bei Xwt.Test.TestRectangle.IsEmpty()

Test 'Xwt.Test.TestRectangle.Union' failed: 
  Expected: 5,5/46x46
  But was:  5,5/45x45
    Playground\View\Rectangle\TestRectangle.cs(180,0): bei Xwt.Test.TestRectangle.Union()

13 passed, 5 failed, 0 skipped, took 3,95 seconds (NUnit 2.5.5).
