### PR TITLE
Wpf.TextEntryBackend: implement MultiLine

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/TextEntryBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TextEntryBackend.cs
@@ -98,7 +98,7 @@ namespace Xwt.WPFBackend
 					if (multiline) {
 						TextBox.VerticalContentAlignment = VerticalAlignment.Top;
 						TextBox.AcceptsReturn = true;
-						TextBox.TextWrapping = TextWrapping.NoWrap;
+						TextBox.TextWrapping = TextWrapping.Wrap;
 					} else {
 						TextBox.VerticalContentAlignment = VerticalAlignment.Center;
 						TextBox.AcceptsReturn = false;


### PR DESCRIPTION
implementation of multiline in wpf

GTK will be a problem, as Gtk.Entry seems not to support multiline, or? 
It would be necessary to switch to GtkTextView as the underlying widget
