### PR TITLE
[Xwt.Gtk] Handle when multiple drag/drop datatypes are allowed

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -937,7 +937,7 @@ namespace Xwt.GtkBackend
 				return false;
 			}
 
-			if (DragDropInfo.DragDataRequests == 0) {
+			if (DragDropInfo.DragDataRequests >= 0) {
 				if (DragDropInfo.DragDataForMotion) {
 					// If no specific action is set, it means that no key has been pressed.
 					// In that case, use Move or Copy or Link as default (when allowed, in this order).


### PR DESCRIPTION
If SetDragDropTarget is called and multiple types are passed in,
DragDataRequests will be set equal to the number of items passed
in.

Util.GetSelectionData already filters out requests which do not
match the current atom, so i believe the correct fix is to simply
remove the 'if' statement which comes after it. As i'm not 100%
sure if that is safe to do, i instead changed it to a >= 0, which
should be perfectly safe.

The exact case where this was failing was if you registered as supporting
Foo and Bar and then tried to do a drag of type Bar. On my system it
would check the 'Bar' TransferDataType' first and then not emit the
events because DragDataRequests was equal to 1.
