### PR TITLE
Implemented RadioButton backend for Mac

### DIFF
--- a/Xwt.Mac/Xwt.Mac.csproj
+++ b/Xwt.Mac/Xwt.Mac.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Xwt.Mac\DialogBackend.cs" />
     <Compile Include="Xwt.Mac\MacSystemInformation.cs" />
     <Compile Include="Xwt.Mac\RichTextViewBackend.cs" />
+    <Compile Include="Xwt.Mac\RadioButtonBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Xwt.Mac/Xwt.Mac/ButtonBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/ButtonBackend.cs
@@ -105,6 +105,14 @@ namespace Xwt.Mac
 	
 	class MacButton: NSButton, IViewObject
 	{
+		//
+		// This is necessary since the Activated event for NSControl in AppKit does 
+		// not take a list of handlers, instead it supports only one handler.
+		//
+		// This event is used by the RadioButton backend to implement radio groups
+		//
+		internal event Action <MacButton> ActivatedInternal;
+
 		public MacButton (IntPtr p): base (p)
 		{
 		}
@@ -116,6 +124,7 @@ namespace Xwt.Mac
 				context.InvokeUserCode (delegate {
 					eventSink.OnClicked ();
 				});
+				OnActivatedInternal ();
 			};
 		}
 		
@@ -125,9 +134,20 @@ namespace Xwt.Mac
 				context.InvokeUserCode (delegate {
 					eventSink.OnClicked ();
 				});
+				OnActivatedInternal ();
 			};
 		}
-		
+
+		public MacButton (IRadioButtonEventSink eventSink, ApplicationContext context)
+		{
+			Activated += delegate {
+				context.InvokeUserCode (delegate {
+					eventSink.OnClicked ();
+				});
+				OnActivatedInternal ();
+			};
+		}
+
 		public ViewBackend Backend { get; set; }
 		
 		public NSView View {
@@ -140,6 +160,14 @@ namespace Xwt.Mac
 
 		public void DisableEvent (Xwt.Backends.ButtonEvent ev)
 		{
+		}
+
+		void OnActivatedInternal ()
+		{
+			if (ActivatedInternal == null)
+				return;
+
+			ActivatedInternal (this);
 		}
 	}
 }

--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -81,6 +81,7 @@ namespace Xwt.Mac
 			RegisterBackend <Xwt.Backends.IMenuItemBackend, MenuItemBackend> ();
 			RegisterBackend <Xwt.Backends.ICheckBoxMenuItemBackend, CheckBoxMenuItemBackend> ();
 			RegisterBackend <Xwt.Backends.IRadioButtonMenuItemBackend, RadioButtonMenuItemBackend> ();
+			RegisterBackend <Xwt.Backends.IRadioButtonBackend, RadioButtonBackend> ();
 			RegisterBackend <Xwt.Backends.ISeparatorMenuItemBackend, SeparatorMenuItemBackend> ();
 			RegisterBackend <Xwt.Backends.IComboBoxBackend, ComboBoxBackend> ();
 			RegisterBackend <Xwt.Backends.IComboBoxEntryBackend, ComboBoxEntryBackend> ();

--- a/Xwt.Mac/Xwt.Mac/RadioButtonBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/RadioButtonBackend.cs
@@ -1,0 +1,127 @@
+//
+// RadioButtonBackend.cs
+//
+// Author:
+//       Marek Habersack <grendel@xamarin.com>
+//
+// Copyright (c) 2013 Xamarin Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+
+using MonoMac.AppKit;
+using Xwt.Backends;
+
+namespace Xwt.Mac
+{
+	public class RadioButtonBackend : ViewBackend <NSButton, IRadioButtonEventSink>, IRadioButtonBackend
+	{
+		MacRadioButtonGroup radioGroup;
+
+		public object Group {
+			get {
+				if (radioGroup == null) {
+					radioGroup = new MacRadioButtonGroup ();
+					radioGroup.Add (Widget);
+				}
+				return radioGroup;
+			}
+
+			set {
+				var g = value as MacRadioButtonGroup;
+				if (g == radioGroup)
+					return;
+				radioGroup = g;
+				radioGroup.Add (Widget);
+			}
+		}
+		
+		public bool Active {
+			get { return Widget.State == NSCellStateValue.On; }
+			set { 
+ 				if (value) {
+					Widget.State = NSCellStateValue.On; 
+					var g = Group as MacRadioButtonGroup;
+					g.Activate (Widget);
+				} else
+					Widget.State = NSCellStateValue.Off;
+			}
+		}
+
+		public RadioButtonBackend ()
+		{
+		}
+	
+		public override void Initialize ()
+		{
+			var mb = new MacButton (EventSink, ApplicationContext);
+			mb.ActivatedInternal += HandleActivatedInternal;
+			ViewObject = mb;
+			Widget.SetButtonType (NSButtonType.Radio);
+			Widget.Title = String.Empty;
+		}
+
+		void HandleActivatedInternal (MacButton button)
+		{
+			if (radioGroup == null)
+				return;
+
+			if (button == null || button.State != NSCellStateValue.On)
+				return;
+			radioGroup.Activate (button);
+		}
+
+		public void SetContent (IWidgetBackend widget)
+		{
+		}
+
+		public void SetContent (string label)
+		{
+			Widget.Title = label;
+			ResetFittingSize ();
+		}
+	}
+
+	// Radio button groups are implemented using a visual element on Mac - NSMatrix. That limits the ways
+	// in which radio buttons can be grouped - they must be children of the same view. Since XWT uses a
+	// non-visual radio button group abstraction we need to emulate the job done by NSMatrix here
+	class MacRadioButtonGroup
+	{
+		NSButton lastActive;
+
+		public void Add (NSButton button)
+		{
+			if (button == null)
+				return;
+			if (button.State == NSCellStateValue.On)
+				Activate (button);
+		}
+
+		public void Activate (NSButton button)
+		{
+			if (button == null || button == lastActive)
+				return;
+			if (lastActive != null)
+				lastActive.State = NSCellStateValue.Off;
+			lastActive = button;
+		}
+	}
+}
+


### PR DESCRIPTION
The patch also contains a small work-around for AppKit NSButton limitation (the Activated event only accepts one handler) and implementation of RadioButton groups for Mac
