### PR TITLE
Add three more cursor types

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -217,6 +217,12 @@ namespace Xwt.GtkBackend
 					ctype = Gdk.CursorType.SbHDoubleArrow;
 				else if (cursor == CursorType.ResizeUpDown)
 					ctype = Gdk.CursorType.SbVDoubleArrow;
+				else if (cursor == CursorType.Move)
+					ctype = Gdk.CursorType.Fleur;
+				else if (cursor == CursorType.Wait)
+					ctype = Gdk.CursorType.Watch;
+				else if (cursor == CursorType.Help)
+					ctype = Gdk.CursorType.QuestionArrow;
 				else
 					ctype = Gdk.CursorType.Arrow;
 				

--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -416,6 +416,14 @@ namespace Xwt.WPFBackend
 				Widget.Cursor = Cursors.SizeWE;
 			else if (cursor == CursorType.ResizeLeftRight)
 				widget.Cursor = Cursors.SizeWE;
+			else if (cursor == CursorType.Move)
+				widget.Cursor = Cursors.SizeAll;
+			else if (cursor == CursorType.Wait)
+				widget.Cursor = Cursors.Wait;
+			else if (cursor == CursorType.Help)
+				widget.Cursor = Cursors.Help;
+			else
+				Widget.Cursor = Cursors.Arrow;
 		}
 		
 		public virtual void UpdateLayout ()

--- a/Xwt/Xwt/CursorType.cs
+++ b/Xwt/Xwt/CursorType.cs
@@ -54,6 +54,9 @@ namespace Xwt
 		public static readonly CursorType ResizeDown = new CursorType ("ResizeDown");
 		public static readonly CursorType ResizeUpDown = new CursorType ("ResizeUpDown");
 		public static readonly CursorType Hand = new CursorType ("Hand");
+		public static readonly CursorType Move = new CursorType ("Move");
+		public static readonly CursorType Wait = new CursorType ("Watch");
+		public static readonly CursorType Help = new CursorType ("Help");
 
 		
 		class CursorTypeValueConverter: TypeConverter


### PR DESCRIPTION
Move, wait and help cursor.
Gtk and WPF only. There are no such standard icons on MacOSX. Mac user will see the standard cursor.
