### PR TITLE
Mac: implement Shown and Hidden events for Window

### DIFF
--- a/Xwt.Mac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/WindowBackend.cs
@@ -134,18 +134,23 @@ namespace Xwt.Mac
 			OnHidden ();
 		}
 		
-		HashSet<WindowFrameEvent> eventsEnabled = new HashSet<WindowFrameEvent> ();
+		bool VisibilityEventsEnabled ()
+		{
+			return eventsEnabled != WindowFrameEvent.BoundsChanged;
+		}
+		WindowFrameEvent eventsEnabled = WindowFrameEvent.BoundsChanged;
+
 		NSString HiddenProperty {
 			get { return new NSString ("hidden"); }
 		}
 		
 		void EnableVisibilityEvent (WindowFrameEvent ev)
 		{
-			if (eventsEnabled.Count == 0) {
+			if (!VisibilityEventsEnabled ()) {
 				ContentView.AddObserver (this, HiddenProperty, NSKeyValueObservingOptions.New, IntPtr.Zero);
 			}
-			if (!eventsEnabled.Contains (ev)) {
-				eventsEnabled.Add (ev);
+			if (!eventsEnabled.HasFlag (ev)) {
+				eventsEnabled |= ev;
 			}
 		}
 
@@ -153,11 +158,11 @@ namespace Xwt.Mac
 		{
 			if (keyPath.ToString () == HiddenProperty.ToString () && ofObject.Equals (ContentView)) {
 				if (ContentView.Hidden) {
-					if (eventsEnabled.Contains (WindowFrameEvent.Hidden)) {
+					if (eventsEnabled.HasFlag (WindowFrameEvent.Hidden)) {
 						OnHidden ();
 					}
 				} else {
-					if (eventsEnabled.Contains (WindowFrameEvent.Shown)) {
+					if (eventsEnabled.HasFlag (WindowFrameEvent.Shown)) {
 						OnShown ();
 					}
 				}
@@ -178,10 +183,13 @@ namespace Xwt.Mac
 			});
 		}
 
-		void DisableVisibilityEvent (WindowFrameEvent ev){
-			eventsEnabled.Remove (ev);
-			if (eventsEnabled.Count == 0) {
-				ContentView.RemoveObserver (this, HiddenProperty);
+		void DisableVisibilityEvent (WindowFrameEvent ev)
+		{
+			if (eventsEnabled.HasFlag (ev)) {
+				eventsEnabled ^= ev;
+				if (!VisibilityEventsEnabled ()) {
+					ContentView.RemoveObserver (this, HiddenProperty);
+				}
 			}
 		}
 

--- a/Xwt/Xwt.Backends/IWindowFrameBackend.cs
+++ b/Xwt/Xwt.Backends/IWindowFrameBackend.cs
@@ -46,12 +46,13 @@ namespace Xwt.Backends
 		void OnShown ();
 		void OnHidden ();
 	}
-	
+
+	[Flags]
 	public enum WindowFrameEvent
 	{
 		BoundsChanged = 1,
-		Shown,
-		Hidden
+		Shown = 2,
+		Hidden = 4
 	}
 }
 


### PR DESCRIPTION
As WPF backend fires the Hidden event when a Windows closes, there's
an extra hook that needs to be done here in the Mac backend to make it
work in the same way.
