### PR TITLE
[GTK] Notebook tabs scrollable

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/NotebookBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/NotebookBackend.cs
@@ -35,6 +35,7 @@ namespace Xwt.GtkBackend
 		public NotebookBackend ()
 		{
 			Widget = new Gtk.Notebook ();
+			Widget.Scrollable = true;
 			Widget.Show ();
 		}
 		


### PR DESCRIPTION
When there are too many tabs to fit the Notebook, scroll arrows are added.