### PR TITLE
[WPF] Error when using nested TextEntry in Notebook sample in ScrollView

### DIFF
--- a/TestApps/Samples/Samples/NotebookSample.cs
+++ b/TestApps/Samples/Samples/NotebookSample.cs
@@ -11,10 +11,40 @@ namespace Samples
 			Notebook nb = new Notebook ();
 			nb.Add (new Label ("First tab content"), "First Tab");
 			nb.Add (new MyWidget (), "Second Tab");
+            nb.Add (new MyTestWidget(), "Third Tab");
 			nb.TabOrientation = NotebookTabOrientation.Bottom;
 			PackStart (nb, true);
 		}
 	}
+
+    class MyTestWidget : VBox
+    {
+        public MyTestWidget()
+        {
+            PackStart(new Label("Test"));
+
+            VBox ContentData = new VBox()
+            {
+                ExpandHorizontal = true,
+                ExpandVertical = true
+            };
+
+            ScrollView ContentScroll = new ScrollView()
+            {
+                Content = ContentData,
+                ExpandHorizontal = true,
+                ExpandVertical = true
+            };
+            PackStart(ContentScroll, true, true);
+
+            ContentData.PackStart(new TextEntry() { PlaceholderText = "Test" }, true, true);
+            ContentData.PackStart(new TextEntry(), true, true);
+            ContentData.PackStart(new TextEntry(), true, true);
+            ContentData.PackStart(new TextEntry(), true, true);
+            ContentData.PackStart(new TextEntry(), true, true);
+            ContentData.PackStart(new TextEntry(), true, true);
+        }
+    }
 	
 	class MyWidget: Canvas
 	{

--- a/Xwt.WPF/Xwt.WPFBackend/TextEntryBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TextEntryBackend.cs
@@ -47,13 +47,21 @@ namespace Xwt.WPFBackend
 		{
 			Widget = new ExTextBox { IsReadOnlyCaretVisible = true };
 			Adorner = new PlaceholderTextAdorner (TextBox);
-			TextBox.Loaded += delegate {
-				var layer = AdornerLayer.GetAdornerLayer (TextBox);
-				if (layer != null)
-					layer.Add (Adorner);
-			};
+            TextBox.Loaded += TextBox_Loaded;
 			TextBox.VerticalContentAlignment = VerticalAlignment.Center;
 		}
+
+        void TextBox_Loaded(object sender, RoutedEventArgs e)
+        {
+            var layer = AdornerLayer.GetAdornerLayer(TextBox);
+
+            if (layer != null)
+                layer.Add(Adorner);
+               
+            TextBox.Loaded -= TextBox_Loaded;
+        }
+
+        
 
 		protected override double DefaultNaturalWidth
 		{


### PR DESCRIPTION
I accidentally hit a problem, when I am trying to use TextEntry -> ScrollVIew -> Notebook list, there is and error when Notebook trying to add already loaded TextEntryPlaceholders, so I simply remove Loaded Callback, after first call. This can cause other issue, which I can not realize. I add an Example for better debugging.
