### PR TITLE
[Gtk] fix pointer coordinates for mouse events

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
@@ -1226,6 +1226,36 @@ namespace Xwt.GtkBackend
 		}
 
 
+		/// <summary>
+		/// Adjusts pointer coordinates to be relative to the widget.
+		/// </summary>
+		/// <returns>The pointer coordinates.</returns>
+		/// <param name="widget">The Widget.</param>
+		/// <param name="eventWindow">The event source window.</param>
+		/// <param name="x">The events pointer x coordinate.</param>
+		/// <param name="y">The events pointer y coordinate.</param>
+		/// <remarks>
+		/// Some widgets have additional child Gdk windows (or real child widgets if
+		/// the widget is a container) on top of their root window.
+		/// In this case pointer events may come from child windows and contain
+		/// wrong coordinates (relative to child window and not to the widget itself).
+		/// 
+		/// CheckPointerCoordinates checks whether the events source window is not
+		/// the widgets root window and adjusts the coordinates to relative
+		/// to the widget and not to its child.
+		///</remarks>
+		public static Xwt.Point CheckPointerCoordinates (this Gtk.Widget widget, Gdk.Window eventWindow, double x, double y)
+		{
+			if (widget.GdkWindow != eventWindow)
+			{
+				int pointer_x, pointer_y;
+				widget.GetPointer (out pointer_x, out pointer_y);
+				return new Xwt.Point (pointer_x, pointer_y);
+			}
+			return new Xwt.Point (x, y);
+		}
+
+
 		[DllImport(GtkInterop.LIBGTK, CallingConvention = CallingConvention.Cdecl)]
 		static extern IntPtr gtk_message_dialog_get_message_area(IntPtr raw);
 		

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -680,7 +680,8 @@ namespace Xwt.GtkBackend
 		protected virtual MouseScrolledEventArgs GetScrollEventArgs (Gtk.ScrollEventArgs args)
 		{
 			var direction = args.Event.Direction.ToXwtValue ();
-			return new MouseScrolledEventArgs ((long) args.Event.Time, args.Event.X, args.Event.Y, direction);
+			var pointer_coords = EventsRootWidget.CheckPointerCoordinates (args.Event.Window, args.Event.X, args.Event.Y);
+			return new MouseScrolledEventArgs ((long) args.Event.Time, pointer_coords.X, pointer_coords.Y, direction);
 		}
         
 
@@ -734,7 +735,8 @@ namespace Xwt.GtkBackend
 
 		protected virtual MouseMovedEventArgs GetMouseMovedEventArgs (Gtk.MotionNotifyEventArgs args)
 		{
-			return new MouseMovedEventArgs ((long) args.Event.Time, args.Event.X, args.Event.Y);
+			var pointer_coords = EventsRootWidget.CheckPointerCoordinates (args.Event.Window, args.Event.X, args.Event.Y);
+			return new MouseMovedEventArgs ((long) args.Event.Time, pointer_coords.X, pointer_coords.Y);
 		}
 
 		void HandleButtonReleaseEvent (object o, Gtk.ButtonReleaseEventArgs args)
@@ -752,8 +754,11 @@ namespace Xwt.GtkBackend
 		protected virtual ButtonEventArgs GetButtonReleaseEventArgs (Gtk.ButtonReleaseEventArgs args)
 		{
 			var a = new ButtonEventArgs ();
-			a.X = args.Event.X;
-			a.Y = args.Event.Y;
+
+			var pointer_coords = EventsRootWidget.CheckPointerCoordinates (args.Event.Window, args.Event.X, args.Event.Y);
+			a.X = pointer_coords.X;
+			a.Y = pointer_coords.Y;
+
 			a.Button = (PointerButton) args.Event.Button;
 			return a;
 		}
@@ -774,8 +779,10 @@ namespace Xwt.GtkBackend
 		protected virtual ButtonEventArgs GetButtonPressEventArgs (Gtk.ButtonPressEventArgs args)
 		{
 			var a = new ButtonEventArgs ();
-			a.X = args.Event.X;
-			a.Y = args.Event.Y;
+
+			var pointer_coords = EventsRootWidget.CheckPointerCoordinates (args.Event.Window, args.Event.X, args.Event.Y);
+			a.X = pointer_coords.X;
+			a.Y = pointer_coords.Y;
 
 			a.Button = (PointerButton) args.Event.Button;
 			if (args.Event.Type == Gdk.EventType.TwoButtonPress)


### PR DESCRIPTION
**EDIT:** Some widgets have additional child Gdk windows (or real child widgets if the widget is a container) on top of their root window. In this case pointer events may come from child windows and contain wrong coordinates (relative to child window and not to the widget itself). 
The CheckPointerCoordinates workaround function checks whether the events source window is not the widgets root window and adjusts the coordinates to be relative to the widget and not to its child.

*Old message: If a widget is a container and a mouse event is raised by one of its children with own child Gdk.Window, the pointer coordinates are relative to the child and not the widget itself. In this case the pointer coordinates should be updated.*