### PR TITLE
Fix InitializeAsGuest on Mac systems #249

### DIFF
--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -47,7 +47,8 @@ namespace Xwt.Mac
 		
 		public override void InitializeApplication ()
 		{
-			NSApplication.Init ();
+			if (!IsGuest)
+				NSApplication.Init ();
 			//Hijack ();
 			if (pool != null)
 				pool.Dispose ();

--- a/Xwt/Xwt/Application.cs
+++ b/Xwt/Xwt/Application.cs
@@ -57,17 +57,17 @@ namespace Xwt
 			Initialize (null);
 		}
 		
-		public static void Initialize (ToolkitType type)
+		public static void Initialize (ToolkitType type, bool isGuest = false)
 		{
-			Initialize (Toolkit.GetBackendType (type));
+			Initialize (Toolkit.GetBackendType (type), isGuest);
 		}
 
-		public static void Initialize (string backendType)
+		public static void Initialize (string backendType, bool isGuest = false)
 		{
 			if (engine != null)
 				return;
 
-			toolkit = Toolkit.Load (backendType, false);
+			toolkit = Toolkit.Load (backendType, isGuest);
 			toolkit.SetActive ();
 			engine = toolkit.Backend;
 			mainLoop = new UILoop (toolkit);
@@ -79,7 +79,7 @@ namespace Xwt
 		
 		public static void InitializeAsGuest (ToolkitType type)
 		{
-			Initialize (type);
+			Initialize (type, true);
 			toolkit.ExitUserCode (null);
 		}
 		


### PR DESCRIPTION
Starting in InitializeAsGuest, add an 'isGuest' parameter through the call-stack to get the message to MacEngine.InitializeApplication not to run NSApplication.Init ().
