### PR TITLE
[WPF] Make sure that the dialog appears on top, instead of behind other windows

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/DialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DialogBackend.cs
@@ -121,6 +121,7 @@ namespace Xwt.WPFBackend
 			if (parent != null)
 				Window.Owner = ((WindowFrameBackend) parent).Window;
 			Window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+			Window.Topmost = true;
 			Window.ShowDialog ();
 		}
 


### PR DESCRIPTION
A dialog should appear above other windows when opened.

If this is not desired, please leave a comment on how to achieve a similiar result since 'TopMost' is not exposed/part to/of the XWT API.