### PR TITLE
Fixed: Screen.ScaleFactor always returns 1, even on a Retina display

### DIFF
--- a/Xwt.Mac/Xwt.Mac/MacDesktopBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/MacDesktopBackend.cs
@@ -107,6 +107,11 @@ namespace Xwt.Mac
 			return ((NSScreen)backend).DeviceDescription ["NSScreenNumber"].ToString ();
 		}
 
+		public override double GetScaleFactor (object backend)
+		{
+			return ((NSScreen)backend).BackingScaleFactor;
+		}
+		
 		#endregion
 	}
 }


### PR DESCRIPTION
With the change, calling Window.Screen.ScaleFactor will return differing values as the window is dragged between retina and non-retina displays, as it should.
