### PR TITLE
[Mac] Fix CanvasBackend QueueDraw (rect) to ensure redraw

### DIFF
--- a/Xwt.Mac/Xwt.Mac/CanvasBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/CanvasBackend.cs
@@ -64,7 +64,7 @@ namespace Xwt.Mac
 		
 		public void QueueDraw (Rectangle rect)
 		{
-			view.NeedsToDraw (new System.Drawing.RectangleF ((float)rect.X, (float)rect.Y, (float)rect.Width, (float)rect.Height));
+			view.SetNeedsDisplayInRect (new System.Drawing.RectangleF ((float)rect.X, (float)rect.Y, (float)rect.Width, (float)rect.Height));
 		}
 		
 		public void AddChild (IWidgetBackend widget, Rectangle rect)

--- a/Xwt.sln
+++ b/Xwt.sln
@@ -1,8 +1,8 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
-VisualStudioVersion = {0}
-MinimumVisualStudioVersion = {0}
+# VisualStudioVersion = {0}
+# MinimumVisualStudioVersion = {0}
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xwt", "Xwt\Xwt.csproj", "{92494904-35FA-4DC9-BDE9-3A3E87AC49D3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xwt.Gtk", "Xwt.Gtk\Xwt.Gtk.csproj", "{C3887A93-B2BD-4097-8E2F-3A063EFF32FD}"


### PR DESCRIPTION
Original code (using view.NeedsToDraw) did not cause OnDraw to be called as expected.

This fixes the first item of Issue #291.  I'll close this and generate a separate one for the MouseMove issue.
