### PR TITLE
[Xwt.Wpf] Use a transparent background for spinners.

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/SpinnerBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/SpinnerBackend.cs
@@ -67,7 +67,7 @@ namespace Xwt.WPFBackend
 		{
 			Width = 25;
 			Height = 25;
-			Background = new SolidColorBrush (Colors.White);
+			Background = new SolidColorBrush (Colors.Transparent);
 			Storyboard = new Storyboard { RepeatBehavior = RepeatBehavior.Forever, Duration = TimeSpan.FromMilliseconds (Duration) };
 
 			for (int i = 0; i < 360; i += 30) {


### PR DESCRIPTION
Previously they would be contained in a white rectangle thus not blending in their container.
