### PR TITLE
[Gtk] Optimize message dialogs

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/Conversion.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Conversion.cs
@@ -186,6 +186,27 @@ namespace Xwt.GtkBackend
 			}
 			throw new InvalidOperationException("Invalid alignment value: " + alignment);
 		}
+
+		public static Gtk.ResponseType ToResponseType (this Xwt.Command command)
+		{
+			if (command.Id == Command.Ok.Id)
+				return Gtk.ResponseType.Ok;
+			if (command.Id == Command.Cancel.Id)
+				return Gtk.ResponseType.Cancel;
+			if (command.Id == Command.Yes.Id)
+				return Gtk.ResponseType.Yes;
+			if (command.Id == Command.No.Id)
+				return Gtk.ResponseType.No;
+			if (command.Id == Command.Close.Id)
+				return Gtk.ResponseType.Close;
+			if (command.Id == Command.Delete.Id)
+				return Gtk.ResponseType.DeleteEvent;
+			if (command.Id == Command.Apply.Id)
+				return Gtk.ResponseType.Accept;
+			if (command.Id == Command.Stop.Id)
+				return Gtk.ResponseType.Reject;
+			return Gtk.ResponseType.None;
+		}
 	}
 }
 

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk2Extensions.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk2Extensions.cs
@@ -93,9 +93,15 @@ namespace Xwt.GtkBackend
 			return context.Targets;
 		}
 
-		public static void AddContent (this Gtk.Dialog dialog, Gtk.Widget widget)
+		public static void AddContent (this Gtk.Dialog dialog, Gtk.Widget widget, bool expand = true, bool fill = true, uint padding = 0)
 		{
-			dialog.VBox.PackStart (widget);
+			dialog.VBox.PackStart (widget, expand, fill, padding);
+		}
+
+		public static void AddContent (this Gtk.MessageDialog dialog, Gtk.Widget widget, bool expand = true, bool fill = true, uint padding = 0)
+		{
+			var messageArea = dialog.GetMessageArea () ?? dialog.VBox;
+			messageArea.PackStart (widget, expand, fill, padding);
 		}
 
 		public static void SetContentSpacing (this Gtk.Dialog dialog, int spacing)

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk3Extensions.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk3Extensions.cs
@@ -82,9 +82,14 @@ namespace Xwt.GtkBackend
 			return context.SelectedAction;
 		}
 
-		public static void AddContent (this Gtk.Dialog dialog, Gtk.Widget widget)
+		public static void AddContent (this Gtk.Dialog dialog, Gtk.Widget widget, bool expand = true, bool fill = true, uint padding = 0)
 		{
-			dialog.ContentArea.Add (widget);
+			dialog.ContentArea.PackStart (widget, expand, fill, padding);
+		}
+
+		public static void AddContent (this Gtk.MessageDialog dialog, Gtk.Widget widget, bool expand = true, bool fill = true, uint padding = 0)
+		{
+			dialog.GetMessageArea().PackStart (widget, expand, fill, padding);
 		}
 
 		public static void SetContentSpacing (this Gtk.Dialog dialog, int spacing)

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkAlertDialog.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkAlertDialog.cs
@@ -59,9 +59,6 @@ namespace Xwt.GtkBackend
 
 			this.Title        = "";
 			this.Resizable    = false;
-			#if !XWT_GTK3
-			this.HasSeparator = false;
-			#endif
 		}
 		
 		public GtkAlertDialog (ApplicationContext actx, MessageDescription message)

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
@@ -1224,6 +1224,26 @@ namespace Xwt.GtkBackend
 			return new Gtk.ComboBoxEntry ();
 			#endif
 		}
+
+
+		[DllImport(GtkInterop.LIBGTK, CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gtk_message_dialog_get_message_area(IntPtr raw);
+		
+		public static Gtk.Box GetMessageArea(this Gtk.MessageDialog dialog)
+		{
+			#if XWT_GTK3
+			// according to Gtk docs MessageArea should always be a Gtk.Box, but we test this
+			// to be on the safe side.
+			var messageArea = dialog.MessageArea as Gtk.Box;
+			return messageArea ?? dialog.ContentArea;
+			#else
+			if (GtkWorkarounds.GtkMajorVersion <= 2 && GtkWorkarounds.GtkMinorVersion < 22) // message area not present before 2.22
+				return dialog.VBox;
+			IntPtr raw_ret = gtk_message_dialog_get_message_area(dialog.Handle);
+			Gtk.Box ret = GLib.Object.GetObject(raw_ret) as Gtk.Box;
+			return ret;
+			#endif
+		}
 	}
 	
 	public struct KeyboardShortcut : IEquatable<KeyboardShortcut>


### PR DESCRIPTION
Let Gtk.MessageDialog do the layout stuff and make use of Gtk.MessageType for a more native icon styles.

This change makes message dialogs look more native and closer to gtk design guidelines (especially with gtk3). Additionally the dialogs should be compatible with more themes (providing special designs for message dialogs).

(an extended message dialog sample has been added to the sample app, too: #380)

Some example screenshots (Ubuntu - Gnome 3):

Before (gtk2/3)| After (gtk2) | After (gtk3)
------------ | ------------- | --------------
![error_old](https://cloud.githubusercontent.com/assets/951587/4178809/4c03f91a-36a8-11e4-9284-110a08beca16.png) | ![error_new_gtk2](https://cloud.githubusercontent.com/assets/951587/4178807/3566b7ba-36a8-11e4-9af7-f53a69f4d9b3.png) | ![error_gtk3](https://cloud.githubusercontent.com/assets/951587/4178810/6c2303c6-36a8-11e4-8d7f-ad9e9ff23dbf.png)
![question_old](https://cloud.githubusercontent.com/assets/951587/4178827/1863451a-36a9-11e4-871d-6dd4663e21ed.png) | ![question_gtk2](https://cloud.githubusercontent.com/assets/951587/4178828/240b912e-36a9-11e4-8d77-cb8e1d480667.png) | ![question_gtk3](https://cloud.githubusercontent.com/assets/951587/4178830/317a0aca-36a9-11e4-9467-26457985bd4e.png)


