### PR TITLE
That's one small step for source code, one giant leap for event handling.

### DIFF
--- a/Xwt/Xwt.Backends/BackendHost.cs
+++ b/Xwt/Xwt.Backends/BackendHost.cs
@@ -129,7 +129,7 @@ namespace Xwt.Backends
 		
 		public void OnAfterEventRemove (object eventId, Delegate eventDelegate)
 		{
-			if (eventDelegate != null && !DefaultEnabledEvents.Contains (eventId))
+			if (eventDelegate == null && !DefaultEnabledEvents.Contains (eventId))
 				Backend.DisableEvent (eventId);
 		}
 		


### PR DESCRIPTION
Before this change this code:

``` csharp
checkBox.Toggled += picker_ValueChanged;
checkBox.Toggled += picker_ValueChanged1;
checkBox.Toggled += picker_ValueChanged2;
checkBox.Toggled -= picker_ValueChanged;
```

Would result in none of events working. After this change work as it should and 1 and 2 are called. 
Also in Wpf this was not working:

``` csharp
checkBox.Toggled += picker_ValueChanged;
checkBox.Toggled -= picker_ValueChanged;
checkBox.Toggled += picker_ValueChanged;
```

It called twice because underlying handler for first was never removed.
