### PR TITLE
Fix spelling in TextLayout API

### DIFF
--- a/Samples/Samples/DrawingText.cs
+++ b/Samples/Samples/DrawingText.cs
@@ -140,7 +140,7 @@ namespace Samples
 			tl0.Text = "This text contains attributes.";
 			tl0.SetUnderline ( 0, "This".Length);
 			tl0.SetForeground (new Color (0, 1.0, 1.0), "This ".Length, "text".Length);
-			tl0.SetBackgound (new Color (0, 0, 0), "This ".Length, "text".Length);
+			tl0.SetBackground (new Color (0, 0, 0), "This ".Length, "text".Length);
 			tl0.SetFontWeight (FontWeight.Bold, "This text ".Length, "contains".Length);
 			tl0.SetFontStyle (FontStyle.Italic, "This text ".Length, "contains".Length);
 			tl0.SetStrikethrough ("This text contains ".Length, "attributes".Length);

--- a/Xwt/Xwt.Drawing/TextLayout.cs
+++ b/Xwt/Xwt.Drawing/TextLayout.cs
@@ -234,7 +234,7 @@ namespace Xwt.Drawing
 		/// <param name="color">The color of the text background.</param>
 		/// <param name="startIndex">Start index of the first character to apply the background color to.</param>
 		/// <param name="count">The number of characters to apply the background color to.</param>
-		public void SetBackgound (Color color, int startIndex, int count)
+		public void SetBackground (Color color, int startIndex, int count)
 		{
 			AddAttribute (new BackgroundTextAttribute () { StartIndex = startIndex, Count = count, Color = color });
 		}


### PR DESCRIPTION
Correct "SetBackGround" spelling - only one reference to fix up.
