### PR TITLE
[Xwt.Wpf] Fixed Tree operations on WPF

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
@@ -104,7 +104,7 @@ namespace Xwt.WPFBackend
 
 			var newNode = new TreeStoreNode (
 				new object[this.columnTypes.Length],
-				node);
+				node.Parent);
 
 			var list = GetContainingList (node);
 			int index = list.IndexOf (node);
@@ -121,7 +121,7 @@ namespace Xwt.WPFBackend
 
 			var newNode = new TreeStoreNode (
 				new object[this.columnTypes.Length],
-				node);
+				node.Parent);
 
 			var list = GetContainingList (node);
 			int index = list.IndexOf (node);

--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -158,7 +158,9 @@ namespace Xwt.WPFBackend
 
 		public void ScrollToRow (TreePosition pos)
 		{
-			GetVisibleTreeItem (pos).BringIntoView();
+			ExTreeViewItem item = GetVisibleTreeItem (pos);
+			if (item != null)
+				item.BringIntoView ();
 		}
 
 		public void SetSelectionMode (SelectionMode mode)
@@ -358,6 +360,9 @@ namespace Xwt.WPFBackend
 			while (nodes.Count > 0) {
 				node = nodes.Pop ();
 				treeItem = (ExTreeViewItem) g.ContainerFromItem (node);
+				if (treeItem == null)
+					continue;
+
 				treeItem.UpdateLayout ();
 				g = treeItem.ItemContainerGenerator;
 


### PR DESCRIPTION
[Xwt.Wpf] Fixed Tree operations on WPF
- InsertBefore / InsertAfter was creating the TreeStoreNode with wrong parent.
- Avoid NRE on GetVisibleItem ( ContainerFromItem can return null, even after UpdateLayout call).
