### PR TITLE
Fix for InitializeAsGuest for Mac

### DIFF
--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -47,9 +47,9 @@ namespace Xwt.Mac
 		
 		public override void InitializeApplication ()
 		{
-      if(!IsGuest) {
+			if(!IsGuest) {
   			NSApplication.Init ();
-      }
+			}
 			//Hijack ();
 			if (pool != null)
 				pool.Dispose ();

--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -47,7 +47,9 @@ namespace Xwt.Mac
 		
 		public override void InitializeApplication ()
 		{
-			NSApplication.Init ();
+      if(!IsGuest) {
+  			NSApplication.Init ();
+      }
 			//Hijack ();
 			if (pool != null)
 				pool.Dispose ();

--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -47,9 +47,8 @@ namespace Xwt.Mac
 		
 		public override void InitializeApplication ()
 		{
-			if(!IsGuest) {
-  			NSApplication.Init ();
-			}
+			if(!IsGuest)
+				NSApplication.Init ();
 			//Hijack ();
 			if (pool != null)
 				pool.Dispose ();

--- a/Xwt/Xwt/Application.cs
+++ b/Xwt/Xwt/Application.cs
@@ -57,9 +57,9 @@ namespace Xwt
 			Initialize (null);
 		}
 		
-    public static void Initialize (ToolkitType type, bool isGuest = false)
+		public static void Initialize (ToolkitType type, bool isGuest = false)
 		{
-      Initialize (Toolkit.GetBackendType (type), isGuest);
+			Initialize (Toolkit.GetBackendType (type), isGuest);
 		}
 
 		public static void Initialize (string backendType, bool isGuest = false)

--- a/Xwt/Xwt/Application.cs
+++ b/Xwt/Xwt/Application.cs
@@ -57,19 +57,19 @@ namespace Xwt
 			Initialize (null);
 		}
 		
-		public static void Initialize (ToolkitType type)
+    public static void Initialize (ToolkitType type, bool isGuest = false)
 		{
-			Initialize (Toolkit.GetBackendType (type));
+      Initialize (Toolkit.GetBackendType (type), isGuest);
 		}
 
-		public static void Initialize (string backendType)
+		public static void Initialize (string backendType, bool isGuest = false)
 		{
 			if (backendType == null)
 				throw new ArgumentNullException ("backendType");
 			if (engine != null)
 				return;
 
-			toolkit = Toolkit.Load (backendType, false);
+			toolkit = Toolkit.Load (backendType, isGuest);
 			toolkit.SetActive ();
 			engine = toolkit.Backend;
 			mainLoop = new UILoop (toolkit);
@@ -81,7 +81,7 @@ namespace Xwt
 		
 		public static void InitializeAsGuest (ToolkitType type)
 		{
-			Initialize (type);
+			Initialize (type, true);
 			toolkit.ExitUserCode (null);
 		}
 		
@@ -89,7 +89,7 @@ namespace Xwt
 		{
 			if (backendType == null)
 				throw new ArgumentNullException ("backendType");
-			Initialize (backendType);
+			Initialize (backendType, true);
 			toolkit.ExitUserCode (null);
 		}
 


### PR DESCRIPTION
These changes avoid the redundant call to NSApplication.Init() when running as guest, which causes the app to fail.

Changes to Application are needed because IsGuest does not get set properly because Application.InitializeAsGuest calls Initialize which calls Toolkit.Load with isGuest hardcoded to false.