### PR TITLE
WPF.FileDialogBackend: bug if no file is selected

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/FileDialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/FileDialogBackend.cs
@@ -63,7 +63,7 @@ namespace Xwt.WPFBackend
 		{
 			get
 			{
-				if (this.filters.Count == 0)
+				if (this.filters.Count == 0 || this.dialog.FilterIndex < 1)
 					return null;
 
 				return this.filters [this.dialog.FilterIndex - 1];


### PR DESCRIPTION
if you don't select a file (cancel the dialog), an out of range exception is thrown
