### PR TITLE
[WPF] Fix NRE in MenuItemBackend when instance is separator

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/MenuItemBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/MenuItemBackend.cs
@@ -157,6 +157,9 @@ namespace Xwt.WPFBackend
 
 		public void EnableEvent (object eventId)
 		{
+			if (menuItem == null)
+				return;
+
 			if (eventId is MenuItemEvent) {
 				switch ((MenuItemEvent)eventId) {
 					case MenuItemEvent.Clicked:
@@ -168,6 +171,9 @@ namespace Xwt.WPFBackend
 
 		public void DisableEvent (object eventId)
 		{
+			if (menuItem == null)
+				return;
+
 			if (eventId is MenuItemEvent) {
 				switch ((MenuItemEvent)eventId) {
 					case MenuItemEvent.Clicked:


### PR DESCRIPTION
Fixed WPF MenuItemBackend that triggered an exception is EnableEvent/DisableEvent when menuItem was null(which happened in the separator backend).

This prevented the buttons sample from running properly.

I'm not 100% sure this is the best possible solution, but it does seem to work for now.
