### PR TITLE
Fixed null-ref exception when rendering Drawing/Figures demo [Win7 x64]

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/DrawingContext.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DrawingContext.cs
@@ -129,10 +129,16 @@ namespace Xwt.WPFBackend
 		
 		internal void CopyTo (DrawingContext dc, bool toCurrent)
 		{
-			if (toCurrent) 
-				dc.Graphics.Restore (this.State);
-			else 
-				dc.State = this.Graphics.Save ();
+			if (toCurrent)
+			{
+				if (State != null)
+					dc.Graphics.Restore(this.State);
+			}
+			else
+			{
+				if(Graphics != null)
+					dc.State = this.Graphics.Save();
+			}
 			dc.Font = this.font;
 			dc.Brush = this.brush;
 			dc.Pen = this.pen;


### PR DESCRIPTION
When cloning a DrawingPath object it also tried to access the Graphics member..which is not set initializing a normal DrawingPath
