### PR TITLE
[Gtk] fix evt handling for widgets with own window

### DIFF
--- a/Xwt.Gtk/Xwt.Gtk3.csproj
+++ b/Xwt.Gtk/Xwt.Gtk3.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Xwt.GtkBackend\GtkWebKitMini.cs" />
     <Compile Include="Xwt.GtkBackend\PopoverBackend.cs" />
     <Compile Include="Xwt.GtkBackend\Gtk3PopoverWindow.cs" />
+    <Compile Include="Xwt.GtkBackend\PanedBackendGtk3.cs" />
     <Compile Include="Xwt.GtkBackend\ColorSelectorBackend.cs" />
     <Compile Include="Xwt.GtkBackend\ColorPickerBackend.cs" />
   </ItemGroup>

--- a/Xwt.Gtk/Xwt.GtkBackend/ButtonBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ButtonBackend.cs
@@ -43,6 +43,7 @@ namespace Xwt.GtkBackend
 
 		public override void Initialize ()
 		{
+			NeedsEventBox = false;
 			Widget = new Gtk.Button ();
 			base.Widget.Show ();
 			

--- a/Xwt.Gtk/Xwt.GtkBackend/CheckBoxBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CheckBoxBackend.cs
@@ -41,6 +41,7 @@ namespace Xwt.GtkBackend
 
 		public override void Initialize ()
 		{
+			NeedsEventBox = false;
 			Widget = new Gtk.CheckButton ();
 			Widget.Toggled += HandleWidgetActivated;
 			Widget.Show ();

--- a/Xwt.Gtk/Xwt.GtkBackend/ComboBoxBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ComboBoxBackend.cs
@@ -41,6 +41,7 @@ namespace Xwt.GtkBackend
 
 		public override void Initialize ()
 		{
+			//NeedsEventBox = false;  // TODO: needs fix: no events with or without event box
 			Widget = (Gtk.ComboBox) CreateWidget ();
 			if (Widget.Cells.Length == 0) {
 				var cr = new Gtk.CellRendererText ();

--- a/Xwt.Gtk/Xwt.GtkBackend/PanedBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PanedBackend.cs
@@ -28,7 +28,7 @@ using Xwt.Backends;
 
 namespace Xwt.GtkBackend
 {
-	public class PanedBackend: WidgetBackend, IPanedBackend
+	public partial class PanedBackend: WidgetBackend, IPanedBackend
 	{
 		protected new Gtk.Paned Widget {
 			get { return (Gtk.Paned)base.Widget; }

--- a/Xwt.Gtk/Xwt.GtkBackend/PanedBackendGtk3.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PanedBackendGtk3.cs
@@ -1,0 +1,38 @@
+﻿//
+// PanedBackendGtk3.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace Xwt.GtkBackend
+{
+	public partial class PanedBackend
+	{
+		public PanedBackend ()
+		{
+			NeedsEventBox = false;
+		}
+	}
+}
+

--- a/Xwt.Gtk/Xwt.GtkBackend/RadioButtonBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/RadioButtonBackend.cs
@@ -38,6 +38,7 @@ namespace Xwt.GtkBackend
 
 		public override void Initialize ()
 		{
+			NeedsEventBox = false;
 			Widget = new Gtk.RadioButton ("");
 			Widget.Show ();
 		}

--- a/Xwt.Gtk/Xwt.GtkBackend/WebViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WebViewBackend.cs
@@ -40,6 +40,7 @@ namespace Xwt.GtkBackend
 
 		public override void Initialize()
 		{
+			NeedsEventBox = false;
 			base.Initialize ();
 
 			view = new WebKit.WebView ();

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -344,6 +344,12 @@ namespace Xwt.GtkBackend
 		protected virtual Gtk.Widget EventsRootWidget {
 			get { return eventBox ?? Widget; }
 		}
+
+		bool needsEventBox = true; // require event box by default
+		protected virtual bool NeedsEventBox {
+			get { return needsEventBox; }
+			set { needsEventBox = value; }
+		}
 		
 		public static Gtk.Widget GetWidget (IWidgetBackend w)
 		{
@@ -431,6 +437,8 @@ namespace Xwt.GtkBackend
 		{
 			// Wraps the widget with an event box. Required for some
 			// widgets such as Label which doesn't have its own gdk window
+
+			if (!NeedsEventBox) return;
 
 			if (eventBox == null && !EventsRootWidget.GetHasWindow()) {
 				if (EventsRootWidget is Gtk.EventBox) {


### PR DESCRIPTION
Some Gtk Widgets have their own Gdk.Window. Most of the events are not raised for such widgets, because WidgetBackend (and its derivates) automatically put them into an EventBox and subscribe its events, instead of using the widgets directly.

This PR allows Gtk backends to overide EventBox allocation and handle events directly for widgets which have a Gdk.Window already. This is achieved though the WidgetBackend.NeedsEventBox property, which is true by default (keeps original behavior). Backends can set it to false during their initialization and force the base class WidgetBackend to subscribe the events from the widgets directly.

I've tested almost all widgets (but not all events, only Mouse events) and added the override to widgets, that did not work previously. Maybe some other backends should use the override, too.

