### PR TITLE
Add XwtComponent.Tag property

### DIFF
--- a/Xwt/Xwt/XwtComponent.cs
+++ b/Xwt/Xwt/XwtComponent.cs
@@ -37,7 +37,6 @@ namespace Xwt
 	public abstract class XwtComponent : Component, IFrontend
 	{
 		BackendHost backendHost;
-        object tag;
 		
 		public XwtComponent ()
 		{
@@ -62,14 +61,10 @@ namespace Xwt
 			get { return backendHost.Backend; }
 		}
 
-        /// <summary>
-        /// A value, that can be used to identify this component
-        /// </summary>
-        public object Tag
-        {
-            get { return tag; }
-            set { tag = value; }
-        }
+		/// <summary>
+		/// A value, that can be used to identify this component
+		/// </summary>
+		public object Tag { get; set; }
 
 		protected static void MapEvent (object eventId, Type type, string methodName)
 		{


### PR DESCRIPTION
Currently it is impossible to mark dynamically created widgets for their subsequent identification. The Windows Forms and WPF for this purpose have a Tag property. In this pull-request I've added a Tag property into the XwtComponent.cs.
Any claims or suggestions about my edits are welcome.
The pre-pull-request discussion was here: https://groups.google.com/forum/#!topic/xwt-list/SlWKPJ7lpBQ and there: https://github.com/mono/xwt/pull/300.

Because of some Git issues, I'm started everything from zero and made the changes again. Sorry for any inconvience.
