### PR TITLE
Add invisible cursor (CursorType.Invisible)

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -217,6 +217,8 @@ namespace Xwt.GtkBackend
 					ctype = Gdk.CursorType.Watch;
 				else if (cursor == CursorType.Help)
 					ctype = Gdk.CursorType.QuestionArrow;
+				else if (cursor == CursorType.Invisible)
+					ctype = (Gdk.CursorType)(-2); // Gdk.CursorType.None, since Gtk 2.16
 				else
 					ctype = Gdk.CursorType.Arrow;
 				

--- a/Xwt.Mac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/ViewBackend.cs
@@ -228,6 +228,9 @@ namespace Xwt.Mac
 				ctype = NSCursor.ResizeLeftRightCursor;
 			else if (cursor == CursorType.ResizeUpDown)
 				ctype = NSCursor.ResizeUpDownCursor;
+			else if (cursor == CursorType.Invisible)
+				// TODO: load transparent cursor
+				Cursor = NSCursor.ArrowCursor;
 			else
 				ctype = NSCursor.ArrowCursor;
 			// TODO: assign the cursor

--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -431,6 +431,8 @@ namespace Xwt.WPFBackend
 				widget.Cursor = Cursors.Wait;
 			else if (cursor == CursorType.Help)
 				widget.Cursor = Cursors.Help;
+			else if (cursor == CursorType.Invisible)
+				widget.Cursor = Cursors.None;
 			else
 				Widget.Cursor = Cursors.Arrow;
 		}

--- a/Xwt/Xwt/CursorType.cs
+++ b/Xwt/Xwt/CursorType.cs
@@ -57,6 +57,7 @@ namespace Xwt
 		public static readonly CursorType Move = new CursorType ("Move");
 		public static readonly CursorType Wait = new CursorType ("Watch");
 		public static readonly CursorType Help = new CursorType ("Help");
+		public static readonly CursorType Invisible = new CursorType ("Invisible");
 
 		
 		class CursorTypeValueConverter: TypeConverter


### PR DESCRIPTION
Adds an invisible cursor type CursorType.Invisible which hides the mouse cursor.
On Gtk and WPF there is a special invisible cursor for this purpose.

TODO MAC: maybe we could simply load some transparent bitmap?
