### PR TITLE
Added CurrentEventRow to TreeView.

### DIFF
--- a/Samples/Samples/TreeViews.cs
+++ b/Samples/Samples/TreeViews.cs
@@ -30,14 +30,25 @@ namespace Samples
 {
 	public class TreeViews: VBox
 	{
+		DataField<bool> check = new DataField<bool>();
 		DataField<string> text = new DataField<string> ();
 		DataField<string> desc = new DataField<string> ();
 		
 		public TreeViews ()
 		{
 			TreeView view = new TreeView ();
-			TreeStore store = new TreeStore (text, desc);
+			TreeStore store = new TreeStore (check, text, desc);
 		
+			var checkCellView = new CheckBoxCellView (check) { Editable = true };
+			checkCellView.Toggled += (object sender, WidgetEventArgs e) => {
+				if (view.CurrentEventRow == null) {
+					MessageDialog.ShowError("CurrentEventRow is null. This is not supposed to happen");
+				}
+				else {
+					store.GetNavigatorAt(view.CurrentEventRow).SetValue(text, "Toggled");
+				}
+			};
+			view.Columns.Add ("Check", checkCellView);
 			view.Columns.Add ("Item", text);
 			view.Columns.Add ("Desc", desc);
 			

--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CellUtil.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CellUtil.cs
@@ -56,25 +56,25 @@ namespace Xwt.GtkBackend
 			if (view is ITextCellViewFrontend) {
 				var cr = new CustomCellRendererText ((ITextCellViewFrontend)view);
 				col.PackStart (target, cr, false);
-				col.SetCellDataFunc (target, cr, (cell_layout, cell, treeModel, iter) => cr.LoadData (treeModel, iter));
+				col.SetCellDataFunc (target, cr, (cell_layout, cell, treeModel, iter) => cr.LoadData (col as TreeViewBackend, treeModel, iter));
 				return cr;
 			}
 			else if (view is ICheckBoxCellViewFrontend) {
 				CustomCellRendererToggle cr = new CustomCellRendererToggle ((ICheckBoxCellViewFrontend)view);
 				col.PackStart (target, cr, false);
-				col.SetCellDataFunc (target, cr, (cellLayout, cell, treeModel, iter) => cr.LoadData (treeModel, iter));
+				col.SetCellDataFunc (target, cr, (cellLayout, cell, treeModel, iter) => cr.LoadData (col as TreeViewBackend, treeModel, iter));
 				return cr;
 			}
 			else if (view is IImageCellViewFrontend) {
 				CustomCellRendererImage cr = new CustomCellRendererImage (actx, (IImageCellViewFrontend)view);
 				col.PackStart (target, cr, false);
-				col.SetCellDataFunc (target, cr, (cellLayout, cell, treeModel, iter) => cr.LoadData (treeModel, iter));
+				col.SetCellDataFunc (target, cr, (cellLayout, cell, treeModel, iter) => cr.LoadData (col as TreeViewBackend, treeModel, iter));
 				return cr;
 			}
 			else if (view is ICanvasCellViewFrontend) {
 				var cr = new CustomCellRenderer ((ICanvasCellViewFrontend) view);
 				col.PackStart (target, cr, false);
-				col.SetCellDataFunc (target, cr, (cellLayout, cell, treeModel, iter) => cr.LoadData (treeModel, iter));
+				col.SetCellDataFunc (target, cr, (cellLayout, cell, treeModel, iter) => cr.LoadData (col as TreeViewBackend, treeModel, iter));
 				return cr;
 			}
 			throw new NotSupportedException ("Unknown cell view type: " + view.GetType ());
@@ -124,6 +124,24 @@ namespace Xwt.GtkBackend
 			else
 				return val;
 		}
+
+		public static void SetCurrentEventRow (TreeViewBackend treeBackend, string path)
+		{
+			if (treeBackend != null) {
+				var treeFrontend = (TreeView)treeBackend.Frontend;
+
+				TreePosition toggledItem = null;
+
+				var pathParts = path.Split (':').Select (part => int.Parse (part));
+
+				foreach (int pathPart in pathParts) {
+					toggledItem = treeFrontend.DataSource.GetChild (toggledItem, pathPart);
+				}
+
+				treeBackend.CurrentEventRow = toggledItem;
+			}
+		}
+
 	}
 	
 	public interface ICellRendererTarget

--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRenderer.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRenderer.cs
@@ -27,6 +27,7 @@ using System;
 using Gtk;
 using Xwt.CairoBackend;
 using Xwt.Backends;
+using Xwt.GtkBackend;
 
 namespace Xwt.GtkBackend
 {
@@ -43,7 +44,7 @@ namespace Xwt.GtkBackend
 
 		#region ICellDataSource implementation
 
-		public void LoadData (TreeModel treeModel, TreeIter iter)
+		public void LoadData (TreeViewBackend treeBackend, TreeModel treeModel, TreeIter iter)
 		{
 			this.treeModel = treeModel;
 			this.iter = iter;

--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererImage.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererImage.cs
@@ -47,7 +47,7 @@ namespace Xwt.GtkBackend
 			this.view = view;
 		}
 		
-		public void LoadData (TreeModel treeModel, TreeIter iter)
+		public void LoadData (TreeViewBackend treeBackend, TreeModel treeModel, TreeIter iter)
 		{
 			this.treeModel = treeModel;
 			this.iter = iter;

--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererText.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererText.cs
@@ -31,6 +31,7 @@ namespace Xwt.GtkBackend
 {
 	public class CustomCellRendererText: Gtk.CellRendererText, ICellDataSource
 	{
+		TreeViewBackend treeBackend;
 		ITextCellViewFrontend view;
 		TreeModel treeModel;
 		TreeIter iter;
@@ -40,8 +41,9 @@ namespace Xwt.GtkBackend
 			this.view = view;
 		}
 
-		public void LoadData (TreeModel treeModel, TreeIter iter)
+		public void LoadData (TreeViewBackend treeBackend, TreeModel treeModel, TreeIter iter)
 		{
+			this.treeBackend = treeBackend;
 			this.treeModel = treeModel;
 			this.iter = iter;
 			view.Initialize (this);
@@ -67,6 +69,8 @@ namespace Xwt.GtkBackend
 
 		protected override void OnEdited (string path, string new_text)
 		{
+			CellUtil.SetCurrentEventRow (treeBackend, path);
+
 			if (!view.RaiseTextChanged () && view.TextField != null) {
 				Gtk.TreeIter iter;
 				if (treeModel.GetIterFromString (out iter, path))

--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererToggle.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererToggle.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Linq;
 using Gtk;
 using Xwt.Backends;
 
@@ -31,6 +32,7 @@ namespace Xwt.GtkBackend
 {
 	public class CustomCellRendererToggle: Gtk.CellRendererToggle, ICellDataSource
 	{
+		TreeViewBackend treeBackend;
 		ICheckBoxCellViewFrontend view;
 		TreeModel treeModel;
 		TreeIter iter;
@@ -40,8 +42,9 @@ namespace Xwt.GtkBackend
 			this.view = view;
 		}
 
-		public void LoadData (TreeModel treeModel, TreeIter iter)
+		public void LoadData (TreeViewBackend treeBackend, TreeModel treeModel, TreeIter iter)
 		{
+			this.treeBackend = treeBackend;
 			this.treeModel = treeModel;
 			this.iter = iter;
 			view.Initialize (this);
@@ -58,6 +61,8 @@ namespace Xwt.GtkBackend
 
 		protected override void OnToggled (string path)
 		{
+			CellUtil.SetCurrentEventRow (treeBackend, path);
+
 			if (!view.RaiseToggled () && view.ActiveField != null) {
 				Gtk.TreeIter iter;
 				if (treeModel.GetIterFromString (out iter, path))

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
@@ -175,6 +175,11 @@ namespace Xwt.GtkBackend
 				return sel;
 			}
 		}
+
+		public TreePosition CurrentEventRow {
+			get;
+			internal set;
+		}
 		
 		public void SelectRow (TreePosition pos)
 		{

--- a/Xwt/Xwt.Backends/ITreeViewBackend.cs
+++ b/Xwt/Xwt.Backends/ITreeViewBackend.cs
@@ -46,6 +46,8 @@ namespace Xwt.Backends
 		bool HeadersVisible { get; set; }
 		
 		bool GetDropTargetRow (double x, double y, out RowDropPosition pos, out TreePosition nodePosition);
+
+		TreePosition CurrentEventRow { get; }
 	}
 	
 	public enum ListViewColumnChange

--- a/Xwt/Xwt/TreeView.cs
+++ b/Xwt/Xwt/TreeView.cs
@@ -183,6 +183,20 @@ namespace Xwt
 				Backend.SetSelectionMode (mode);
 			}
 		}
+
+		/// <summary>
+		/// Gets or sets the row the current event applies to.
+		/// The behavior of this property is undefined when used outside an
+		/// event that supports it.
+		/// </summary>
+		/// <value>
+		/// The current event row.
+		/// </value>
+		public TreePosition CurrentEventRow {
+			get {
+				return Backend.CurrentEventRow;
+			}
+		}
 		
 		/// <summary>
 		/// Gets the selected row.


### PR DESCRIPTION
This allows e.g. Toggled event handlers to know which row was changed.
It is also implemented for the Text cell renderer text changed events.
The Image and custom cell renderers were also changed to receive the TreeViewBackend, but do nothing with it at this point.
Other tree events (such as selected row changed) do not set the CurrentEventRow property.
This property is only implemented for the Gtk backend.
