### PR TITLE
[WPF] WidgetBacked change makes sense and it improved behaviour to be

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/PanedBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/PanedBackend.cs
@@ -438,7 +438,7 @@ namespace Xwt.WPFBackend
 			// This line is hack to fix a measuring issue with Grid. For some reason, the grid 'remembers' the constraint
 			// parameter, so if MeasureOverride is called with a constraining size, but ArrangeOverride is later called
 			// with a bigger size, the Grid still uses the constrained size when determining the size of the children
-			constraint = new SW.Size (double.PositiveInfinity, double.PositiveInfinity);
+			//constraint = new SW.Size (double.PositiveInfinity, double.PositiveInfinity);
 
 			var s = base.MeasureOverride (constraint);
 			return Backend.MeasureOverride (constraint, s);

--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -264,6 +264,10 @@ namespace Xwt.WPFBackend
 				}
 			}
 			minSize = Widget.DesiredSize;
+			if (widget.MinWidth > 0)
+				minSize.Width = widget.MinWidth;
+			if (widget.MinHeight > 0)
+				minSize.Height = widget.MinHeight;
 			naturalSize = lastNaturalSize;
 		}
 


### PR DESCRIPTION
same as GTK at Boxes sample.(and everywhere else)

PanedBacked is abit different. It also improved compatibility with GTK mostly TreeView of samples(left side) now have ScrollBars but I'm not sure what bug i reincarnated :) but from what i tested its much better and didnt find any bug
