### PR TITLE
[WPF] Fixes #329

### DIFF
--- a/TestApps/Samples/Samples/NotebookSample.cs
+++ b/TestApps/Samples/Samples/NotebookSample.cs
@@ -11,43 +11,56 @@ namespace Samples
 			Notebook nb = new Notebook ();
 			nb.Add (new Label ("First tab content"), "First Tab");
 			nb.Add (new MyWidget (), "Second Tab");
-            nb.Add (new MyTestWidget(), "Third Tab");
+			nb.Add (new MyTestWidget(), "Third Tab");
 			nb.TabOrientation = NotebookTabOrientation.Bottom;
 			PackStart (nb, true);
 		}
 	}
 
-    class MyTestWidget : VBox
-    {
-        public MyTestWidget()
-        {
-            PackStart(new Label("Test"));
+	class MyTestWidget : VBox
+	{
+		public MyTestWidget()
+		{
+			PackStart(new TextEntry() { PlaceholderText = "Placeholder Test" });
+			PackStart(new Label("Scrollable Test:"));
 
-            VBox ContentData = new VBox()
-            {
-                ExpandHorizontal = true,
-                ExpandVertical = true
-            };
+			VBox ContentData = new VBox()
+			{
+				ExpandHorizontal = true,
+				ExpandVertical = true
+			};
 
-            ScrollView ContentScroll = new ScrollView()
-            {
-                Content = ContentData,
-                ExpandHorizontal = true,
-                ExpandVertical = true
-            };
-            PackStart(ContentScroll, true, true);
+			ScrollView ContentScroll = new ScrollView()
+			{
+				Content = ContentData,
+				ExpandHorizontal = true,
+				ExpandVertical = true
+			};
+			PackStart(ContentScroll, true, true);
 
-            ContentData.PackStart(new TextEntry() { PlaceholderText = "Test" }, true, true);
-            ContentData.PackStart(new TextEntry(), true, true);
-            ContentData.PackStart(new TextEntry(), true, true);
-            ContentData.PackStart(new TextEntry(), true, true);
-            ContentData.PackStart(new TextEntry(), true, true);
-            ContentData.PackStart(new TextEntry(), true, true);
-        }
-    }
-	
+			ContentData.PackStart(new TextEntry() { PlaceholderText = "Placeholder Test" }, true, true);
+			ContentData.PackStart(new TextEntry(), true, true);
+			ContentData.PackStart(new TextEntry() { PlaceholderText = "Placeholder Test" }, true, true);
+			ContentData.PackStart(new TextEntry(), true, true);
+			ContentData.PackStart(new TextEntry() { PlaceholderText = "Placeholder Test" }, true, true);
+			ContentData.PackStart(new MyWidget (), true, true);
+			ContentData.PackStart(new TextEntry() { PlaceholderText = "Placeholder Test" }, true, true);
+			ContentData.PackStart(new TextEntry(), true, true);
+			ContentData.PackStart(new TextEntry() { PlaceholderText = "Placeholder Test" }, true, true);
+			ContentData.PackStart(new TextEntry(), true, true);
+			ContentData.PackStart(new TextEntry() { PlaceholderText = "Placeholder Test" }, true, true);
+			ContentData.PackStart(new TextEntry(), true, true);
+		}
+	}
+
 	class MyWidget: Canvas
 	{
+		public MyWidget()
+		{
+			MinWidth = 210;
+			MinHeight = 110;
+		}
+
 		protected override void OnDraw (Context ctx, Rectangle dirtyRect)
 		{
 			ctx.SetLineWidth (5);

--- a/Xwt.WPF/Xwt.WPFBackend/TextEntryBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TextEntryBackend.cs
@@ -39,29 +39,25 @@ namespace Xwt.WPFBackend
 		: WidgetBackend, ITextEntryBackend
 	{
 		bool multiline;
+		string placeholderText;
 
 		PlaceholderTextAdorner Adorner {
 			get; set;
 		}
+
 		public TextEntryBackend()
 		{
 			Widget = new ExTextBox { IsReadOnlyCaretVisible = true };
-			Adorner = new PlaceholderTextAdorner (TextBox);
-            TextBox.Loaded += TextBox_Loaded;
+			TextBox.Loaded += delegate {
+				Adorner = new PlaceholderTextAdorner (TextBox);
+				var layer = AdornerLayer.GetAdornerLayer (TextBox);
+				if (layer != null)
+					layer.Add (Adorner);
+				if (!String.IsNullOrEmpty(placeholderText))
+					Adorner.PlaceholderText = placeholderText;
+			};
 			TextBox.VerticalContentAlignment = VerticalAlignment.Center;
-		}
-
-        void TextBox_Loaded(object sender, RoutedEventArgs e)
-        {
-            var layer = AdornerLayer.GetAdornerLayer(TextBox);
-
-            if (layer != null)
-                layer.Add(Adorner);
-               
-            TextBox.Loaded -= TextBox_Loaded;
-        }
-
-        
+		}        
 
 		protected override double DefaultNaturalWidth
 		{
@@ -80,10 +76,15 @@ namespace Xwt.WPFBackend
 			set { TextBox.TextAlignment = DataConverter.ToTextAlignment (value); }
 		}
 
-		public string PlaceholderText
-		{
-			get { return Adorner.PlaceholderText; }
-			set { Adorner.PlaceholderText = value; }
+		public string PlaceholderText {
+			get {
+				return placeholderText;
+			}
+			set {
+				placeholderText = value;
+				if (Adorner != null)
+					Adorner.PlaceholderText = value;
+			}
 		}
 
 		public bool ReadOnly


### PR DESCRIPTION
PlaceholderTextAdorner should be initialized after the backend widget has been fully loaded.
The placeholder text has to be kept in a field, so it gets correctly assigned to the Adorner after the loading is finished.

(fixes #329)
