### PR TITLE
[Mac] fix crash when tree view SelectedRows count is zero

### DIFF
--- a/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
@@ -92,8 +92,10 @@ namespace Xwt.Mac
 			get {
 				TreePosition[] res = new TreePosition [Table.SelectedRowCount];
 				int n = 0;
-				foreach (var i in Table.SelectedRows) {
-					res [n] = ((TreeItem)Tree.ItemAtRow ((int)i)).Position;
+				if (Table.SelectedRowCount > 0) {
+					foreach (var i in Table.SelectedRows) {
+						res [n] = ((TreeItem)Tree.ItemAtRow ((int)i)).Position;
+					}
 				}
 				return res;
 			}


### PR DESCRIPTION
This is really a workaround for an apparent MonoMac bug. The foreach steps into the iteration when Table.SelectedRowCount == 0, so you get a null reference exception when trying to access the Position property. 
