### PR TITLE
[Mac] fix color chooser sample

### DIFF
--- a/Xwt.Mac/Xwt.Mac/CustomWidgetBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/CustomWidgetBackend.cs
@@ -42,6 +42,8 @@ namespace Xwt.Mac
 		public override void Initialize ()
 		{
 			ViewObject = new WidgetView (EventSink, ApplicationContext);
+			if (Frontend is XwtWidgetBackend)
+				SetAutosizeMode (true);
 		}
 
 		public void SetContent (IWidgetBackend widget)

--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -173,17 +173,27 @@ namespace Xwt.Mac
 		
 		public override object GetNativeWidget (Widget w)
 		{
-			ViewBackend wb = (ViewBackend)Toolkit.GetBackend (w);
+			var wb = GetNativeBackend (w);
 			wb.SetAutosizeMode (true);
 			return wb.Widget;
 		}
 
 		public override bool HasNativeParent (Widget w)
 		{
-			ViewBackend wb = (ViewBackend)Toolkit.GetBackend (w);
+			var wb = GetNativeBackend (w);
 			return wb.Widget.Superview != null;
 		}
-		
+
+		public ViewBackend GetNativeBackend (Widget w)
+		{
+			var backend = Toolkit.GetBackend (w);
+			if (backend is ViewBackend)
+				return (ViewBackend)backend;
+			if (backend is XwtWidgetBackend)
+				return GetNativeBackend ((Widget)backend);
+			return null;
+		}
+
 		public override Xwt.Backends.IWindowFrameBackend GetBackendForWindow (object nativeWindow)
 		{
 			throw new NotImplementedException ();

--- a/Xwt.Mac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/ViewBackend.cs
@@ -79,8 +79,10 @@ namespace Xwt.Mac
 			canGetFocus = Widget.AcceptsFirstResponder ();
 		}
 
-		// To be called when the widget is a root and is not inside a Xwt window. For example, when it is in a popover or a tooltip
-		// In that case, the widget has to listen to the change event of the children and resize itself
+		/// <summary>
+		/// To be called when the widget is a root and is not inside a Xwt window. For example, when it is in a popover or a tooltip
+		/// In that case, the widget has to listen to the change event of the children and resize itself
+		/// </summary>
 		public void SetAutosizeMode (bool autosize)
 		{
 			this.autosize = autosize;


### PR DESCRIPTION
Color chooser sample is broken on Mac. There are 2 separate problems. 

1. Color chooser uses XwtWidgetBackend instead of a native backend, so trying to cast the backend to a ViewBackend throws and exception. I added the method GetNativeBackend() to recursively get a ViewBackend object in the case of an XwtWidgetBackend object.

2. After fixing the above problem, there is no more exception thrown, but the color chooser is still not visible. It turns out you need to call SetAutosizeMode (true) in order for it to be visible, so I added code to set this for all XwtWidgetBackend objects.