### PR TITLE
SearchTextEntry focus and escape key preventing dialog from closing.

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/SearchTextEntryBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/SearchTextEntryBackend.cs
@@ -50,6 +50,12 @@ namespace Xwt.GtkBackend
 			((WidgetBackend)this).Widget = searchEntry;
 			searchEntry.Show ();
 		}
+
+		public override void SetFocus ()
+		{
+			base.SetFocus ();
+			TextEntry.GrabFocus ();
+		}
 	}
 
 	class SearchEntry : Gtk.EventBox

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -161,7 +161,7 @@ namespace Xwt.GtkBackend
 			get { return Widget.IsFocus; }
 		}
 		
-		public void SetFocus ()
+		public virtual void SetFocus ()
 		{
 			Widget.IsFocus = true;
 //			SetFocus (Widget);


### PR DESCRIPTION
**Fix SearchTextEntry being unable to get focus**

Override the SetFocus method so focus can be forced by using GrabFocus.

**Do not capture escape key when search text entry is empty**

Capturing the escape key prevents a dialog from closing.

When there is text in the search text entry then the escape key is
captured and the text is cleared when this key is pressed.

When there is no text in the search text entry then the escape key
is not handled/captured by the search text entry and can be
handled elsewhere, such as by a dialog.
