### PR TITLE
Review requested: Improve the semantics for Image.Size

### DIFF
--- a/Xwt/Xwt.Drawing/Image.cs
+++ b/Xwt/Xwt.Drawing/Image.cs
@@ -163,17 +163,14 @@ namespace Xwt.Drawing
 		}
 		
 		public bool HasFixedSize {
-			get { return !Size.IsZero; }
+			get { return !requestedSize.IsZero || !ToolkitEngine.ImageBackendHandler.HasMultipleSizes (Backend); }
 		}
 
 		public Size Size {
 			get {
 				if (!requestedSize.IsZero)
 					return requestedSize;
-				if (!ToolkitEngine.ImageBackendHandler.HasMultipleSizes (Backend))
-					return ToolkitEngine.ImageBackendHandler.GetSize (Backend);
-				else
-					return Size.Zero;
+				return GetDefaultSize ();
 			}
 			internal set {
 				requestedSize = value;
@@ -225,21 +222,13 @@ namespace Xwt.Drawing
 			};
 		}
 
-		Size DefaultSize {
-			get {
-				if (!requestedSize.IsZero)
-					return requestedSize;
-				else
-					return GetDefaultSize ();
-			}
-		}
-
 		internal Size GetFixedSize ()
 		{
-			var size = !Size.IsZero ? Size : DefaultSize;
-			if (size.IsZero)
-				throw new InvalidOperationException ("Image size has not been set and the image doesn't have a default size");
-			return size;
+			if (!requestedSize.IsZero)
+				return requestedSize;
+			if (!ToolkitEngine.ImageBackendHandler.HasMultipleSizes (Backend))
+				return ToolkitEngine.ImageBackendHandler.GetSize (Backend);
+			throw new InvalidOperationException ("Image size has not been set and the image doesn't have a default size");
 		}
 		
 		public Image WithBoxSize (double maxWidth, double maxHeight)


### PR DESCRIPTION
Image.Size is used as the de-facto size in places like the Gtk backend ImageBox,
so in the absence of any other fixed size, it should return the default size if
there is one. This enables DrawingImage to give a preferred size to be used.

Since Image.Size will now return the default size, consumers should not depend on
it returning Size.Zero if there is no fixed size (it can still do so if there is no
default size). Instead, they should check the HasFixedSize property.
