### PR TITLE
Support fenced code blocks

### DIFF
--- a/Samples/Samples/Markdown.cs
+++ b/Samples/Samples/Markdown.cs
@@ -70,6 +70,13 @@ MediaPicker API:
 		//Present Image here
 	});
 
+Foo API:
+
+```csharp
+Console.WriteLine (""Foo!"")
+Console.WriteLine (""Testing fenced block support!"")
+```
+
 # Documentation
 
 - Technical Docs: http://betaapi.xamarin.com/?link=root:/Xamarin.Mobile

--- a/Xwt/Xwt.Formats/MarkdownTextFormat.cs
+++ b/Xwt/Xwt.Formats/MarkdownTextFormat.cs
@@ -114,13 +114,26 @@ namespace Xwt.Formats
 				}
 
 				// Code blocks
-				else if (line.StartsWith ("\t") || line.StartsWith ("    ")) {
+				else if (line.StartsWith ("\t") || line.StartsWith ("    ") || line.StartsWith ("```")) {
+					bool isFencedCodeBlock = line.StartsWith ("```");
+
+					if (isFencedCodeBlock)
+						i++;
+
 					var codeblock = new StringBuilder ();
 					for (; i < lines.Length; i++) {
 						line = lines[i];
-						if (!line.StartsWith ("\t") && !line.StartsWith ("    "))
+						if (!line.StartsWith ("\t") && !line.StartsWith ("    ") && !isFencedCodeBlock)
 							break;
-						codeblock.AppendLine (line.StartsWith ("\t") ? line.Substring (1) : line.Substring (4));
+						if (isFencedCodeBlock && line.StartsWith ("```")) {
+							i++;
+							break;
+						}
+
+						if (isFencedCodeBlock && !line.StartsWith ("```"))
+							codeblock.AppendLine (line);
+						else
+							codeblock.AppendLine (line.StartsWith ("\t") ? line.Substring (1) : line.Substring (4));
 					}
 					i--;
 					if (wasParagraph) {


### PR DESCRIPTION
GitHub supports fenced code blocks—Xwt's Markdown engine is minimal, but supporting fenced code blocks (in the sense of not mangling their display horribly) is relatively trivial.
