### PR TITLE
[Gtk CanvasBackend]  Offset dirtyRect in Canvas OnDraw to allow for CanvasBackend origin

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/CanvasBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CanvasBackend.cs
@@ -169,7 +169,9 @@ namespace Xwt.GtkBackend
 			Backend.ApplicationContext.InvokeUserCode (delegate {
 				using (var context = CreateContext ()) {
 					var a = evnt.Area;
-					EventSink.OnDraw (context, new Rectangle (a.X, a.Y, a.Width, a.Height));
+					// offset exposed area by CanvasBackend origin
+					var r = new Rectangle (a.X - context.Origin.X, a.Y - context.Origin.Y, a.Width, a.Height);
+					EventSink.OnDraw (context, r);
 				}
 			});
 			return base.OnExposeEvent (evnt);


### PR DESCRIPTION
This is for the [Gtk] CanvasBackend only, and allows for the case where a Canvas does not have a Visible window when the Canvas is created. A similar offset is required when the CTM is evaluated (see PR #272) but the problem with the OnDraw dirtyRect has only just come to light when trying to copy from an off-screen display cache, which has a (0,0) origin.  
