### PR TITLE
Fixed NRE in Xwt for DialogButtons

### DIFF
--- a/Xwt/Xwt/Dialog.cs
+++ b/Xwt/Xwt/Dialog.cs
@@ -199,7 +199,9 @@ namespace Xwt
 			}
 			set {
 				label = value;
-				ParentDialog.UpdateButton (this);
+				if (ParentDialog != null) {
+					ParentDialog.UpdateButton (this);
+				}
 			}
 		}
 		
@@ -211,7 +213,9 @@ namespace Xwt
 			}
 			set {
 				image = value;
-				ParentDialog.UpdateButton (this);
+				if (ParentDialog != null) {
+					ParentDialog.UpdateButton (this);
+				}
 			}
 		}
 		
@@ -219,7 +223,9 @@ namespace Xwt
 			get { return visible; }
 			set {
 				visible = value;
-				ParentDialog.UpdateButton (this);
+				if (ParentDialog != null) {
+					ParentDialog.UpdateButton (this);
+				}
 			}
 		}
 		
@@ -227,7 +233,9 @@ namespace Xwt
 			get { return sensitive; }
 			set {
 				sensitive = value;
-				ParentDialog.UpdateButton (this);
+				if (ParentDialog != null) {
+					ParentDialog.UpdateButton (this);
+				}
 			}
 		}
 		


### PR DESCRIPTION
Test code:

``` csharp
public class MyDialog : Dialog
{
    public MyDialog ()
    {
        Buttons.Add (new Xwt.DialogButton (Command.Ok) { Sensitive = false });
    }
}
```

The problem being that `ParentDialog` is not yet set by the time `Sensitive = false` is run and, therefore, `ParentDialog.UpdateButton (this);` causes an NRE.
This fix ensures `UpdateButton` is only called when ParentDialog is not null.
