### PR TITLE
WPF Ensure proper MarkdownView behavior

### DIFF
--- a/Xwt/Xwt/MarkdownView.cs
+++ b/Xwt/Xwt/MarkdownView.cs
@@ -81,6 +81,7 @@ namespace Xwt
 		public MarkdownView ()
 		{
 			NavigateToUrl += delegate { }; // ensure the virtual method is always called
+			Markdown = string.Empty;
 		}
 
 		protected override BackendHost CreateBackendHost ()


### PR DESCRIPTION
When the Markdown property is not set, MarkdownView has different behavior - notably, the editor is editable.
This simple patch fixes it by setting the Markdown property in the constructor.
