### PR TITLE
CairoContextbackendHandler: place first line on baseline, not on descender

### DIFF
--- a/Xwt.Gtk/Xwt.CairoBackend/CairoContextBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.CairoBackend/CairoContextBackendHandler.cs
@@ -288,12 +288,14 @@ namespace Xwt.CairoBackend
 				var lc = pl.LineCount;
 				var scale = Pango.Scale.PangoScale;
 				double h = 0;
+				var fe = ctx.Context.FontExtents;
+				var baseline = fe.Ascent / (fe.Ascent + fe.Descent);
 				for (int i=0; i<lc; i++) {
 					var line = pl.Lines [i];
 					var ext = new Pango.Rectangle ();
 					var extl = new Pango.Rectangle ();
 					line.GetExtents (ref ext, ref extl);
-					h += (extl.Height / scale);
+					h += h == 0 ? (extl.Height / scale * baseline) : (extl.Height / scale);
 					if (h > layout.Height)
 						break;
 					ctx.Context.MoveTo (x, y + h);


### PR DESCRIPTION
this is a follow up of https://github.com/mono/xwt/pull/277

CairoContextBackendHandler.DrawTextLayout 
positions text on different locations depending on TextLayout.Height:

![drawtextgtkerror](https://f.cloud.github.com/assets/1479980/1984208/b1aa4772-8426-11e3-9c9c-72d89820d64a.PNG)

reason:  pango_layout_set_text sets text origin to top/left, pango_cairo_show_layout_line to the BASELINE of the text  (see: http://cairographics.org/FAQ/)
h+extl.Height means setting to the descender line

![500px-typography_line_terms svg](https://f.cloud.github.com/assets/1479980/2013103/247c66dc-8791-11e3-88a3-3a59258d07f6.png)

so the position of the first line has to be the baseline
the baseline can calculated with Context.FontExtents.Ascent and Descent  (approx. 75% of the font height in most fonts). 
