### PR TITLE
Work around a bug in MonoMac/XamarinMac when invoking code on UI thread

### DIFF
--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -147,7 +147,7 @@ namespace Xwt.Mac
 			if (action == null)
 				throw new ArgumentNullException ("action");
 
-			NSApplication.SharedApplication.BeginInvokeOnMainThread (delegate {
+			NSRunLoop.Main.BeginInvokeOnMainThread (delegate {
 				action ();
 			});
 		}


### PR DESCRIPTION
Current editions of MonoMac/XamarinMac have a bug which will cause async invocation on UI thread to fail. This commit works around the issue (and is also a perfectly legit way of calling code on UI thread)
