### PR TITLE
add null check for text in TextLayoutBackend

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/TextLayoutBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TextLayoutBackendHandler.cs
@@ -71,13 +71,13 @@ namespace Xwt.GtkBackend
 				}
 			}
 
-			string text;
+			string text = String.Empty;
 			public string Text {
 				get {
 					return text;
 				}
 				set {
-					text = value;
+					text = value ?? String.Empty;;
 					indexer = null;
 					if (attributes != null) {
 						attributes.Dispose ();
@@ -139,6 +139,7 @@ namespace Xwt.GtkBackend
 		public override void SetText (object backend, string text)
 		{
 			var tl = (PangoBackend) backend;
+			text = text ?? String.Empty;
 			tl.Layout.SetText (text);
 			tl.Text = text;
 		}

--- a/Xwt.Mac/Xwt.Mac/TextLayoutBackendHandler.cs
+++ b/Xwt.Mac/Xwt.Mac/TextLayoutBackendHandler.cs
@@ -43,7 +43,7 @@ namespace Xwt.Mac
 	{
 		class LayoutInfo
 		{
-			public string Text;
+			public string Text = String.Empty;
 			public NSFont Font;
 			public float? Width, Height;
 			public TextTrimming TextTrimming;
@@ -57,7 +57,7 @@ namespace Xwt.Mac
 		public override void SetText (object backend, string text)
 		{
 			LayoutInfo li = (LayoutInfo)backend;
-			li.Text = text.Replace ("\r\n", "\n");
+			li.Text = text == null ? String.Empty : text.Replace ("\r\n", "\n");
 		}
 
 		public override void SetFont (object backend, Xwt.Drawing.Font font)

--- a/Xwt.WPF/Xwt.WPFBackend/TextLayoutBackendHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TextLayoutBackendHandler.cs
@@ -112,7 +112,7 @@ namespace Xwt.WPFBackend
 		SolidColorBrush brush = System.Windows.Media.Brushes.Black;
 		double width;
 		double height;
-		string text = null;
+		string text = String.Empty;
 		Xwt.Drawing.TextTrimming? textTrimming;
 		bool needsRebuild;
 
@@ -160,7 +160,7 @@ namespace Xwt.WPFBackend
 		{
 			if (this.text != text)
 			{
-				this.text = text;
+				this.text = text ?? String.Empty;
 				needsRebuild = true;
 			}
 		}


### PR DESCRIPTION
The text should never be null in a layout, because the toolkits require a string value, when drawing. Otherwise WPF and MAC throw a NullReferenceException and Gtk prints a warning to the console (Pango-CRITICAL).
