### PR TITLE
Fix WPF must run on UI Thread, GC may run on new thread and call Dispose

### DIFF
--- a/Xwt/Xwt/Widget.cs
+++ b/Xwt/Xwt/Widget.cs
@@ -238,8 +238,6 @@ namespace Xwt
 		protected override void Dispose (bool disposing)
 		{
 			base.Dispose (disposing);
-			if (Backend != null)
-				Backend.Dispose (disposing);
 		}
 		
 		public WindowFrame ParentWindow {

--- a/Xwt/Xwt/WindowFrame.cs
+++ b/Xwt/Xwt/WindowFrame.cs
@@ -86,7 +86,6 @@ namespace Xwt
 		protected override void Dispose (bool release_all)
 		{
 			base.Dispose (release_all);
-			Backend.Dispose (release_all);
 		}
 		
 		new IWindowFrameBackend Backend {


### PR DESCRIPTION
GC may sometimes run on new thread and call Dispose(). Do not call Backend property getter in Dispose() because XwtComponent will load if not yet, so WPF fails on other thread. You can assume XwtComponent class dispose the Backend so subclasses don't need to override and dispose the Backend.
