### PR TITLE
[WPF] Fix SeparatorMenuItem Show / Hide

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/MenuBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/MenuBackend.cs
@@ -73,6 +73,12 @@ namespace Xwt.WPFBackend
 				ParentWindow.mainMenu.Items.Insert (index, itemBackend.Item);
 			else if (this.menu != null)
 				this.menu.Items.Insert (index, itemBackend.Item);
+
+            if (item.GetType() == typeof(SeparatorMenuItemBackend))
+            {
+                var separatorItem = item as SeparatorMenuItemBackend;
+                separatorItem.Parent = this;
+            }
 		}
 
 		public void RemoveItem (IMenuItemBackend item)

--- a/Xwt.WPF/Xwt.WPFBackend/SeparatorMenuItemBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/SeparatorMenuItemBackend.cs
@@ -35,6 +35,32 @@ namespace Xwt.WPFBackend
 		public SeparatorMenuItemBackend()
 			: base (new SWC.Separator())
 		{
+            _visible = true;   
 		}
-	}
+
+        public MenuBackend Parent { get; set; }
+
+        private bool _visible;
+        private int _savedIndex;
+
+        public new bool Visible
+        {
+            get { return _visible; }
+            set { SetVisibilit(value); }
+        }
+
+        private void SetVisibilit(bool value)
+        {
+            _visible = value;
+            if (!_visible)
+            {
+                _savedIndex = Parent.Items.IndexOf(this);
+                Parent.RemoveItem(this);
+            }
+            else
+            {
+                Parent.InsertItem(_savedIndex, this);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hi.

I was porting a GUI from WinForms and at some point I had to add a hidden MenuItem and a SeparatorMenuItem to show them only in when a certain state is active.

On GTK+Windows it works fine, I just have to change the Visibility property or call Show or Hide methods.
But in WPF the separator cannot be hidden as I seems not to be a subclass of MenuItem.

Then I thought on remove temporary the Separator from the MenuItems list, saving the current position, and inserting it again at that position. The behavior almost the same.

I have not tested it on Mac, so I cannot say if the same issue occurs.
