### PR TITLE
Fix a buglet in GtkBackend

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -208,7 +208,7 @@ namespace Xwt.GtkBackend
 		
 		protected virtual void Dispose (bool disposing)
 		{
-			if (Widget != null && !disposing && Widget.Parent == null)
+			if (Widget != null && disposing && Widget.Parent == null)
 				Widget.Destroy ();
 		}
 		


### PR DESCRIPTION
Calling Widget.Destroy from the finalizer is incorrect as the widgets finalizer may already have run and it may already be have had it's ToggleRef collected and freed it's unmanaged resources. Calling Destroy like this would just throw an exception and tear down the appdomain in this scenario.
