### PR TITLE
Xwt.Wpf.DrawingContext: reduced resource usage

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ContextBackendHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ContextBackendHandler.cs
@@ -208,18 +208,13 @@ namespace Xwt.WPFBackend
 			var c = (DrawingContext) backend;
 
 			var dc = color.ToDrawingColor ();
-			if (c.Pen.Color != dc) {
-				c.Pen.Color = dc;
-
-				c.Brush.Dispose();
-				c.Brush = new SolidBrush (dc);
-			}
+			c.SetColor (dc);
 		}
 
 		public void SetLineWidth (object backend, double width)
 		{
 			var c = (DrawingContext) backend;
-			c.Pen.Width = (float) width;
+			c.SetWidth ((float) width);
 		}
 
 		public void SetLineDash (object backend, double offset, params double[] pattern)

--- a/Xwt.WPF/Xwt.WPFBackend/DrawingContext.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DrawingContext.cs
@@ -3,6 +3,7 @@
 //  
 // Author:
 //       Eric Maupin <ermau@xamarin.com>
+//       Lytico (http://limada.sourceforge.net)
 // 
 // Copyright (c) 2012 Xamarin, Inc.
 // 
@@ -23,7 +24,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -31,91 +31,156 @@ using System.Drawing.Drawing2D;
 
 namespace Xwt.WPFBackend
 {
-	internal class DrawingContext
-		: IDisposable
+	internal class DrawingContext:IDisposable
 	{
 		internal DrawingContext (Graphics graphics)
 		{
 			if (graphics == null)
 				throw new ArgumentNullException ("graphics");
-
-			graphics.SmoothingMode = SmoothingMode.HighSpeed;
+			
+			graphics.SmoothingMode = SmoothingMode.None;
 			graphics.PixelOffsetMode = PixelOffsetMode.Half;
+			graphics.CompositingQuality = CompositingQuality.HighSpeed;
+			
+			
 			Graphics = graphics;
 		}
 
 		internal DrawingContext (DrawingContext context)
 		{
-			Graphics = context.Graphics;
 			
-			var f = context.Font;
-			Font = new Font (f.FontFamily, f.Size, f.Style, f.Unit, f.GdiCharSet, f.GdiVerticalFont);
-			Pen = new Pen (context.Pen.Brush, context.Pen.Width);
-			Brush = (Brush)context.Brush.Clone ();
-			Path = (GraphicsPath) context.Path.Clone();
-			Transform = Graphics.Transform;
+			context.CopyTo (this, false);
 			
 			CurrentX = context.CurrentX;
 			CurrentY = context.CurrentY;
 		}
 
-		public void Dispose()
-		{
-			Font.Dispose();
-			Pen.Dispose();
-			Brush.Dispose();
-			Path.Dispose();
-			
-			if (Transform != null)
-				Transform.Dispose();
+		internal readonly Graphics Graphics;
+		Font font = null;
 
-			if (this.contexts != null) {
-				foreach (var drawingContext in this.contexts) {
-					drawingContext.Dispose ();
-				}
-			}
+		internal Font Font {
+			get { return font ?? (font = new Font (FontFamily.GenericSansSerif, 12));}
+			set { font = value;}
 		}
 
-		internal readonly Graphics Graphics;
+		Color color = Color.Black;
+		float width = 1;
+		Pen pen = null;
 
-		internal Font Font = new Font (FontFamily.GenericSansSerif, 12);
-		internal Pen Pen = new Pen (Color.Black, 1);
-		internal Brush Brush = new SolidBrush (Color.Black);
-		internal Matrix Transform;
+		internal Pen Pen {
+			get { return pen ?? (pen = new Pen (color, width));}
+			set { pen = value;}
+		}
 
+		Brush brush = null;
+
+		internal Brush Brush {
+			get { return brush ?? (brush = new SolidBrush (color));}
+			set { brush = value;}
+		}
+
+		internal GraphicsState State;
 		internal float CurrentX;
 		internal float CurrentY;
+		GraphicsPath path = null;
 
-		internal GraphicsPath Path = new GraphicsPath();
+		internal GraphicsPath Path {
+			get { return path ?? (path = new GraphicsPath ());}
+			set { path = value;}
+		}
 
-		internal void Save()
+		internal void SetColor (Color color)
+		{
+			if (this.color != color) {
+				if (pen != null && pen.Color != color) {
+					pen.Color = color;
+				}
+				if (brush is SolidBrush && ((SolidBrush) brush).Color != color) {
+					brush.Dispose ();
+					brush = null;
+				}
+			}
+			this.color = color;
+		}
+		
+		internal void SetWidth (float width)
+		{
+			if (this.width != width) {
+				if (pen != null) {
+					pen.Width = width;
+				}
+			}
+			this.width = width;
+		}
+		
+		internal void CopyTo (DrawingContext dc, bool toCurrent)
+		{
+			if (toCurrent) 
+				dc.Graphics.Restore (this.State);
+			else 
+				dc.State = this.Graphics.Save ();
+			dc.Font = this.font;
+			dc.Brush = this.brush;
+			dc.Pen = this.pen;
+			dc.SetWidth (this.width);
+			dc.SetColor (this.color);
+			dc.CurrentX = this.CurrentX;
+			dc.CurrentY = this.CurrentY;
+			if (this.path != null && this.path.PointCount > 0)
+				dc.Path = (GraphicsPath) this.path.Clone ();
+		}
+		
+		internal void Save ()
 		{
 			if (this.contexts == null)
 				this.contexts = new Stack<DrawingContext> ();
 
 			this.contexts.Push (new DrawingContext (this));
 		}
-
-		internal void Restore()
+		
+		internal void Restore ()
 		{
 			if (this.contexts == null || this.contexts.Count == 0)
-				throw new InvalidOperationException();
+				throw new InvalidOperationException ();
 
 			var dc = this.contexts.Pop ();
 
-			Font = dc.Font;
-			Pen = dc.Pen;
-			Brush = dc.Brush;
-			Path = dc.Path;
-			if (dc.Transform != null)
-				Graphics.Transform = dc.Transform;
-			else
-				Graphics.ResetTransform ();
+			dc.CopyTo (this, true);
+			dc.Dispose (true);
 
-			CurrentX = dc.CurrentX;
-			CurrentY = dc.CurrentY;
 		}
 
 		private Stack<DrawingContext> contexts;
+
+		public void Dispose (bool stacked)
+		{
+			if (!stacked) {
+				if (font != null)
+					font.Dispose ();
+				if (brush != null)
+					brush.Dispose ();
+				if (pen != null)
+					pen.Dispose ();
+			}
+			
+			if (path != null)
+				path.Dispose ();
+			
+			if (contexts != null)
+				while (contexts.Count!=0) {
+					var c = contexts.Pop ();
+					c.Dispose (true);
+				}
+		}
+		
+		public void Dispose ()
+		{
+			Dispose (false);
+		}
+		
+		~DrawingContext ()
+		{
+			Dispose (false);
+		}
 	}
 }


### PR DESCRIPTION
refactored Wpf.DrawingContext to reuse and lazy use of expensive System.Drawing-objects like pen, brush, font

<pre>results in short        old Code                       new Code
Time in sec  (Frames 1210)
                               5,66                              4,68 
Frames per sec     
                              213,71                          258,49
SetColor memory usage in bytes:
                           14,673,402                      90
Context.Save memory usage in bytes:
                           305,184                           83,248 

Brush is lazy cause its never used in
             Stroke without FillPreserve
             DrawTextLayout without Fill
             Draw Image without Fill
Pen is lazy cause its never used in 
             Fill without StrokePreserve
             DrawTextLayout without Stroke
             Draw Image without Stroke
Path is lazy cause its never used in 
             DrawTextLayout without Stroke or Fill
             Draw Image without Stroke or Fill
Font is lazy cause its never used if
            DrawTextLayout is never used or
            Context.SetFont is called

</pre>
