### PR TITLE
[Wpf] Fix GetCTM by correctly evaluating DrawingContext CurrentTransform

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ContextBackendHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ContextBackendHandler.cs
@@ -300,7 +300,7 @@ namespace Xwt.WPFBackend
 		public override Drawing.Matrix GetCTM (object backend)
 		{
 			var c = (DrawingContext)backend;
-			var m = c.CurrentTransform.Value;
+			SWM.Matrix m = c.CurrentTransform;
 			return new Drawing.Matrix (m.M11, m.M12, m.M21, m.M22, m.OffsetX, m.OffsetY);
 		}
 

--- a/Xwt.WPF/Xwt.WPFBackend/DrawingContext.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DrawingContext.cs
@@ -60,9 +60,14 @@ namespace Xwt.WPFBackend
 			}
 		}
 
-		public TransformGroup CurrentTransform {
+		public SWM.Matrix CurrentTransform {
 			get {
-				return transforms;
+				TransformCollection children = transforms.Children;
+				Matrix ctm = Matrix.Identity;
+				foreach (Transform t in children) {
+					ctm.Prepend (t.Value);
+				};
+				return ctm;
 			}
 		}
 


### PR DESCRIPTION
The Value returned by a TransformGroup Appends each successive Transform, even though they are Prepended when rendering.  This change evaluates the CTM by Prepending each transform in the collection, as is required. This restores the correct mirror-image figure in Samples.Drawing.Transformation.
