### PR TITLE
TextInput event optimization

### DIFF
--- a/TestApps/Samples/Samples/TextInput.cs
+++ b/TestApps/Samples/Samples/TextInput.cs
@@ -15,7 +15,7 @@ namespace Samples
 
 			public TextEditor ()
 			{
-				this.PreviewTextInput += HandleTextInput;
+				this.TextInput += HandleTextInput;
 				this.ButtonPressed += HandleButtonPressed;
 
 				CanGetFocus = true;
@@ -28,7 +28,7 @@ namespace Samples
 				SetFocus();
 			}
 
-			void HandleTextInput (object sender, PreviewTextInputEventArgs e)
+			void HandleTextInput (object sender, TextInputEventArgs e)
 			{
 				text += e.Text;
 				e.Handled = true;

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk2Extensions.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk2Extensions.cs
@@ -145,6 +145,11 @@ namespace Xwt.GtkBackend
 				widget.ModifyBg (Gtk.StateType.Normal, color.ToGtkValue ());
 		}
 
+		public static string GetText (this Gtk.TextInsertedArgs args)
+		{
+			return args.Text;
+		}
+
 		public static void RenderPlaceholderText (this Gtk.Entry entry, Gtk.ExposeEventArgs args, string placeHolderText, ref Pango.Layout layout)
 		{
 			// The Entry's GdkWindow is the top level window onto which

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk3Extensions.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk3Extensions.cs
@@ -171,6 +171,11 @@ namespace Xwt.GtkBackend
 			return Gtk.StateFlags.Normal;
 		}
 
+		public static string GetText (this Gtk.TextInsertedArgs args)
+		{
+			return args.NewText;
+		}
+
 		public static double GetSliderPosition (this Gtk.Scale scale)
 		{
 			int start, end;

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
@@ -1274,6 +1274,15 @@ namespace Xwt.GtkBackend
 			return ret;
 			#endif
 		}
+
+
+		[DllImport(GtkInterop.LIBGOBJECT, CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr g_signal_stop_emission_by_name(IntPtr raw, string name);
+
+		public static void StopSignal (this GLib.Object gobject, string signalid)
+		{
+			g_signal_stop_emission_by_name (gobject.Handle, signalid);
+		}
 	}
 	
 	public struct KeyboardShortcut : IEquatable<KeyboardShortcut>

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -260,6 +260,8 @@ namespace Xwt.GtkBackend
 				MarkDestroyed (Frontend);
 				Widget.Destroy ();
 			}
+			if (IMContext != null)
+				IMContext.Dispose ();
 		}
 
 		void MarkDestroyed (Widget w)
@@ -511,11 +513,26 @@ namespace Xwt.GtkBackend
 				case WidgetEvent.BoundsChanged:
 					Widget.SizeAllocated += HandleWidgetBoundsChanged;
 					break;
-                case WidgetEvent.MouseScrolled:
-                    AllocEventBox();
+				case WidgetEvent.MouseScrolled:
+					AllocEventBox();
 					EventsRootWidget.AddEvents ((int)Gdk.EventMask.ScrollMask);
-                    Widget.ScrollEvent += HandleScrollEvent;
-                    break;
+					Widget.ScrollEvent += HandleScrollEvent;
+					break;
+				case WidgetEvent.TextInput:
+					if (EditableWidget != null) {
+						EditableWidget.TextInserted += HandleTextInserted;
+					} else {
+						RunWhenRealized (delegate {
+							if (IMContext == null) {
+								IMContext = new Gtk.IMMulticontext ();
+								IMContext.ClientWindow = EventsRootWidget.GdkWindow;
+								IMContext.Commit += HandleImCommitEvent;
+							}
+						});
+						Widget.KeyPressEvent += HandleTextInputKeyPressEvent;
+						Widget.KeyReleaseEvent += HandleTextInputKeyReleaseEvent;
+					}
+					break;
 				}
 				if ((ev & dragDropEvents) != 0 && (enabledEvents & dragDropEvents) == 0) {
 					// Enabling a drag&drop event for the first time
@@ -578,11 +595,21 @@ namespace Xwt.GtkBackend
 				case WidgetEvent.BoundsChanged:
 					Widget.SizeAllocated -= HandleWidgetBoundsChanged;
 					break;
-                case WidgetEvent.MouseScrolled:
+				case WidgetEvent.MouseScrolled:
 					if (!EventsRootWidget.IsRealized)
 						EventsRootWidget.Events &= ~Gdk.EventMask.ScrollMask;
-                    Widget.ScrollEvent -= HandleScrollEvent;
-                    break;
+					Widget.ScrollEvent -= HandleScrollEvent;
+					break;
+				case WidgetEvent.TextInput:
+					if (EditableWidget != null) {
+						EditableWidget.TextInserted -= HandleTextInserted;
+					} else {
+						if (IMContext != null)
+							IMContext.Commit -= HandleImCommitEvent;
+						Widget.KeyPressEvent -= HandleTextInputKeyPressEvent;
+						Widget.KeyReleaseEvent -= HandleTextInputKeyReleaseEvent;
+					}
+					break;
 				}
 				
 				enabledEvents &= ~ev;
@@ -662,17 +689,73 @@ namespace Xwt.GtkBackend
 			return new KeyEventArgs (k, (int)args.Event.KeyValue, m, false, (long)args.Event.Time);
 		}
 
-        [GLib.ConnectBefore]
-        void HandleScrollEvent(object o, Gtk.ScrollEventArgs args)
-        {
+		protected Gtk.IMContext IMContext { get; set; }
+
+		[GLib.ConnectBefore]
+		void HandleTextInserted (object o, Gtk.TextInsertedArgs args)
+		{
+			if (String.IsNullOrEmpty (args.GetText ()))
+				return;
+
+			var pargs = new TextInputEventArgs (args.GetText ());
+			ApplicationContext.InvokeUserCode (delegate {
+				EventSink.OnTextInput (pargs);
+			});
+
+			if (pargs.Handled)
+				args.RetVal = true;
+		}
+
+		[GLib.ConnectBefore]
+		void HandleTextInputKeyReleaseEvent (object o, Gtk.KeyReleaseEventArgs args)
+		{
+			if (IMContext != null)
+				IMContext.FilterKeypress (args.Event);
+		}
+
+		[GLib.ConnectBefore]
+		void HandleTextInputKeyPressEvent (object o, Gtk.KeyPressEventArgs args)
+		{
+			if (IMContext != null)
+				IMContext.FilterKeypress (args.Event);
+
+			// new lines are not triggered by im, handle them here
+			if (args.Event.Key == Gdk.Key.Return ||
+			    args.Event.Key == Gdk.Key.ISO_Enter ||
+			    args.Event.Key == Gdk.Key.KP_Enter) {
+				var pargs = new TextInputEventArgs (Environment.NewLine);
+				ApplicationContext.InvokeUserCode (delegate {
+					EventSink.OnTextInput (pargs);
+				});
+			}
+		}
+
+		[GLib.ConnectBefore]
+		void HandleImCommitEvent (object o, Gtk.CommitArgs args)
+		{
+			if (String.IsNullOrEmpty (args.Str))
+				return;
+
+			var pargs = new TextInputEventArgs (args.Str);
+			ApplicationContext.InvokeUserCode (delegate {
+				EventSink.OnTextInput (pargs);
+			});
+
+			if (pargs.Handled)
+				args.RetVal = true;
+		}
+
+		[GLib.ConnectBefore]
+		void HandleScrollEvent(object o, Gtk.ScrollEventArgs args)
+		{
 			var a = GetScrollEventArgs (args);
 			if (a == null)
 				return;
-            ApplicationContext.InvokeUserCode (delegate {
-                EventSink.OnMouseScrolled(a);
-            });
-            if (a.Handled)
-                args.RetVal = true;
+			ApplicationContext.InvokeUserCode (delegate {
+				EventSink.OnMouseScrolled(a);
+			});
+			if (a.Handled)
+			args.RetVal = true;
 		}
 
 		protected virtual MouseScrolledEventArgs GetScrollEventArgs (Gtk.ScrollEventArgs args)

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -703,7 +703,7 @@ namespace Xwt.GtkBackend
 			});
 
 			if (pargs.Handled)
-				args.RetVal = true;
+				((GLib.Object)o).StopSignal ("insert-text");
 		}
 
 		[GLib.ConnectBefore]

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackendGtk2.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackendGtk2.cs
@@ -33,6 +33,11 @@ namespace Xwt.GtkBackend
 	{
 		bool gettingPreferredSize;
 
+		protected Gtk.Editable EditableWidget 
+		{
+			get { return Widget as Gtk.Editable; }
+		}
+
 		protected virtual void OnSetBackgroundColor (Color color)
 		{
 			EventsRootWidget.SetBackgroundColor (color);

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackendGtk3.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackendGtk3.cs
@@ -31,6 +31,11 @@ namespace Xwt.GtkBackend
 {
 	public partial class WidgetBackend
 	{
+		protected Gtk.IEditable EditableWidget 
+		{
+			get { return Widget as Gtk.IEditable; }
+		}
+
 		protected virtual void OnSetBackgroundColor (Color color)
 		{
 			Widget.SetBackgroundColor (color);

--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -456,7 +456,7 @@ namespace Xwt.WPFBackend
 					case WidgetEvent.KeyReleased:
 						Widget.PreviewKeyUp += WidgetKeyUpHandler;
 						break;
-					case WidgetEvent.PreviewTextInput:
+					case WidgetEvent.TextInput:
 						TextCompositionManager.AddPreviewTextInputHandler(Widget, WidgetPreviewTextInputHandler);
 						break;
 					case WidgetEvent.ButtonPressed:
@@ -510,7 +510,7 @@ namespace Xwt.WPFBackend
 					case WidgetEvent.KeyReleased:
 						Widget.PreviewKeyUp -= WidgetKeyUpHandler;
 						break;
-					case WidgetEvent.PreviewTextInput:
+					case WidgetEvent.TextInput:
 						TextCompositionManager.RemovePreviewTextInputHandler(Widget, WidgetPreviewTextInputHandler);
 						break;
 					case WidgetEvent.ButtonPressed:
@@ -612,10 +612,10 @@ namespace Xwt.WPFBackend
 
 		void WidgetPreviewTextInputHandler (object sender, System.Windows.Input.TextCompositionEventArgs e)
 		{
-			PreviewTextInputEventArgs args = new PreviewTextInputEventArgs(e.Text);
+			TextInputEventArgs args = new TextInputEventArgs(e.Text);
 			Context.InvokeUserCode(delegate
 			{
-				eventSink.OnPreviewTextInput(args);
+				eventSink.OnTextInput(args);
 			});
 			if (args.Handled)
 				e.Handled = true;

--- a/Xwt/Xwt.Backends/IWidgetBackend.cs
+++ b/Xwt/Xwt.Backends/IWidgetBackend.cs
@@ -290,7 +290,7 @@ namespace Xwt.Backends
 		/// Notifies the frontend that a text has been entered.
 		/// </summary>
 		/// <param name="args">The text input arguments.</param>
-		void OnPreviewTextInput (PreviewTextInputEventArgs args);
+		void OnTextInput (TextInputEventArgs args);
 
 		/// <summary>
 		/// Notifies the frontend that the widget has received the focus.
@@ -444,7 +444,7 @@ namespace Xwt.Backends
 		/// <summary>  The widget can/wants to be notified of scroll events. </summary>
 		MouseScrolled = 1 << 17,
 		/// <summary>  The widget can/wants to be notified of text input events. </summary>
-		PreviewTextInput = 1 << 18
+		TextInput = 1 << 18
 	}
 	
 	/// <summary>

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -38,7 +38,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Xwt.Backends\IPasswordEntryBackend.cs" />
     <Compile Include="Xwt\PasswordEntry.cs" />
-    <Compile Include="Xwt\PreviewTextEventArgs.cs" />
+    <Compile Include="Xwt\TextInputEventArgs.cs" />
     <Compile Include="Xwt\Widget.cs" />
     <Compile Include="Xwt\Window.cs" />
     <Compile Include="Xwt\Button.cs" />

--- a/Xwt/Xwt/TextInputEventArgs.cs
+++ b/Xwt/Xwt/TextInputEventArgs.cs
@@ -5,12 +5,12 @@ using System.Text;
 
 namespace Xwt
 {
-	public class PreviewTextInputEventArgs : EventArgs
+	public class TextInputEventArgs : EventArgs
 	{
 		public bool Handled { get; set; }
 		public string Text { get; private set; }
 
-		public PreviewTextInputEventArgs(string text)
+		public TextInputEventArgs(string text)
 		{
 			Text = text;
 		}

--- a/Xwt/Xwt/Widget.cs
+++ b/Xwt/Xwt/Widget.cs
@@ -72,7 +72,7 @@ namespace Xwt
 		EventHandler dragLeave;
 		EventHandler<KeyEventArgs> keyPressed;
 		EventHandler<KeyEventArgs> keyReleased;
-		EventHandler<PreviewTextInputEventArgs> previewTextInput;
+		EventHandler<TextInputEventArgs> textInput;
 		EventHandler mouseEntered;
 		EventHandler mouseExited;
 		EventHandler<ButtonEventArgs> buttonPressed;
@@ -180,9 +180,9 @@ namespace Xwt
 				Parent.OnKeyReleased (args);
 			}
 
-			void IWidgetEventSink.OnPreviewTextInput (PreviewTextInputEventArgs args)
+			void IWidgetEventSink.OnTextInput (TextInputEventArgs args)
 			{
-				Parent.OnPreviewTextInput (args);
+				Parent.OnTextInput (args);
 			}
 			
 			Size IWidgetEventSink.GetPreferredSize (SizeConstraint widthConstraint, SizeConstraint heightConstraint)
@@ -263,7 +263,7 @@ namespace Xwt
 			MapEvent (WidgetEvent.DragLeave, typeof(Widget), "OnDragLeave");
 			MapEvent (WidgetEvent.KeyPressed, typeof(Widget), "OnKeyPressed");
 			MapEvent (WidgetEvent.KeyReleased, typeof(Widget), "OnKeyReleased");
-			MapEvent (WidgetEvent.PreviewTextInput, typeof(Widget), "OnPreviewTextInput");
+			MapEvent (WidgetEvent.TextInput, typeof(Widget), "OnTextInput");
 			MapEvent (WidgetEvent.GotFocus, typeof(Widget), "OnGotFocus");
 			MapEvent (WidgetEvent.LostFocus, typeof(Widget), "OnLostFocus");
 			MapEvent (WidgetEvent.MouseEntered, typeof(Widget), "OnMouseEntered");
@@ -1127,10 +1127,10 @@ namespace Xwt
 		/// The event will be enabled in the backend automatically, if <see cref="Xwt.Widget.OnPreviewTextInput"/>
 		/// is overridden.
 		/// </remarks>
-		internal protected virtual void OnPreviewTextInput (PreviewTextInputEventArgs args)
+		internal protected virtual void OnTextInput (TextInputEventArgs args)
 		{
-			if (previewTextInput != null)
-				previewTextInput (this, args);
+			if (textInput != null)
+				textInput (this, args);
 		}
 
 		/// <summary>
@@ -1951,14 +1951,14 @@ namespace Xwt
 		/// <summary>
 		/// Raised when a text has been entered.
 		/// </summary>
-		public event EventHandler<PreviewTextInputEventArgs> PreviewTextInput {
+		public event EventHandler<TextInputEventArgs> TextInput {
 			add {
-				BackendHost.OnBeforeEventAdd (WidgetEvent.PreviewTextInput, previewTextInput);
-				previewTextInput += value;
+				BackendHost.OnBeforeEventAdd (WidgetEvent.TextInput, textInput);
+				textInput += value;
 			}
 			remove {
-				previewTextInput -= value;
-				BackendHost.OnAfterEventRemove (WidgetEvent.PreviewTextInput, previewTextInput);
+				textInput -= value;
+				BackendHost.OnAfterEventRemove (WidgetEvent.TextInput, textInput);
 			}
 		}
 		


### PR DESCRIPTION
Consistency: rename PreviewTextInput event to TextInput
* Xwt has no preview events. To stop an event, the Handled property of the event arguments object should be used.

GTK: adds TextInput event support
* different implementation for Editable and non-Editable widgets
* Gtk.Editable (like Entry, TextView, etc.): simply handle TextInserted event
* Other widgets: use Gtk.IMMulticontext to get text input directly from the system IM
