### PR TITLE
[WpfBackend] Add a range check for bounds assignation.

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -195,6 +195,9 @@ namespace Xwt.WPFBackend
 				loc.Y += SystemParameters.MenuBarHeight;
 			}
 
+			size.Width = Math.Max (0, size.Width);
+			size.Height = Math.Max (0, size.Height);
+
 			return new Rectangle (loc, size);
 		}
 	}


### PR DESCRIPTION
When retrieving the bounds for a WindowFrame we adjust
the size by removing the spaced used by menu/borders,
which may be 0 for Width, Height or both. In such cases
make sure we are returning a 0.
