### PR TITLE
Fixing Issue #235 

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
@@ -51,31 +51,6 @@ namespace Xwt.WPFBackend
 			Loaded += new RoutedEventHandler(ExTreeView_Loaded);
 		}
 
-		void ItemContainerGenerator_StatusChanged(object sender, EventArgs e)
-		{
-			//Check only when new ExTreeViewItem is generated
-			if (ItemContainerGenerator.Status == SWC.Primitives.GeneratorStatus.ContainersGenerated)
-			{
-				//This shouldn't happen since we register only if SelectedItems.Count != 0
-				if (SelectedItems.Count > 0)
-				{
-					//Check if ExTreeViewItem is generated for SelectedItem[0](this event could be fired for any other ExTreeViewItem generated not just one we want)
-					if (ContainerFromObject(SelectedItems[0]) != null)
-					{
-						//Unregister because ExTreeViewItem for SelectedItem[0] was finnaly generated
-						ItemContainerGenerator.StatusChanged -= new EventHandler(ItemContainerGenerator_StatusChanged);
-						//Reselect item so correct visual effects appear on selected item otherwise it displays as unselected(no highligthing) because
-						//when it was selected first time ExTreeViewItem was not generated yet since WPF is LazyLoading them and no visual effect could be set
-						SelectItem(SelectedItems[0]);
-					}
-				}
-				else
-				{
-					ItemContainerGenerator.StatusChanged -= new EventHandler(ItemContainerGenerator_StatusChanged);
-				}
-			}
-		}
-
 		void ExTreeView_Loaded(object sender, RoutedEventArgs e)
 		{
 			if (SelectionMode == SWC.SelectionMode.Single)
@@ -84,11 +59,6 @@ namespace Xwt.WPFBackend
 				{
 					if (Items.Count > 0)
 						SelectItem(Items[0]);
-				}
-				else
-				{
-					//Register to event which fires when WPF generates visual elements(ExTreeViewItem) for selected Items
-					ItemContainerGenerator.StatusChanged += new EventHandler(ItemContainerGenerator_StatusChanged);
 				}
 			}
 		}


### PR DESCRIPTION
Here are 2 problems fixed. 1. TreeView problem with overwriting selected values at Loaded event with default Items[0] value. Now this is checked with if (SelectedItems.Count == 0) and 2. Not selecting TreeItem because Item was selected before TreeItem created because WPF is LazyLoading TreeItems for Items after Loaded event... Now we register for ItemContainerGenerator_StatusChanged which is fired when TreeItem is lazyloaded so we check with ContainerFromObject(SelectedItems[0]) != null if our item is loaded and if it is we reselect it to make it visible...
