### PR TITLE
Fixed TreeNavigator: Don't throw exception in GetValue<T> when result is null

### DIFF
--- a/Xwt/Xwt/TreeNavigator.cs
+++ b/Xwt/Xwt/TreeNavigator.cs
@@ -120,7 +120,8 @@ namespace Xwt
 		
 		public T GetValue<T> (IDataField<T> field)
 		{
-			return (T) backend.GetValue (pos, field.Index);
+			var value = backend.GetValue (pos, field.Index);
+			return value == null ? default(T) : (T)value;
 		}
 		
 		public void Remove ()


### PR DESCRIPTION
Fixed bug in TreeNavigator.GetValue<T> (IDataField<T> field).

Attempting to cast null to T (where T was an enum) caused an exception. This changes Xwt to return default(T) instead.
