### PR TITLE
Correctly handle WPF window bounds.

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
@@ -52,6 +52,10 @@ namespace Xwt.WPFBackend
 			Window.Content = rootPanel;
 		}
 
+		public override bool HasMenu {
+			get { return mainMenu != null; }
+		}
+
 		public void SetChild (IWidgetBackend child)
 		{
 			if (widget != null)


### PR DESCRIPTION
This involves two things:
1. Window's Width and Height include non-client areas,
   so we need to adjust the values.
2. Window's Width and Height return Double.NaN if they haven't been
   manually set, so we use the actual 'automatic' size as a
   fallback.
