### PR TITLE
Fixing issue #177 "WPF Paned position bug"

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/PanedBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/PanedBackend.cs
@@ -348,7 +348,7 @@ namespace Xwt.WPFBackend
 						var oldPanel2Size = oldAvailableSize - position - SplitterSize;
 						position = availableSize - oldPanel2Size - SplitterSize;
 					}
-					else if (!IsFixed (panel1))
+					else if (!IsFixed (panel1) && lastSize != 0)
 						position = availableSize * (position / oldAvailableSize);
 				}
 


### PR DESCRIPTION
Fixing issue #177. Problem was at start because method ArrangeChildren was calculating changes from previous state(which at start is 0) luckly SplitterSize is substracted so it was not devided by zero.
