### PR TITLE
[WPF] center all lines in wrapped centered labels

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/LabelBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/LabelBackend.cs
@@ -181,7 +181,10 @@ namespace Xwt.WPFBackend
 
 		public Alignment TextAlignment {
 			get { return DataConverter.ToXwtAlignment (Label.HorizontalContentAlignment); }
-			set { Label.HorizontalContentAlignment = DataConverter.ToWpfAlignment (value); }
+			set { 
+				Label.HorizontalContentAlignment = DataConverter.ToWpfAlignment (value); 
+				Label.TextBlock.TextAlignment = DataConverter.ToTextAlignment (value);
+			}
 		}
 
 		public EllipsizeMode Ellipsize {


### PR DESCRIPTION
This one fixes the text alignment of wrapped centered labels when using the WPF backend.
Without this patch only the first line is centered and the following lines are left-aligned to the first one.
