### PR TITLE
Fix Linux-Debug build

### DIFF
--- a/MixedGtkMacTest/MixedGtkMacTest.csproj
+++ b/MixedGtkMacTest/MixedGtkMacTest.csproj
@@ -11,22 +11,22 @@
     <AssemblyName>MixedGtkMacTest</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>True</DebugSymbols>
+    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>False</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <ConsolePause>False</ConsolePause>
+    <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
-    <Optimize>True</Optimize>
+    <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Externalconsole>True</Externalconsole>
+    <Externalconsole>true</Externalconsole>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -45,10 +45,6 @@
     <ProjectReference Include="..\Xwt.Gtk\Xwt.Gtk.csproj">
       <Project>{C3887A93-B2BD-4097-8E2F-3A063EFF32FD}</Project>
       <Name>Xwt.Gtk</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Xwt.Mac\Xwt.Mac.csproj">
-      <Project>{B7C1673E-5124-4BE5-8D21-EC8B12F85B6B}</Project>
-      <Name>Xwt.Mac</Name>
     </ProjectReference>
     <ProjectReference Include="..\Samples\Samples.csproj">
       <Project>{88C04B85-B69B-47B4-AB9F-64F6DD4E0897}</Project>


### PR DESCRIPTION
The reference to Xwt.Mac doesn't seem to be needed in MixedGtkMacTest, so I've removed it.  I'm assuming there are no other implications, but my build is now OK (I don't have Xwt.Mac.dll on my machine).  Only commit c007509 is needed - not sure how the other has got included (or how to remove it, I'm afraid!)
