### PR TITLE
[GTK] ListView gets keyboard focus when SetFocus is called.

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
@@ -155,6 +155,12 @@ namespace Xwt.GtkBackend
 
 			return new Rectangle (x, y, w, h);
 		}
+
+		public override void SetFocus ()
+		{
+			base.SetFocus ();
+			Widget.GrabFocus ();
+		}
 	}
 }
 


### PR DESCRIPTION
Calling ListView.SetFocus() was not getting the keyboard focus so the up/down arrow keys did not select the next list view item.