### PR TITLE
Gtk CanvasBackend: out of bounds

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/CanvasBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CanvasBackend.cs
@@ -191,6 +191,9 @@ namespace Xwt.GtkBackend
 				// Set ContextBackend Origin
 				ctx.Origin.X = Allocation.X;
 				ctx.Origin.Y = Allocation.Y;
+				// clip ContextBackend to Allocation to avoid drawing outside of canvas
+				ctx.Context.Rectangle (0, 0, Allocation.Width, Allocation.Height);
+				ctx.Context.Clip ();
 			}
 			return ctx;
 		}


### PR DESCRIPTION
2 errors in CanvasBackend:
OnDraw dirtyRect is outside of Canvas-bounds
ContextBackend needs clipping to avoid drawing out of Canvas-bounds
