### PR TITLE
Wpf CheckBox Unchecked handling

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/CheckBoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/CheckBoxBackend.cs
@@ -89,6 +89,7 @@ namespace Xwt.WPFBackend
 
 				case CheckBoxEvent.Toggled:
 					CheckBox.Checked += OnChecked;
+					CheckBox.Unchecked += OnChecked;
 					break;
 				}
 			}
@@ -105,6 +106,7 @@ namespace Xwt.WPFBackend
 
 				case CheckBoxEvent.Toggled:
 					CheckBox.Checked -= OnChecked;
+					CheckBox.Unchecked -= OnChecked;
 					break;
 				}
 			}


### PR DESCRIPTION
Wpf has seperate Checked and Unchecked events but GTK or WinForms had same so for same behaviour as GTK Unchecked must be also handled
