### PR TITLE
[WPF] fix canvas mouse events

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
@@ -73,6 +73,11 @@ namespace Xwt.WPFBackend
 
 		public WidgetBackend Backend { get; set; }
 
+		public CustomPanel()
+		{
+			Background = System.Windows.Media.Brushes.Transparent;
+		}
+
 		public Action<System.Windows.Media.DrawingContext> RenderAction;
 
 		protected override void OnRender (System.Windows.Media.DrawingContext dc)


### PR DESCRIPTION
Initialize the background of the underlying Panel with a transparent background.
A Panel does not receive mouse events, if no background is set.

(see MSDN remarks: http://msdn.microsoft.com/en-us/library/system.windows.controls.panel(v=vs.110).aspx)