### PR TITLE
Modifier Keys are Flags

### DIFF
--- a/Xwt/Xwt/ModifierKeys.cs
+++ b/Xwt/Xwt/ModifierKeys.cs
@@ -27,13 +27,14 @@ using System;
 
 namespace Xwt
 {
+	[Flags]
 	public enum ModifierKeys
 	{
-		None,
-		Alt,
-		Control,
-		Shift,
-		Command
+		None = 0,
+		Alt = 0x1 << 0,
+		Control = 0x1 << 1,
+		Shift = 0x1 << 2,
+		Command = 0x1 << 3
 	}
 }
 


### PR DESCRIPTION
shouldn't modifier keys be flagged? 
otherwise we can't detect ctrl-alt-del
