### PR TITLE
[WPF] Fix Altertdialog GTK backend uses as well IAlertDialogBackend instad of MessageDialog

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
@@ -75,7 +75,7 @@ namespace Xwt.WPFBackend
 			WidgetRegistry.RegisterBackend (typeof (ScrollAdjustment), typeof (ScrollAdjustmentBackend));
 			WidgetRegistry.RegisterBackend (typeof (OpenFileDialog), typeof (OpenFileDialogBackend));
 			WidgetRegistry.RegisterBackend (typeof (SelectFolderDialog), typeof (SelectFolderDialogBackend));
-			WidgetRegistry.RegisterBackend (typeof (MessageDialog), typeof (AlertDialogBackend));
+			WidgetRegistry.RegisterBackend (typeof (IAlertDialogBackend), typeof (AlertDialogBackend));
 			WidgetRegistry.RegisterBackend (typeof (ImageBuilder), typeof (ImageBuilderBackendHandler));
 		}
 


### PR DESCRIPTION
This is the exception without the change:
System.NullReferenceException: Object reference not set to an instance of an object.

   at Xwt.MessageDialog.GenericAlert(WindowFrame parent, MessageDescription message) in c:\Users\tzi\Documents\Projects\xwt\Xwt\Xwt\MessageDialog.cs:line 174

   at Xwt.MessageDialog.GenericAlert(WindowFrame parent, String icon, String primaryText, String secondaryText, Int32 defaultButton, Command[] buttons) in c:\Users\tzi\Documents\Projects\xwt\Xwt\Xwt\MessageDialog.cs:line 163

   at Xwt.MessageDialog.GenericAlert(WindowFrame parent, String icon, String primaryText, String secondaryText, Command[] buttons) in c:\Users\tzi\Documents\Projects\xwt\Xwt\Xwt\MessageDialog.cs:line 149

   at Xwt.MessageDialog.ShowMessage(WindowFrame parent, String primaryText, String secondaryText) in c:\Users\tzi\Documents\Projects\xwt\Xwt\Xwt\MessageDialog.cs:line 91

   at Xwt.MessageDialog.ShowMessage(WindowFrame parent, String primaryText) in c:\Users\tzi\Documents\Projects\xwt\Xwt\Xwt\MessageDialog.cs:line 83

   at Samples.Windows.<.ctor>b__2(Object , EventArgs ) in c:\Users\tzi\Documents\Projects\xwt\Samples\Samples\Windows.cs:line 53

   at Xwt.Button.OnClicked(EventArgs e) in c:\Users\tzi\Documents\Projects\xwt\Xwt\Xwt\Button.cs:line 138

   at Xwt.Button.EventSink.OnClicked()
