### PR TITLE
[WPF] Fix loading of 8bit paletted images

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ImageHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ImageHandler.cs
@@ -72,7 +72,7 @@ namespace Xwt.WPFBackend
 			byte[] pixelData = new byte[stride * height];
 			bitmapImage.CopyPixels (pixelData, stride, 0);
 
-			return BitmapSource.Create (width, height, dpi, dpi, bitmapImage.Format, null, pixelData, stride);
+			return BitmapSource.Create (width, height, dpi, dpi, bitmapImage.Format, bitmapImage.Palette, pixelData, stride);
 		}
 
 		public override object CreateCustomDrawn (ImageDrawCallback drawCallback)


### PR DESCRIPTION
WPF requires a palette to be set when loading paletted images. We need
to maintain the BitmapSource palette in ConvertBitmapTo96DPI().

Edit: without this change, calling `Image.FromFile()` on 8bit / paletted bitmaps fails with an InvalidOperationException at [ImageHandler.cs:75](https://github.com/thefiddler/xwt/blob/master/Xwt.WPF/Xwt.WPFBackend/ImageHandler.cs#L75). With this change, both paletted and color bitmaps work as expected.
