### PR TITLE
Wpf removing item kept it in SelectedItems list

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
@@ -155,7 +155,7 @@ namespace Xwt.WPFBackend
 			int index = list.IndexOf (node);
 			list.RemoveAt (index);
 
-			OnNodeDeleted (new TreeNodeChildEventArgs (node.Parent, index));
+			OnNodeDeleted (new TreeNodeChildEventArgs (node.Parent, index, pos));
 		}
 
 		public TreePosition GetNext (TreePosition pos)

--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -160,7 +160,18 @@ namespace Xwt.WPFBackend
 
 		public void SetSource (ITreeDataSource source, IBackend sourceBackend)
 		{
+			var currentItemsSource = Tree.ItemsSource as TreeStoreBackend;
+			if (currentItemsSource != null)
+				currentItemsSource.NodeDeleted -= TreeViewBackend_NodeDeleted;
 			Tree.ItemsSource = (TreeStoreBackend) sourceBackend;
+			var newItemsSource = sourceBackend as TreeStoreBackend;
+			if (newItemsSource != null)
+				newItemsSource.NodeDeleted += TreeViewBackend_NodeDeleted;
+		}
+
+		void TreeViewBackend_NodeDeleted(object sender, TreeNodeChildEventArgs e)
+		{
+			UnselectRow(e.Child);
 		}
 
 		public object AddColumn (ListViewColumn column)

--- a/Xwt/Xwt/ITreeDataSource.cs
+++ b/Xwt/Xwt/ITreeDataSource.cs
@@ -61,12 +61,18 @@ namespace Xwt
 	
 	public class TreeNodeChildEventArgs: TreeNodeEventArgs
 	{
-		public TreeNodeChildEventArgs (TreePosition parent, int childIndex): base (parent)
+		public TreeNodeChildEventArgs (TreePosition parent, int childIndex, TreePosition child): base (parent)
 		{
+			Child = child;
 			ChildIndex = childIndex;
 		}
-		
+
 		public int ChildIndex {
+			get;
+			private set;
+		}
+
+		public TreePosition Child {
 			get;
 			private set;
 		}

--- a/Xwt/Xwt/TreeStore.cs
+++ b/Xwt/Xwt/TreeStore.cs
@@ -367,7 +367,7 @@ namespace Xwt
 			var index = np.NodeIndex;
 			version++;
 			if (NodeDeleted != null)
-				NodeDeleted (this, new TreeNodeChildEventArgs (parent, index));
+				NodeDeleted (this, new TreeNodeChildEventArgs (parent, index, pos));
 		}
 		
 		public TreePosition GetParent (TreePosition pos)


### PR DESCRIPTION
Wpf when removing item from TreeView WpfBackend did not remove item from SelectedItems.

I tried not to modify TreeNodeChildEventArgs class but problem was that I could not identify removed node based on parent + childIndex because it was already removed from DataSource before NodeDeleted event was called.

To see this bug navigate to TreeViews sample in Samples and 2x click Remove selected item. First time it will remove properly second error will occure because SelectedItems still has removed item.