### PR TITLE
Added support for text layout attributes.

### DIFF
--- a/Samples/Samples/DrawingText.cs
+++ b/Samples/Samples/DrawingText.cs
@@ -133,6 +133,21 @@ namespace Samples
 			// scale example here:
 			
 			ctx.Restore ();
+
+			TextLayout tl0 = new TextLayout (this);
+
+			tl0.Font = this.Font.WithPointSize (10);
+			tl0.Text = "This text contains attributes.";
+			tl0.SetTextAttributes (
+				new TextAttributeDecoration (TextDecoration.Underline, 0, "This".Length),
+				new TextAttributeForeground (new Color (0, 1.0, 1.0), "This ".Length, "text".Length),
+				new TextAttributeBackground (new Color (0, 0, 0), "This ".Length, "text".Length),
+				new TextAttributeWeight (TextWeight.Bold, "This text ".Length, "contains".Length),
+				new TextAttributeStyle (TextStyle.Italic, "This text ".Length, "contains".Length),
+				new TextAttributeDecoration (TextDecoration.Strikethrough, "This text contains ".Length, "attributes".Length)
+			);
+			ctx.DrawTextLayout (tl0, col2.Left, col2.Bottom + 100);
+
 			
 			// Text boces
 			
@@ -157,6 +172,7 @@ namespace Samples
 			tl.Text = "\nEmpty line above\nLine break above\n\nEmpty line above\n\n\nTwo empty lines above\nEmpty line below\n";
 			tl.Width = 200;
 			DrawText (ctx, tl, ref y);
+
 		}	
 		
 		void DrawText (Context ctx, TextLayout tl, ref double y)

--- a/Xwt.Gtk/Xwt.CairoBackend/CairoTextLayoutBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.CairoBackend/CairoTextLayoutBackendHandler.cs
@@ -263,6 +263,10 @@ namespace Xwt.CairoBackend
 			}
 		}
 		
+		public override void SetTextAttributes(object backend, IEnumerable<TextAttribute> textAttributes)
+		{
+			throw new NotImplementedException ();
+		}
 		#endregion
 	}
 }

--- a/Xwt.Mac/Xwt.Mac/TextLayoutBackendHandler.cs
+++ b/Xwt.Mac/Xwt.Mac/TextLayoutBackendHandler.cs
@@ -35,6 +35,7 @@ using Xwt.Drawing;
 using PointF = System.Drawing.PointF;
 using SizeF = System.Drawing.SizeF;
 using RectangleF = System.Drawing.RectangleF;
+using System.Collections.Generic;
 
 namespace Xwt.Mac
 {
@@ -178,6 +179,11 @@ namespace Xwt.Mac
 				}
 				ctx.RestoreState ();
 			}
+		}
+		
+		public override void SetTextAttributes(object backend, IEnumerable<TextAttribute> textAttributes)
+		{
+			throw new NotImplementedException ();
 		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/TextLayoutBackendHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TextLayoutBackendHandler.cs
@@ -31,6 +31,7 @@ using Xwt.Backends;
 using Xwt.Drawing;
 
 using Font = Xwt.Drawing.Font;
+using System.Collections.Generic;
 
 namespace Xwt.WPFBackend
 {
@@ -78,6 +79,11 @@ namespace Xwt.WPFBackend
 		public override Size GetSize (object backend)
 		{
 			return ((TextLayoutContext) backend).GetSize ();
+		}
+		
+		public override void SetTextAttributes(object backend, IEnumerable<TextAttribute> textAttributes)
+		{
+			throw new NotImplementedException ();
 		}
 	}
 }

--- a/Xwt.sln
+++ b/Xwt.sln
@@ -178,7 +178,7 @@ Global
 		{14CF6E75-0D08-4BBD-B0F5-742196E5656D} = {83D74DDF-581E-4E2A-AE02-F4047A5B96C7}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		StartupItem = Testing\GtkTestRunner\GtkTestRunner.csproj
+		StartupItem = GtkTest\GtkTest.csproj
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = None

--- a/Xwt/Xwt.Backends/TextLayoutBackendHandler.cs
+++ b/Xwt/Xwt.Backends/TextLayoutBackendHandler.cs
@@ -27,6 +27,7 @@
 
 using System;
 using Xwt.Drawing;
+using System.Collections.Generic;
 
 namespace Xwt.Backends
 {
@@ -41,6 +42,7 @@ namespace Xwt.Backends
 		public abstract void SetFont (object backend, Font font);
 		public abstract void SetTrimming (object backend, TextTrimming textTrimming);
 		public abstract Size GetSize (object backend);
+		public abstract void SetTextAttributes(object backend, IEnumerable<TextAttribute> textAttributes);
 	}
 }
 

--- a/Xwt/Xwt.Drawing/TextAttribute.cs
+++ b/Xwt/Xwt.Drawing/TextAttribute.cs
@@ -1,0 +1,289 @@
+//
+// TextAttribute.cs
+//
+// Author:
+//       Mike Krüger <mkrueger@xamarin.com>
+//
+// Copyright (c) 2013 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+using Xwt.Backends;
+
+namespace Xwt.Drawing
+{
+	/// <summary>
+	/// This is the base class for all Xwt text attributes.
+	/// </summary>
+	public abstract class TextAttribute
+	{
+		/// <summary>
+		/// The start index of this attribute.
+		/// </summary>
+		public uint StartIndex { get; set; }
+
+		/// <summary>
+		/// The end index of this attribute.
+		/// Invariant: <c>EndIndex == StartIndex + Length</c>
+		/// </summary>
+		public uint EndIndex { get { return StartIndex + Length; } }
+
+		/// <summary>
+		/// The length of this attribute.
+		/// </summary>
+		public uint Length { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttribute"/> class.
+		/// </summary>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttribute (uint startIndex, uint length)
+		{
+			this.StartIndex = startIndex;
+			this.Length = length;
+		}
+	}
+
+	/// <summary>
+	/// A text attribute that represents a foreground color.
+	/// </summary>
+	public sealed class TextAttributeForeground : TextAttribute
+	{
+		/// <summary>
+		/// The color represented by this attribute.
+		/// </summary>
+		public Color Color { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeBackground"/> class.
+		/// </summary>
+		/// <param name="color">The color represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeForeground  (Color color, uint startIndex, uint endIndex) : base (startIndex, endIndex)
+		{
+			this.Color = color;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeBackground"/> class.
+		/// </summary>
+		/// <param name="color">The color represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeForeground  (Color color, int startIndex, int endIndex) : this (color, (uint)startIndex, (uint)endIndex)
+		{
+		}
+	}
+	
+	/// <summary>
+	/// A text attribute that represents a foreground color.
+	/// </summary>
+	public sealed class TextAttributeBackground : TextAttribute
+	{
+		/// <summary>
+		/// The color represented by this attribute.
+		/// </summary>
+		public Color Color { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeBackground"/> class.
+		/// </summary>
+		/// <param name="color">The color represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeBackground  (Color color, uint startIndex, uint endIndex) : base (startIndex, endIndex)
+		{
+			this.Color = color;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeBackground"/> class.
+		/// </summary>
+		/// <param name="color">The color represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeBackground  (Color color, int startIndex, int endIndex) : this (color, (uint)startIndex, (uint)endIndex)
+		{
+		}
+	}
+
+	/// <summary>
+	/// An enumeration specifying different text styles.
+	/// </summary>
+	public enum TextStyle
+	{
+		/// <summary>
+		/// The font is upright.
+		/// </summary>
+		Normal,
+		
+		/// <summary>
+		/// A font slanted in an italic style.
+		/// </summary>
+		Italic,
+		
+		/// <summary>
+		/// A font slanted, but in a roman style.
+		/// </summary>
+		Oblique
+	}
+	
+	/// <summary>
+	/// A text attribute that represents a text style.
+	/// </summary>
+	public sealed class TextAttributeStyle : TextAttribute
+	{
+		/// <summary>
+		/// The text style represented by this attribute.
+		/// </summary>
+		public TextStyle TextStyle { get; set; }
+		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeStyle"/> class.
+		/// </summary>
+		/// <param name="textStyle">The text style represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeStyle (TextStyle textStyle, uint startIndex, uint length) : base (startIndex, length)
+		{
+			this.TextStyle = textStyle;
+		}
+		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeStyle"/> class.
+		/// </summary>
+		/// <param name="textStyle">The text style represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeStyle (TextStyle textStyle, int startIndex, int length) : this (textStyle, (uint)startIndex, (uint)length)
+		{
+		}
+	}
+
+	/// <summary>
+	/// An enumeration specifying different text weights.
+	/// </summary>
+	public enum TextWeight
+	{
+		/// <summary>
+		/// The default weight
+		/// </summary>
+		Normal,
+		
+		/// <summary>
+		/// The bold weight
+		/// </summary>
+		Bold,
+		
+		/// <summary>
+		/// The heavy weight
+		/// </summary>
+		Heavy,
+		
+		/// <summary>
+		/// The light weight
+		/// </summary>
+		Light
+	}
+	
+	/// <summary>
+	/// A text attribute that represents a text style.
+	/// </summary>
+	public sealed class TextAttributeWeight : TextAttribute
+	{
+		/// <summary>
+		/// The text weight represented by this attribute.
+		/// </summary>
+		public TextWeight TextWeight { get; set; }
+		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeWeight"/> class.
+		/// </summary>
+		/// <param name="textWeight">The text weight represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeWeight (TextWeight textWeight, uint startIndex, uint length) : base (startIndex, length)
+		{
+			this.TextWeight = textWeight;
+		}
+		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeWeight"/> class.
+		/// </summary>
+		/// <param name="textWeight">The text weight represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeWeight (TextWeight textWeight, int startIndex, int length) : this (textWeight, (uint)startIndex, (uint)length)
+		{
+		}
+	}
+
+	/// <summary>
+	/// An enumeration specifying different text decorations.
+	/// </summary>
+	[Flags]
+	public enum TextDecoration
+	{
+		/// <summary>
+		/// The default weight
+		/// </summary>
+		Underline,
+		
+		/// <summary>
+		/// The bold weight
+		/// </summary>
+		Strikethrough
+	}
+	
+	/// <summary>
+	/// A text attribute that represents a text style.
+	/// </summary>
+	public sealed class TextAttributeDecoration : TextAttribute
+	{
+		/// <summary>
+		/// The text decoration represented by this attribute.
+		/// </summary>
+		public TextDecoration TextDecoration { get; set; }
+		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeDecoration"/> class.
+		/// </summary>
+		/// <param name="textDecoration">The text decoration represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeDecoration (TextDecoration textDecoration, uint startIndex, uint length) : base (startIndex, length)
+		{
+			this.TextDecoration = textDecoration;
+		}
+		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.Drawing.TextAttributeStyle"/> class.
+		/// </summary>
+		/// <param name="textDecoration">The text decoration represented by this attribute.</param>
+		/// <param name="startIndex">The start index of this attribute.</param>
+		/// <param name="length">The length of this attribute.</param>
+		public TextAttributeDecoration (TextDecoration textDecoration, int startIndex, int length) : this (textDecoration, (uint)startIndex, (uint)length)
+		{
+		}
+	}
+}

--- a/Xwt/Xwt.Drawing/TextLayout.cs
+++ b/Xwt/Xwt.Drawing/TextLayout.cs
@@ -28,6 +28,7 @@
 using System;
 
 using Xwt.Backends;
+using System.Collections.Generic;
 
 namespace Xwt.Drawing
 {
@@ -105,6 +106,16 @@ namespace Xwt.Drawing
 		public TextTrimming Trimming {
 			get { return textTrimming; }
 			set { textTrimming = value; handler.SetTrimming (Backend, value); }
+		}
+
+		public void SetTextAttributes(params TextAttribute[] textAttributes)
+		{
+			handler.SetTextAttributes (Backend, textAttributes);
+		}
+
+		public void SetTextAttributes(IEnumerable<TextAttribute> textAttributes)
+		{
+			handler.SetTextAttributes (Backend, textAttributes);
 		}
 	}
 	

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -387,6 +387,7 @@
     <Compile Include="Xwt.Drawing\ImageFileType.cs" />
     <Compile Include="Xwt\Slider.cs" />
     <Compile Include="Xwt.Backends\ISliderBackend.cs" />
+    <Compile Include="Xwt.Drawing\TextAttribute.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />


### PR DESCRIPTION
Added support for text attributes.

btw. The attributes are set only to prevent the mistake from altering the attributes after they are set.

How is the Pango.Layout supposed to be destroyed ?
The attributes (if any) should be destroyed with it. How about implementing IDisposable for the text layout and let the user do the memory management ?
