### PR TITLE
[Drawing API] Add GetCTM to Context and update Transform code

### DIFF
--- a/Xwt.Gtk/Xwt.CairoBackend/CairoContextBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.CairoBackend/CairoContextBackendHandler.cs
@@ -314,17 +314,12 @@ namespace Xwt.CairoBackend
 			gc.Context.Translate (tx, ty);
 		}
 
-		public override void TransformPoint (object backend, ref double x, ref double y)
-		{
-			Cairo.Context ctx = ((CairoContextBackend)backend).Context;
-			ctx.TransformPoint (ref x, ref y);
-		}
-
-		public override void TransformDistance (object backend, ref double dx, ref double dy)
-		{
-			Cairo.Context ctx = ((CairoContextBackend)backend).Context;
-			ctx.TransformDistance (ref dx, ref dy);
-		}
+        public override Matrix GetCTM (object backend)
+        {
+            Cairo.Matrix cm = ((CairoContextBackend)backend).Context.Matrix;
+            Matrix ctm = new Matrix (cm.Xx, cm.Yx, cm.Xy, cm.Yy, cm.X0, cm.Y0);
+            return ctm;
+        }
 
 		public override object CreatePath ()
 		{

--- a/Xwt.Mac/Xwt.Mac/ContextBackendHandler.cs
+++ b/Xwt.Mac/Xwt.Mac/ContextBackendHandler.cs
@@ -271,26 +271,12 @@ namespace Xwt.Mac
 			((CGContextBackend)backend).Context.TranslateCTM ((float)tx, (float)ty);
 		}
 		
-		public override void TransformPoint (object backend, ref double x, ref double y)
-		{
-			CGAffineTransform t = GetContextTransform ((CGContextBackend)backend);
-
-			PointF p = t.TransformPoint (new PointF ((float)x, (float)y));
-			x = p.X;
-			y = p.Y;
-		}
-
-		public override void TransformDistance (object backend, ref double dx, ref double dy)
-		{
-			CGAffineTransform t = GetContextTransform ((CGContextBackend)backend);
-			// remove translational elements from CTM
-			t.x0 = 0;
-			t.y0 = 0;
-
-			PointF p = t.TransformPoint (new PointF ((float)dx, (float)dy));
-			dx = p.X;
-			dy = p.Y;
-		}
+        public override Matrix GetCTM (object backend)
+        {
+            CGAffineTransform t = GetContextTransform ((CGContextBackend)backend);
+            Matrix ctm = new Matrix (t.a, t.b, t.c, t.d, t.x0, t.y0);
+            return ctm;
+        }
 
 		public override object CreatePath ()
 		{

--- a/Xwt.WPF/Xwt.WPFBackend/ContextBackendHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ContextBackendHandler.cs
@@ -330,25 +330,13 @@ namespace Xwt.WPFBackend
 			c.Graphics.TranslateTransform ((float)tx, (float)ty);
 		}
 
-		public override void TransformPoint (object backend, ref double x, ref double y)
-		{
-			var m = ((DrawingContext)backend).Graphics.Transform;
-			PointF p = new PointF ((float)x, (float)y);
-			PointF[] pts = new PointF[] { p };
-			m.TransformPoints (pts);
-			x = pts[0].X;
-			y = pts[0].Y;
-		}
-
-		public override void TransformDistance (object backend, ref double dx, ref double dy)
-		{
-			var m = ((DrawingContext)backend).Graphics.Transform;
-			PointF p = new PointF ((float)dx, (float)dy);
-			PointF[] pts = new PointF[] {p};
-			m.TransformVectors (pts);
-			dx = pts[0].X;
-			dy = pts[0].Y;
-		}
+        public override Xwt.Drawing.Matrix GetCTM (object backend)
+        {
+            var m = ((DrawingContext)backend).Graphics.Transform;
+			float [] e = m.Elements;
+			Xwt.Drawing.Matrix ctm = new Xwt.Drawing.Matrix (e[0], e[1], e[2], e[3], e[4], e[5]);
+            return ctm;
+        }
 
 		public override object CreatePath ()
         {

--- a/Xwt/Xwt.Backends/ContextBackendHandler.cs
+++ b/Xwt/Xwt.Backends/ContextBackendHandler.cs
@@ -74,9 +74,7 @@ namespace Xwt.Backends
 		
 		public abstract void Translate (object backend, double tx, double ty);
 
-		public abstract void TransformPoint (object backend, ref double x, ref double y);
-
-		public abstract void TransformDistance (object backend, ref double dx, ref double dy);
+        public abstract Matrix GetCTM (object backend);
 
 		public abstract bool IsPointInStroke (object backend, double x, double y);
 

--- a/Xwt/Xwt.Drawing/Context.cs
+++ b/Xwt/Xwt.Drawing/Context.cs
@@ -259,13 +259,24 @@ namespace Xwt.Drawing
 		{
 			handler.Translate (Backend, p.X, p.Y);
 		}
+
+        /// <summary>
+        /// Returns a copy of the current transformation matrix (CTM)
+        /// </summary>
+        public Matrix GetCTM ()
+        {
+            return handler.GetCTM (Backend);
+        }
 		
 		/// <summary>
 		/// Transforms the point (x, y) by the current transformation matrix (CTM)
 		/// </summary>
 		public void TransformPoint (ref double x, ref double y)
 		{
-			handler.TransformPoint (Backend, ref x, ref y);
+            Matrix m = GetCTM ();
+            Point p = m.Transform (new Point (x, y));
+            x = p.X;
+            y = p.Y;
 		}
 
 		/// <summary>
@@ -273,10 +284,8 @@ namespace Xwt.Drawing
 		/// </summary>
 		public Point TransformPoint (Point p)
 		{
-			var x = p.X;
-			var y = p.Y;
-			handler.TransformPoint (Backend, ref x, ref y);
-			return new Point (x, y);
+            Matrix m = GetCTM ();
+			return m.Transform (p);
 		}
 		
 		/// <summary>
@@ -284,7 +293,10 @@ namespace Xwt.Drawing
 		/// </summary>
 		public void TransformDistance (ref double dx, ref double dy)
 		{
-			handler.TransformDistance (Backend, ref dx, ref dy);
+            Matrix m = GetCTM ();
+            Point p = m.TransformVector (new Point (dx, dy));
+            dx = p.X;
+            dy = p.Y;
 		}
 		
 		/// <summary>
@@ -292,9 +304,9 @@ namespace Xwt.Drawing
 		/// </summary>
 		public Distance TransformDistance (Distance distance)
 		{
-			var dx = distance.Dx;
-			var dy = distance.Dy;
-			handler.TransformDistance (Backend, ref dx, ref dy);
+			double dx = distance.Dx;
+			double dy = distance.Dy;
+            TransformDistance (ref dx, ref dy);
 			return new Distance (dx, dy);
 		}
 
@@ -303,14 +315,8 @@ namespace Xwt.Drawing
 		/// </summary>
 		public void TransformPoints (Point[] points)
 		{
-			double x, y;
-			for (int i = 0; i < points.Length; ++i) {
-				x = points[i].X;
-				y = points[i].Y;
-				TransformPoint (ref x, ref y);
-				points[i].X = x;
-				points[i].Y = y;
-			}
+            Matrix m = GetCTM ();
+            m.Transform (points);
 		}
 
 		/// <summary>
@@ -318,13 +324,13 @@ namespace Xwt.Drawing
 		/// </summary>
 		public void TransformDistances (Distance[] vectors)
 		{
-			double x, y;
+            Point p;
+            Matrix m = GetCTM ();
 			for (int i = 0; i < vectors.Length; ++i) {
-				x = vectors[i].Dx;
-				y = vectors[i].Dy;
-				TransformDistance (ref x, ref y);
-				vectors[i].Dx = x;
-				vectors[i].Dy = y;
+                p = (Point)vectors[i];
+				m.TransformVector (p);
+				vectors[i].Dx = p.X;
+				vectors[i].Dy = p.Y;
 			}
 		}
 


### PR DESCRIPTION
Adding this links nicely to the Matrix facilities added to the API, and allows TransformPoint and TransformDistance to be done locally. 

Tested for Cairo and Wpf backends, but added 'blindly' for Mac.  I'd be grateful if someone could check this visually with the Drawing.Transformations Sample.
