### PR TITLE
[API] Remove ResetTransform from Drawing API

### DIFF
--- a/Samples/Samples/ScrollWindowSample.cs
+++ b/Samples/Samples/ScrollWindowSample.cs
@@ -90,6 +90,7 @@ namespace Samples
 		
 		protected override void OnDraw (Context ctx, Rectangle dirtyRect)
 		{
+			ctx.Save ();
 			ctx.Translate (-hscroll.Value, -vscroll.Value);
 			ctx.Rectangle (new Rectangle (0, 0, imageSize, imageSize));
 			ctx.SetColor (Xwt.Drawing.Colors.White);
@@ -97,8 +98,8 @@ namespace Samples
 			ctx.Arc (imageSize / 2, imageSize / 2, imageSize / 2 - 20, 0, 360);
 			ctx.SetColor (new Color (0,0,1));
 			ctx.Fill ();
-			ctx.ResetTransform ();
-			
+			ctx.Restore ();
+
 			ctx.Rectangle (0, 0, Bounds.Width, 30);
 			ctx.SetColor (new Color (1, 0, 0, 0.5));
 			ctx.Fill ();

--- a/Xwt.Gtk/Xwt.CairoBackend/CairoContextBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.CairoBackend/CairoContextBackendHandler.cs
@@ -279,12 +279,6 @@ namespace Xwt.CairoBackend
 			return new Size (0,0);
 		}
 		
-		public void ResetTransform (object backend)
-		{
-			CairoContextBackend gc = (CairoContextBackend)backend;
-			gc.Context.IdentityMatrix();
-		}
-
         public void Rotate (object backend, double angle)
 		{
 			CairoContextBackend gc = (CairoContextBackend)backend;

--- a/Xwt.Mac/Xwt.Mac/ContextBackendHandler.cs
+++ b/Xwt.Mac/Xwt.Mac/ContextBackendHandler.cs
@@ -271,16 +271,6 @@ namespace Xwt.Mac
 			ctx.RestoreState ();
 		}
 		
-		public void ResetTransform (object backend)
-		{
-			// http://stackoverflow.com/questions/469505/how-to-reset-to-identity-the-current-transformation-matrix-with-some-cgcontext
-			// "Note that inverting the current CTM with CGAffineTransformInvert does not work if your current CTM is singular."
-
-			CGContext ctx = ((CGContextBackend)backend).Context;
-			CGAffineTransform matrix = ctx.GetCTM ();
-			ctx.ConcatCTM (matrix.Invert ());
-		}
-		
 		public void Rotate (object backend, double angle)
 		{
 			((CGContextBackend)backend).Context.RotateCTM ((float)(angle * degrees));

--- a/Xwt.WPF/Xwt.WPFBackend/ContextBackendHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ContextBackendHandler.cs
@@ -315,12 +315,6 @@ namespace Xwt.WPFBackend
 			DrawImageCore (c.Graphics, bmp, srcRect, destRect, (float) alpha);
 		}
 
-		public void ResetTransform (object backend)
-		{
-			var c = (DrawingContext)backend;
-			c.Graphics.ResetTransform ();
-		}
-
 		public void Rotate (object backend, double angle)
 		{
 			var c = (DrawingContext)backend;

--- a/Xwt/Xwt.Backends/IContextBackendHandler.cs
+++ b/Xwt/Xwt.Backends/IContextBackendHandler.cs
@@ -90,8 +90,6 @@ namespace Xwt.Backends
 
 		void DrawImage (object backend, object img, Rectangle srcRect, Rectangle destRect, double alpha);
 
-		void ResetTransform (object backend);
-
 		void Rotate (object backend, double angle);
 		
 		void Scale (object backend, double scaleX, double scaleY);

--- a/Xwt/Xwt.Drawing/Context.cs
+++ b/Xwt/Xwt.Drawing/Context.cs
@@ -417,14 +417,6 @@ namespace Xwt.Drawing
 		}
 
 		/// <summary>
-		/// Resets the current trasnformation matrix (CTM) to the Identity Matrix
-		/// </summary>
-		public void ResetTransform ()
-		{
-			handler.ResetTransform (Backend);
-		}
-		
-		/// <summary>
 		/// Applies a rotation transformation
 		/// </summary>
 		/// <param name='angle'>


### PR DESCRIPTION
ResetTransform cannot be safely implemented in Mac CoreGraphics.
The same functionality can be available using a Save/Restore pair.
An unfortunate case of the Backend wagging the API!
