### PR TITLE
Fix Xwt.WPF on Visual Studio 2010

### DIFF
--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>9.0.21022</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{C93D746E-1586-4D4F-B411-BF5A966E6A08}</ProjectGuid>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
Currently, Xwt.WPF isn't properly compiled on Visual Studio 2010.
This patch allows VS2010 to work properly by changing the project version to match the project version for the Xwt and Xwt.Gtk projects.
