### PR TITLE
[Gtk] Fix default icon sizes

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererImage.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererImage.cs
@@ -47,7 +47,8 @@ namespace Xwt.GtkBackend
 		{
 			var view = (IImageCellViewFrontend)Frontend;
 			renderer.Context = ApplicationContext;
-			renderer.Image = view.Image.ToImageDescription (ApplicationContext);
+			var image = view.Image.ToImageDescription (ApplicationContext);
+			renderer.Image = image.Size.IsZero ? image.WithDefaultSize (Gtk.IconSize.Menu) : image;
 		}
 	}
 

--- a/Xwt.Gtk/Xwt.GtkBackend/ButtonBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ButtonBackend.cs
@@ -87,7 +87,7 @@ namespace Xwt.GtkBackend
 			
 			Gtk.Widget imageWidget = null;
 			if (image.Backend != null)
-				imageWidget = new ImageBox (ApplicationContext, image.WithDefaultSize (Gtk.IconSize.Button));
+				imageWidget = new ImageBox (ApplicationContext, image.Size.IsZero ? image.WithDefaultSize (Gtk.IconSize.Button) : image);
 
 			if (label != null && imageWidget == null) {
 				contentWidget = new Gtk.Label (label) { UseUnderline = useMnemonic }; 

--- a/Xwt.Gtk/Xwt.GtkBackend/Util.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Util.cs
@@ -231,10 +231,9 @@ namespace Xwt.GtkBackend
 		
 		public static ImageDescription WithDefaultSize (this ImageDescription image, Gtk.IconSize defaultIconSize)
 		{
-			if (image.Size.IsZero) {
-				var s = iconSizes [(int)defaultIconSize];
+			var s = iconSizes [(int)defaultIconSize];
+			if (!s.IsZero)
 				image.Size = s;
-			}
 			return image;
 		}
 


### PR DESCRIPTION
ImageDescription.WithDefaultSize should always return the icon with the default size.
Backends like Button or ImageRenderer should decide to enforce a default size, or to set it only, if not done by the user.

(78f999f follow up)