### PR TITLE
Initial window position without content fix for #279

### DIFF
--- a/Testing/Tests/WindowTests.cs
+++ b/Testing/Tests/WindowTests.cs
@@ -218,6 +218,44 @@ namespace Xwt
 			}
 			Assert.IsFalse (closed, "Window should not be closed");
 		}
+
+		[Test]
+		public void InitialLocationManualWithoutContent ()
+		{
+			using (var win = new Window ()) {
+				win.InitialLocation = WindowLocation.Manual;
+				win.Location = new Point (210, 230);
+				win.Size = new Size (100, 100);
+				ShowWindow (win);
+				Assert.AreEqual (210, win.X);
+				Assert.AreEqual (230, win.Y);
+			}
+		}
+
+		[Test]
+		public void InitialLocationManualWithoutContentAndSize ()
+		{
+			using (var win = new Window ()) {
+				win.InitialLocation = WindowLocation.Manual;
+				win.Location = new Point (210, 230);
+				ShowWindow (win);
+				Assert.AreEqual (210, win.X);
+				Assert.AreEqual (230, win.Y);
+			}
+		}
+
+		[Test]
+		public void InitialLocationManual ()
+		{
+			using (var win = new Window ()) {
+				win.InitialLocation = WindowLocation.Manual;
+				win.Content = new Label ("Hi there!");
+				win.Location = new Point (210, 230);
+				ShowWindow (win);
+				Assert.AreEqual (210, win.X);
+				Assert.AreEqual (230, win.Y);
+			}
+		}
 	}
 
 	public class SquareBox: Canvas

--- a/Xwt/Xwt/Window.cs
+++ b/Xwt/Xwt/Window.cs
@@ -196,9 +196,11 @@ namespace Xwt
 
 		internal override void AdjustSize ()
 		{
-			if (child == null)
+			if (child == null) {
+				if (!shown)
+					Show (initialBounds.Size);
 				return;
-
+			}
 			Size mMinSize, mDecorationsSize;
 			Backend.GetMetrics (out mMinSize, out mDecorationsSize);
 
@@ -230,6 +232,12 @@ namespace Xwt
 			if (ws.Height > size.Height)
 				size.Height = ws.Height;
 
+			Show (size);
+			Backend.SetMinSize (new Size (ws.Width, ws.Height));
+		}
+
+		void Show (Size size)
+		{
 			if (!shown) {
 				shown = true;
 
@@ -249,14 +257,13 @@ namespace Xwt
 						Backend.Bounds = new Rectangle (initialBounds.X, initialBounds.Y, size.Width, size.Height);
 					else
 						Backend.SetSize (size.Width, size.Height);
-				} else if (locationSet && !shown)
+				} else if (locationSet)
 					Backend.Move (initialBounds.X, initialBounds.Y);
 	
 			} else {
 				if (size != Size)
 					Backend.SetSize (size.Width, size.Height);
 			}
-			Backend.SetMinSize (new Size (ws.Width, ws.Height));
 		}
 	}
 }


### PR DESCRIPTION
If window has Content everything is same except "} else if (locationSet && !shown)" where !shown is removed because it didn't make sense because it was always true but actually false(see code at start of method)

Atm InitialLocationManualWithoutContentAndSize is failing for WPF because there is some bug in WPFBackend.Move method compering to WPFBackend.Bounds(called when Size is set)
I think it's somehow connected to Xwt.WPFBackend.WpfWindow.initialX not being set by Move method.

All 3 methods are failing for GTK because known bug of 8px offset.