### PR TITLE
[Mac] Fix Slider control orientation

### DIFF
--- a/Xwt.Mac/Xwt.Mac/SliderBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/SliderBackend.cs
@@ -40,7 +40,7 @@ namespace Xwt.Mac
 		{
 			ViewObject = new MacSlider ();
 			//((NSSliderCell)Widget.Cell).SetValueForKey (NSObject.FromObject (false), (NSString)"NSVertical");
-			if (dir == Orientation.Vertical)
+			if (dir == Orientation.Horizontal)
 				Widget.SetFrameSize (new System.Drawing.SizeF (10, 5));
 			else
 				Widget.SetFrameSize (new System.Drawing.SizeF (5, 10));


### PR DESCRIPTION
The initial width of the widget is bigger than the height, so the orientation is horizontal.
