### PR TITLE
Refine DatePicker API and impement DatePickerStyle support [Gtk][Mac]

### DIFF
--- a/TestApps/Samples/Samples/DatePickerSample.cs
+++ b/TestApps/Samples/Samples/DatePickerSample.cs
@@ -32,13 +32,31 @@ namespace Samples
 	{
 		public DatePickerSample ()
 		{
-			var dp = new DatePicker ();
+			var dtp = new DatePicker (DateTime.Now);
+			PackStart (dtp);
+
+			Label la1 = new Label ("Initial Value: " + dtp.DateTime);
+			PackStart (la1);
+			dtp.ValueChanged += delegate {
+				la1.Text = "Value changed: " + dtp.DateTime;
+			};
+
+			var dp = new DatePicker (DatePickerStyle.Date);
 			PackStart (dp);
 
-			Label la = new Label ();
-			PackStart (la);
+			Label la2 = new Label ("Initial Value: " + dp.DateTime);
+			PackStart (la2);
 			dp.ValueChanged += delegate {
-				la.Text = "Value changed: " + dp.DateTime;
+				la2.Text = "Value changed: " + dp.DateTime;
+			};
+
+			var tp = new DatePicker (DatePickerStyle.Time, DateTime.MinValue);
+			PackStart (tp);
+
+			Label la3 = new Label ("Initial Value: " + tp.DateTime);
+			PackStart (la3);
+			tp.ValueChanged += delegate {
+				la3.Text = "Value changed: " + tp.DateTime;
 			};
 		}
 	}

--- a/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
@@ -60,21 +60,21 @@ namespace Xwt.GtkBackend
 			}
 		}
 
-		public DateTime MinDateTime {
+		public DateTime MinimumDateTime {
 			get {
-				return Widget.MinDateTime;
+				return Widget.MinimumDateTime;
 			}
 			set {
-				Widget.MinDateTime = value;
+				Widget.MinimumDateTime = value;
 			}
 		}
 
-		public DateTime MaxDateTime {
+		public DateTime MaximumDateTime {
 			get {
-				return Widget.MaxDateTime;
+				return Widget.MaximumDateTime;
 			}
 			set {
-				Widget.MaxDateTime = value;
+				Widget.MaximumDateTime = value;
 			}
 		}
 
@@ -148,7 +148,7 @@ namespace Xwt.GtkBackend
 				}
 			}
 
-			public DateTime MinDateTime {
+			public DateTime MinimumDateTime {
 				get {
 					return new DateTime ((long)Adjustment.Lower);
 				}
@@ -159,7 +159,7 @@ namespace Xwt.GtkBackend
 				}
 			}
 
-			public DateTime MaxDateTime {
+			public DateTime MaximumDateTime {
 				get {
 					return new DateTime ((long)Adjustment.Upper);
 				}

--- a/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
@@ -60,6 +60,24 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		public DateTime MinDateTime {
+			get {
+				return Widget.MinDateTime;
+			}
+			set {
+				Widget.MinDateTime = value;
+			}
+		}
+
+		public DateTime MaxDateTime {
+			get {
+				return Widget.MaxDateTime;
+			}
+			set {
+				Widget.MaxDateTime = value;
+			}
+		}
+
 		public DatePickerStyle Style {
 			get {
 				return Widget.Style;
@@ -127,6 +145,28 @@ namespace Xwt.GtkBackend
 					currentValue = value;
 					Adjustment.Value = value.Ticks;
 					RaiseChangedEvent ();
+				}
+			}
+
+			public DateTime MinDateTime {
+				get {
+					return new DateTime ((long)Adjustment.Lower);
+				}
+				set {
+					Adjustment.Lower = value.Ticks;
+					if (DateTime < value)
+						DateTime = value;
+				}
+			}
+
+			public DateTime MaxDateTime {
+				get {
+					return new DateTime ((long)Adjustment.Upper);
+				}
+				set {
+					Adjustment.Upper = value.Ticks;
+					if (DateTime > value)
+						DateTime = value;
 				}
 			}
 

--- a/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
@@ -3,6 +3,7 @@
 //
 // Author:
 //       Jérémie Laval <jeremie.laval@xamarin.com>
+//       Vsevolod Kukol <sevo@sevo.org>
 //
 // Copyright (c) 2012 Xamarin, Inc.
 //
@@ -25,8 +26,9 @@
 // THE SOFTWARE.
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using Xwt.Backends;
 
 
@@ -51,10 +53,19 @@ namespace Xwt.GtkBackend
 		
 		public DateTime DateTime {
 			get {
-				return Widget.CurrentValue;
+				return Widget.DateTime;
 			}
 			set {
-				Widget.CurrentValue = value;
+				Widget.DateTime = value;
+			}
+		}
+
+		public DatePickerStyle Style {
+			get {
+				return Widget.Style;
+			}
+			set {
+				Widget.Style = value;
 			}
 		}
 		
@@ -85,253 +96,348 @@ namespace Xwt.GtkBackend
 		
 		public class GtkDatePickerEntry : Gtk.SpinButton
 		{
-			enum Component {
-				None = 0,
-				Month,
-				Day,
-				Year,
-				Hour,
-				Minute,
-				Second
-			}
+			Dictionary<DatePickerStyle, string> styleFormats = new Dictionary<DatePickerStyle, string>();
+			Dictionary<DateTimeComponent, int> componentPosition = new Dictionary<DateTimeComponent, int>();
+			Dictionary<DateTimeComponent, int> componentLength = new Dictionary<DateTimeComponent, int>();
+			List<DateTimeComponent> componentsSorted = new List<DateTimeComponent>();
+			string dateSeparator = CultureInfo.CurrentCulture.DateTimeFormat.DateSeparator;
+			string timeSeparator = CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator;
 			
 			public new EventHandler ValueChanged;
-	
-			// We use the format of the invariant culture which is american biased apparently
-			const string DateTimeFormat = "MM/dd/yyyy HH:mm:ss";
-			Component selectedComponent;
-			double oldValue = -1;
-			int internalChangeCntd;
-	
-			int startPos = -1, endPos = -1;
-			int currentDigitInsert;
-	
-			public GtkDatePickerEntry () : base (DateTime.MinValue.Ticks,
-			                                     DateTime.MaxValue.Ticks,
-			                                     TimeSpan.TicksPerSecond)
+
+			DateTimeComponent selectedComponent = DateTimeComponent.None;
+
+			GtkClipboardBackend clipboard = new GtkClipboardBackend();
+
+			DateTime currentValue = DateTime.MinValue;
+
+			public DateTime DateTime {
+				get {
+					return currentValue;
+				}
+				set {
+					currentValue = value;
+					Adjustment.Value = value.Ticks;
+					RaiseChangedEvent ();
+				}
+			}
+
+			DatePickerStyle style;
+			public DatePickerStyle Style {
+				get {
+					return style;
+				}
+				set {
+					style = value;
+
+					string format = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern +
+						" " + "HH" + timeSeparator + "mm" + timeSeparator + "ss";
+
+					if (styleFormats.ContainsKey (value))
+						format = styleFormats [value];
+
+					componentPosition.Clear ();
+					componentLength.Clear ();
+
+					if (value == DatePickerStyle.DateTime ||
+					    value == DatePickerStyle.Date) {
+						componentPosition.Add (DateTimeComponent.Day, format.IndexOf ('d'));
+						componentPosition.Add (DateTimeComponent.Month, format.IndexOf ('M'));
+						componentPosition.Add (DateTimeComponent.Year, format.IndexOf ('y'));
+						componentLength.Add (DateTimeComponent.Day, 2);
+						componentLength.Add (DateTimeComponent.Month, 2);
+						componentLength.Add (DateTimeComponent.Year, 4);
+					}
+					if (value == DatePickerStyle.DateTime ||
+					    value == DatePickerStyle.Time) {
+						componentPosition.Add (DateTimeComponent.Hour, format.IndexOfAny (new char[] { 'H', 'h' }));
+						componentPosition.Add (DateTimeComponent.Minute, format.IndexOf ('m'));
+						componentPosition.Add (DateTimeComponent.Second, format.IndexOf ('s'));
+						componentLength.Add (DateTimeComponent.Hour, 2);
+						componentLength.Add (DateTimeComponent.Minute, 2);
+						componentLength.Add (DateTimeComponent.Second, 2);
+					}
+
+					componentsSorted = componentPosition.OrderBy (k => k.Value).Select (k => k.Key).ToList ();
+
+					WidthChars = format.Length;
+				}
+			}
+
+			public GtkDatePickerEntry () : this (DatePickerStyle.DateTime)
 			{
-				Adjustment.PageIncrement = TimeSpan.TicksPerDay;
-				IsEditable = true;
-				HasFrame = false;
-				CurrentValue = DateTime.MinValue;
-				Adjustment.ValueChanged += HandleValueChanged;
 			}
 	
-			// Hack to supply the right tick value
+			public GtkDatePickerEntry (DatePickerStyle style) : base (DateTime.MinValue.Ticks,
+			                                                          DateTime.MaxValue.Ticks,
+			                                                          TimeSpan.TicksPerSecond)
+			{
+				styleFormats[DatePickerStyle.Date] = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
+				styleFormats[DatePickerStyle.Time] = "HH" + timeSeparator + "mm" + timeSeparator + "ss";
+				styleFormats[DatePickerStyle.DateTime] = styleFormats[DatePickerStyle.Date] + " " + styleFormats[DatePickerStyle.Time];
+
+				Style = style;
+
+				Adjustment.PageIncrement = TimeSpan.TicksPerDay;
+				IsEditable = true;
+				HasFrame = true;
+				DateTime = DateTime.Now;
+				Adjustment.ValueChanged += HandleValueChanged;
+			}
+
 			void HandleValueChanged (object sender, EventArgs e)
 			{
-				// Prevent reentrant call
-				if (internalChangeCntd > 0) {
-					internalChangeCntd--;
+				if (Math.Abs (Adjustment.Value - currentValue.Ticks) < 1)
 					return;
-				}
-				double currentValue = oldValue;
 
-				var adjustedValue = Adjustment.Value;
-				if (adjustedValue > currentValue)
-					GoUp (ref currentValue);
-				else if (adjustedValue < currentValue)
-					GoDown (ref currentValue);
-				
-				internalChangeCntd++;
-				Adjustment.Value = currentValue;
-				RaiseChangedEvent ();
-	
-				oldValue = Adjustment.Value;
+				if (selectedComponent == DateTimeComponent.None)
+					SelectComponent (componentsSorted.Last ());
+
+				if (Adjustment.Value > currentValue.Ticks)
+					DateTime = currentValue.AddComponent (selectedComponent, 1);
+				else if (Adjustment.Value < currentValue.Ticks)
+					DateTime = currentValue.AddComponent (selectedComponent, -1);
 			}
 			
 			protected override int OnOutput ()
 			{
-				DateTime dateTime = CurrentValue;
-				Text = dateTime.ToString (DateTimeFormat);
-				
+				DateTime dateTime = new DateTime ((long)Adjustment.Value);
+				if (styleFormats.ContainsKey (Style))
+					Text = dateTime.ToString (styleFormats [Style]);
+				else
+					Text = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern
+					+ " " + "HH" + timeSeparator + "mm" + timeSeparator + "ss";
 				return 1;
 			}
 			
-			protected override int OnInput (out double newValue)
+			protected override int OnInput (out double new_value)
 			{
-				newValue = Adjustment.Value;
+				new_value = Adjustment.Value;
 				return 1;
 			}
-	
-			void GoDown (ref double newValue)
+
+			protected override void OnFocusGrabbed ()
 			{
-				switch (selectedComponent) {
-				case Component.Second:
-					newValue -= TimeSpan.TicksPerSecond;
-					break;
-				case Component.Minute:
-					newValue -= TimeSpan.TicksPerMinute;
-					break;
-				case Component.Hour:
-					newValue -= TimeSpan.TicksPerHour;
-					break;
-				case Component.Day:
-					newValue = CurrentValue.AddDays (-1).Ticks;
-					break;
-				case Component.Month:
-					newValue = CurrentValue.AddMonths (-1).Ticks;
-					break;
-				case Component.Year:
-					newValue = CurrentValue.AddYears (-1).Ticks;
-					break;
+				base.OnFocusGrabbed ();
+				// Override default GTK behavior which is to select the whole entry
+				SelectComponent (selectedComponent);
+			}
+
+			protected override bool OnFocusOutEvent (Gdk.EventFocus evnt)
+			{
+				SelectComponent (DateTimeComponent.None);
+				return base.OnFocusOutEvent (evnt);
+			}
+
+			protected override void OnChanged ()
+			{
+				base.OnChanged ();
+				SelectComponent (selectedComponent);
+			}
+
+			protected override void OnClipboardPasted ()
+			{
+				if (clipboard.IsTypeAvailable(TransferDataType.Text)) {
+					var newText = clipboard.GetData(TransferDataType.Text) as string;
+					DateTime newDateTime;
+					if (DateTime.TryParse (newText, out newDateTime))
+						DateTime = newDateTime;
+					else  if (componentLength.ContainsKey (selectedComponent) 
+					          && componentLength[selectedComponent] == newText.Length) {
+
+						try {
+							var value = int.Parse (newText);
+							DateTime = DateTime.SetComponent (selectedComponent, value);
+						} catch {
+							return;
+						}
+					}
 				}
 			}
-	
-			void GoUp (ref double newValue)
-			{
-				switch (selectedComponent) {
-				case Component.Second:
-					newValue += TimeSpan.TicksPerSecond;
-					break;
-				case Component.Minute:
-					newValue += TimeSpan.TicksPerMinute;
-					break;
-				case Component.Hour:
-					newValue += TimeSpan.TicksPerHour;
-					break;
-				case Component.Day:
-					newValue = CurrentValue.AddDays (1).Ticks;
-					break;
-				case Component.Month:
-					newValue = CurrentValue.AddMonths (1).Ticks;
-					break;
-				case Component.Year:
-					newValue = CurrentValue.AddYears (1).Ticks;
-					break;
+
+			Gdk.Window entryWindow;
+			Gdk.Window EntryWindow {
+				get {
+					if (entryWindow == null) {
+						#if XWT_GTK3
+						// Problem: base.GdkWindow is the parent window and this widgets windows
+						// (3: entry + two spin buttons) are children of the parent, which may hold
+						// other windows of its children (e.g. container).
+						// 
+						// Workaround: find child windows inside own allocation and select the first
+						// window from the left, which is the window holding the text entry of the
+						// spin button.
+						entryWindow = GdkWindow.Children
+							// get child window geometry
+							.Select(childw => {
+									int x, y, w, h;
+									childw.GetGeometry (out x, out y, out w, out h);
+									return new KeyValuePair<Gdk.Window, Gdk.Rectangle> (childw, new Gdk.Rectangle (x, y, w, h));
+								})
+							// select windows inside own allocation
+							.Where(k => Allocation.Contains (k.Value))
+							// order by X location from the left
+							.OrderBy (k => k.Value.X)
+							// select first window or null if failed
+							.FirstOrDefault ().Key;
+						#else
+						// Hacky. Since it's the entry that maintains the text GdkWindow it's normally
+						// the last child of the widget's GdkWindow because the other children are created
+						// by the spin button
+						entryWindow = GdkWindow.Children.LastOrDefault ();
+						#endif
+					}
+					return entryWindow;
 				}
 			}
 			
 			protected override bool OnButtonPressEvent (Gdk.EventButton evnt)
 			{
-				int posX = (int)evnt.X, posY = (int)evnt.Y;
-				//GetPointer (out posX, out posY);
+				// handle left click only
+				if (evnt.Button != 1)
+					return base.OnButtonPressEvent (evnt);
+
+				// a spin button has 3 windows (entry + 2 buttons), handle this event only for the window
+				// containing the text entry widget
+				if (evnt.Window != EntryWindow)
+					return base.OnButtonPressEvent (evnt);
+
 				int layoutX, layoutY;
 				GetLayoutOffsets (out layoutX, out layoutY);
 				int index, trailing;
-				
-				bool result = Layout.XyToIndex (Pango.Units.FromPixels (posX - layoutX),
-				                                Pango.Units.FromPixels (posY - layoutY),
-				                                out index,
-				                                out trailing);
-	
-				// Hacky. Since it's entry that maintain the text GdkWindow it's normally always
-				// the last children of the widget GdkWindow because the other children are created
-				// by the spin button
-				if (evnt.Window == GdkWindow.Children.Last () && result) {
-					index = TextIndexToLayoutIndex (index);
-					UpdateSelectedComponent (index);
-					currentDigitInsert = 0;
+				bool insideLayout = Layout.XyToIndex (Pango.Units.FromPixels ((int)evnt.X),
+				                                      Pango.Units.FromPixels ((int)evnt.Y),
+				                                      out index,
+				                                      out trailing);
+
+				if (insideLayout) {
+					SelectComponentAtPosition (TextIndexToLayoutIndex (index));
 					GrabFocus ();
 					return false;
-				} else {
-					return base.OnButtonPressEvent (evnt);
 				}
+				SelectComponent (DateTimeComponent.None);
+				return base.OnButtonPressEvent (evnt);
 			}
-	
-			// Override default GTK behavior which is to select the whole entry
-			protected override void OnFocusGrabbed ()
-			{
-				base.OnFocusGrabbed ();
-				SelectRegion (startPos, endPos);
-			}
-	
-			void UpdateSelectedComponent (int index)
-			{
-				int componentSelected = -1;
-				string txt = Text;
-				List<int> stops = Enumerable.Range (0, txt.Length)
-					.Where (i => char.IsPunctuation (txt, i) || char.IsSeparator (txt, i))
-					.ToList ();
-				stops.Insert (0, -1);
-				stops.Add (txt.Length);
-				
-				for (int i = 0; i < stops.Count - 1 && stops[i] <= index; i++) {
-					componentSelected = i;
-					startPos = stops[i] + 1;
-					endPos = stops[i + 1];
-				}
-				selectedComponent = (Component)componentSelected + 1;
-			}
-			
-			protected override void OnChanged ()
-			{
-				base.OnChanged ();
-				if (startPos == -1 || endPos == -1)
-					SelectRegion (0, 0);
-				else
-					SelectRegion (startPos, endPos);
-			}
-	
+
+			int currentDigitInsert;
 			protected override bool OnKeyReleaseEvent (Gdk.EventKey evnt)
 			{
 				char pressedKey = (char)Gdk.Keyval.ToUnicode (evnt.KeyValue);
-				if (char.IsDigit (pressedKey) && selectedComponent != Component.None && pressedKey > '0') {
+
+				if (char.IsWhiteSpace(pressedKey) || char.IsPunctuation (pressedKey) || char.IsSeparator (pressedKey)) {
+					if (pressedKey != '\t') // exclude tab
+						SelectNextComponent ();
+				}
+
+				if (char.IsDigit (pressedKey) && selectedComponent != DateTimeComponent.None && pressedKey >= '0') {
 					try {
-						int value = (int)pressedKey - (int)'0';
-						DateTime current = CurrentValue;
-						switch (selectedComponent) {
-						case Component.Month:
-							current = FromCopy (current, month: ValueFromDigitInsert (current.Month, value));
-							break;
-						case Component.Day:
-							current = FromCopy (current, day: ValueFromDigitInsert (current.Day, value));
-							break;
-						case Component.Year:
-							current = FromCopy (current, year: ValueFromDigitInsert (current.Year, value));
-							break;
-						case Component.Hour:
-							current = FromCopy (current, hour: ValueFromDigitInsert (current.Hour, value));
-							break;
-						case Component.Minute:
-							current = FromCopy (current, minute: ValueFromDigitInsert (current.Minute, value));
-							break;
-						case Component.Second:
-							current = FromCopy (current, second: ValueFromDigitInsert (current.Second, value));
-							break;
-						}
-						currentDigitInsert++;
-						CurrentValue = current;
+						DateTime current = DateTime;
+						current = current.SetComponent (selectedComponent, AddDigitToValue (current.GetComponent (selectedComponent), pressedKey));
+						if (currentDigitInsert < componentLength[selectedComponent] - 1)
+							currentDigitInsert++;
+						else
+							currentDigitInsert = 0;
+
+						DateTime = current;
 					} catch (ArgumentOutOfRangeException) {
-						// In case date wasn't representable we redo the call with an updated digit insert
-						currentDigitInsert = 0;
-						return OnKeyReleaseEvent (evnt);
+						if (pressedKey == '0')
+							return true;
+						if (currentDigitInsert != 0) {
+							// In case date wasn't representable we redo the call with an updated digit insert
+							currentDigitInsert = 0;
+							return OnKeyReleaseEvent (evnt);
+						}
+						return true;
 					}
 				}
 				return base.OnKeyReleaseEvent (evnt);
 			}
+
+			int AddDigitToValue (int baseValue, char newValue)
+			{
+				if (currentDigitInsert == 0 || currentDigitInsert > componentLength [selectedComponent])
+					return int.Parse (newValue.ToString ());
+				return int.Parse (baseValue.ToString () + newValue);
+			}
 	
 			protected override bool OnKeyPressEvent (Gdk.EventKey evnt)
 			{
+
+				if (evnt.Key == Gdk.Key.Left || evnt.Key == Gdk.Key.KP_Left) {
+					SelectPrevComponent ();
+					return true;
+				}
+
+				if (evnt.Key == Gdk.Key.Right || evnt.Key == Gdk.Key.KP_Right) {
+					SelectNextComponent ();
+					return true;
+				}
+
 				// We only allow the keypress to proceed to the normal handler
 				// if it doesn't involve adding an actual character
 				// (i.e. navigation keys)
 				uint value = Gdk.Keyval.ToUnicode (evnt.KeyValue);
-				if (value == 0)
+				var xwtModifiers = evnt.State.ToXwtValue ();
+				if (value == 0 || value == '\t' || xwtModifiers.HasFlag(ModifierKeys.Control) || xwtModifiers.HasFlag (ModifierKeys.Alt))
 					return base.OnKeyPressEvent (evnt);
+				return true;
+			}
+
+			void SelectComponentAtPosition (int characterIndex)
+			{
+				foreach (var entry in componentPosition) {
+					if (characterIndex >= entry.Value  && characterIndex <= entry.Value + componentLength [entry.Key]) {
+						SelectComponent (entry.Key);
+						return;
+					}
+				}
+				SelectComponent (DateTimeComponent.None);
+			}
+
+			void SelectComponent (DateTimeComponent component)
+			{
+				int startPos, endPos;
+				if (componentPosition.ContainsKey (component) && componentLength.ContainsKey (component)) {
+					startPos = componentPosition[component];
+					endPos = startPos + componentLength[component];
+				} else {
+					startPos = CursorPosition;
+					endPos = CursorPosition;
+				}
+				SelectRegion (startPos, endPos);
+
+				if (selectedComponent != component) {
+					selectedComponent = component;
+					currentDigitInsert = 0;
+				}
+			}
+
+			void SelectNextComponent ()
+			{
+				if (selectedComponent == DateTimeComponent.None ||
+				        componentsSorted.IndexOf (selectedComponent) == componentsSorted.Count - 1)
+					selectedComponent = componentsSorted [0];
 				else
-					return true;
+					selectedComponent = componentsSorted [componentsSorted.IndexOf (selectedComponent) + 1];
+
+				int startPos = componentPosition[selectedComponent];
+				int endPos = startPos + componentLength[selectedComponent];
+				SelectRegion (startPos, endPos);
+				currentDigitInsert = 0;
 			}
-	
-			int ValueFromDigitInsert (int baseValue, int newValue)
+
+			void SelectPrevComponent ()
 			{
-				return currentDigitInsert == 0 ? newValue : newValue + baseValue * 10;
-			}
-	
-			DateTime FromCopy (DateTime source,
-			                   int year = -1,
-			                   int month = -1,
-			                   int day = -1,
-			                   int hour = -1,
-			                   int minute = -1,
-			                   int second = -1)
-			{
-				return new DateTime (year == -1 ? source.Year : year,
-				                     month == -1 ? source.Month : month,
-				                     day == -1 ? source.Day : day,
-				                     hour == -1 ? source.Hour : hour,
-				                     minute == -1 ? source.Minute : minute,
-				                     second == -1 ? source.Second : second);
+				if (selectedComponent == DateTimeComponent.None ||
+				        componentsSorted.IndexOf (selectedComponent) == 0)
+					selectedComponent = componentsSorted [componentsSorted.Count - 1];
+				else
+					selectedComponent = componentsSorted [componentsSorted.IndexOf (selectedComponent) - 1];
+
+				int startPos = componentPosition[selectedComponent];
+				int endPos = startPos + componentLength[selectedComponent];
+				SelectRegion (startPos, endPos);
+				currentDigitInsert = 0;
 			}
 			
 			void RaiseChangedEvent ()
@@ -340,18 +446,98 @@ namespace Xwt.GtkBackend
 				if (tmp != null)
 					tmp (this, EventArgs.Empty);
 			}
-			
+
+			[Obsolete("Use DateTime property instead.")]
 			public DateTime CurrentValue {
 				get {
-					return new DateTime ((long)Adjustment.Value);
+					return DateTime;
 				}
 				set {
-					// Inhibit our custom handler for specific set
-					internalChangeCntd++;
-					Adjustment.Value = value.Ticks;
-					oldValue = value.Ticks;
-					RaiseChangedEvent ();
+					DateTime = value;
 				}
+			}
+		}
+	}
+
+	enum DateTimeComponent {
+		None = 0,
+		Month,
+		Day,
+		Year,
+		Hour,
+		Minute,
+		Second
+	}
+
+	static class DateTimeExtensions
+	{
+		public static DateTime AddComponent(this DateTime dateTime, DateTimeComponent component, int value)
+		{
+			try {
+				switch (component) {
+					case DateTimeComponent.Second:
+						return dateTime.AddSeconds (value);
+					case DateTimeComponent.Minute:
+						return dateTime.AddMinutes (value);
+					case DateTimeComponent.Hour:
+						return dateTime.AddHours (value);
+					case DateTimeComponent.Day:
+						return dateTime.AddDays (value);
+					case DateTimeComponent.Month:
+						return dateTime.AddMonths (value);
+					case DateTimeComponent.Year:
+						return dateTime.AddYears (value);
+					default:
+						return dateTime.AddSeconds (value);
+				}
+			} catch (ArgumentOutOfRangeException) {
+				return dateTime;
+			}
+		}
+
+		public static int GetComponent(this DateTime dateTime, DateTimeComponent component)
+		{
+			switch (component) {
+				case DateTimeComponent.Second:
+					return dateTime.Second;
+				case DateTimeComponent.Minute:
+					return dateTime.Minute;
+				case DateTimeComponent.Hour:
+					return dateTime.Hour;
+				case DateTimeComponent.Day:
+					return dateTime.Day;
+				case DateTimeComponent.Month:
+					return dateTime.Month;
+				case DateTimeComponent.Year:
+					return dateTime.Year;
+				default:
+					return 0;
+			}
+		}
+
+		public static DateTime SetComponent (this DateTime source, DateTimeComponent component, int newValue)
+		{
+			int year = source.Year;
+			int month = source.Month;
+			int day = source.Day;
+			int hour = source.Hour;
+			int minute = source.Minute;
+			int second = source.Second;
+			switch (component) {
+				case DateTimeComponent.Year:
+					return new DateTime (newValue, month, day, hour, minute, second);
+				case DateTimeComponent.Month:
+					return new DateTime (year, newValue, day, hour, minute, second);
+				case DateTimeComponent.Day:
+					return new DateTime (year, month, newValue, hour, minute, second);
+				case DateTimeComponent.Hour:
+					return new DateTime (year, month, day, newValue, minute, second);
+				case DateTimeComponent.Minute:
+					return new DateTime (year, month, day, hour, newValue, second);
+				case DateTimeComponent.Second:
+					return new DateTime (year, month, day, hour, minute, newValue);
+				default:
+					return source;
 			}
 		}
 	}

--- a/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
@@ -114,15 +114,15 @@ namespace Xwt.GtkBackend
 		
 		public class GtkDatePickerEntry : Gtk.SpinButton
 		{
-			static Dictionary<DatePickerStyle, string> styleFormats = new Dictionary<DatePickerStyle, string>();
+			static string[] styleFormats = new string[3];
 
 			static GtkDatePickerEntry ()
 			{
-				styleFormats[DatePickerStyle.Date] = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
+				styleFormats[(int)DatePickerStyle.Date] = CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern;
 				// we use a custom static long time pattern, since we do not support 12/24 formats
 				string timeSeparator = CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator;
-				styleFormats[DatePickerStyle.Time] = "HH" + timeSeparator + "mm" + timeSeparator + "ss";
-				styleFormats[DatePickerStyle.DateTime] = styleFormats[DatePickerStyle.Date] + " " + styleFormats[DatePickerStyle.Time];
+				styleFormats[(int)DatePickerStyle.Time] = "HH" + timeSeparator + "mm" + timeSeparator + "ss";
+				styleFormats[(int)DatePickerStyle.DateTime] = styleFormats[(int)DatePickerStyle.Date] + " " + styleFormats[(int)DatePickerStyle.Time];
 			}
 
 			Dictionary<DateTimeComponent, int> componentPosition = new Dictionary<DateTimeComponent, int>();
@@ -177,8 +177,7 @@ namespace Xwt.GtkBackend
 				}
 				set {
 					style = value;
-					string format = String.Empty;
-					styleFormats.TryGetValue (value, out format);
+					string format = styleFormats [(int)value];
 
 					componentPosition.Clear ();
 					componentLength.Clear ();
@@ -242,8 +241,7 @@ namespace Xwt.GtkBackend
 			protected override int OnOutput ()
 			{
 				DateTime dateTime = new DateTime ((long)Adjustment.Value);
-				string format = String.Empty;
-				styleFormats.TryGetValue (Style, out format);
+				string format = styleFormats [(int)Style];
 
 				Text = dateTime.ToString (format);
 				return 1;

--- a/Xwt.WPF/Xwt.WPFBackend/DatePickerBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DatePickerBackend.cs
@@ -49,6 +49,8 @@ namespace Xwt.WPFBackend
 		{
 			get { return (IDatePickerEventSink)base.EventSink; }
 		}
+
+		public DatePickerStyle Style { get; set; }
 		
 		public DateTime DateTime
 		{

--- a/Xwt.WPF/Xwt.WPFBackend/DatePickerBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DatePickerBackend.cs
@@ -64,7 +64,7 @@ namespace Xwt.WPFBackend
 			}
 		}
 
-		public DateTime MinDateTime {
+		public DateTime MinimumDateTime {
 			get {
 				return DatePicker.DisplayDateStart ?? DateTime.MinValue;
 			}
@@ -75,7 +75,7 @@ namespace Xwt.WPFBackend
 			}
 		}
 
-		public DateTime MaxDateTime {
+		public DateTime MaximumDateTime {
 			get {
 				return DatePicker.DisplayDateEnd ?? DateTime.MaxValue;
 			}

--- a/Xwt.WPF/Xwt.WPFBackend/DatePickerBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DatePickerBackend.cs
@@ -64,6 +64,28 @@ namespace Xwt.WPFBackend
 			}
 		}
 
+		public DateTime MinDateTime {
+			get {
+				return DatePicker.DisplayDateStart ?? DateTime.MinValue;
+			}
+			set {
+				DatePicker.DisplayDateStart = value;
+				if (DateTime < value)
+					DateTime = value;
+			}
+		}
+
+		public DateTime MaxDateTime {
+			get {
+				return DatePicker.DisplayDateEnd ?? DateTime.MaxValue;
+			}
+			set {
+				DatePicker.DisplayDateEnd = value;
+				if (DateTime > value)
+					DateTime = value;
+			}
+		}
+
 		public override void EnableEvent(object eventId)
 		{
 			base.EnableEvent(eventId);

--- a/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
@@ -96,7 +96,7 @@ namespace Xwt.Mac
 			}
 		}
 
-		public DateTime MinDateTime {
+		public DateTime MinimumDateTime {
 			get {
 				if (userMinDateKind == DateTimeKind.Utc)
 					return ((DateTime)Widget.MinDate).ToUniversalTime ();
@@ -108,7 +108,7 @@ namespace Xwt.Mac
 			}
 		}
 
-		public DateTime MaxDateTime {
+		public DateTime MaximumDateTime {
 			get {
 				if (userMaxDateKind == DateTimeKind.Utc)
 					return ((DateTime)Widget.MaxDate).ToUniversalTime ();

--- a/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
@@ -96,7 +96,7 @@ namespace Xwt.Mac
 					Widget.TimeZone = NSTimeZone.FromName("UTC");
 				}
 
-				Widget.DateValue = value.ToUniversalTime();
+				Widget.DateValue = (NSDate)value.ToUniversalTime ();
 			}
 		}
 
@@ -108,7 +108,7 @@ namespace Xwt.Mac
 					return ((DateTime)Widget.MinDate).ToLocalTime();
 			}
 			set {
-				Widget.MinDate = value.ToUniversalTime();
+				Widget.MinDate = (NSDate)value.ToUniversalTime ();
 			}
 		}
 
@@ -120,7 +120,7 @@ namespace Xwt.Mac
 					return ((DateTime)Widget.MaxDate).ToLocalTime();
 			}
 			set {
-				Widget.MaxDate = value.ToUniversalTime();
+				Widget.MaxDate = (NSDate)value.ToUniversalTime ();
 			}
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
@@ -48,6 +48,9 @@ namespace Xwt.Mac
 		{
 			base.Initialize ();
 			ViewObject = new MacDatePicker ();
+			Widget.DatePickerMode = NSDatePickerMode.Single;
+			Widget.DatePickerStyle = NSDatePickerStyle.TextFieldAndStepper;
+			Widget.DatePickerElements = DatePickerStyle.DateTime.ToMacValue();
 		}
 
 		public override void EnableEvent (object eventId)
@@ -81,8 +84,12 @@ namespace Xwt.Mac
 		}
 
 		public DatePickerStyle Style {
-			get;
-			set;
+			get {
+				return Widget.DatePickerElements.ToXwtValue();
+			}
+			set {
+				Widget.DatePickerElements = value.ToMacValue ();
+			}
 		}
 
 		#endregion

--- a/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
@@ -100,6 +100,30 @@ namespace Xwt.Mac
 			}
 		}
 
+		public DateTime MinDateTime {
+			get {
+				if (userTimeIsUTC)
+					return ((DateTime)Widget.MinDate).ToUniversalTime();
+				else
+					return ((DateTime)Widget.MinDate).ToLocalTime();
+			}
+			set {
+				Widget.MinDate = value.ToUniversalTime();
+			}
+		}
+
+		public DateTime MaxDateTime {
+			get {
+				if (userTimeIsUTC)
+					return ((DateTime)Widget.MaxDate).ToUniversalTime();
+				else
+					return ((DateTime)Widget.MaxDate).ToLocalTime();
+			}
+			set {
+				Widget.MaxDate = value.ToUniversalTime();
+			}
+		}
+
 		public DatePickerStyle Style {
 			get {
 				return Widget.DatePickerElements.ToXwtValue();

--- a/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DatePickerBackend.cs
@@ -80,6 +80,11 @@ namespace Xwt.Mac
 			}
 		}
 
+		public DatePickerStyle Style {
+			get;
+			set;
+		}
+
 		#endregion
 	}
 

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -463,6 +463,32 @@ namespace Xwt.Mac
 			return GridLines.None;
 		}
 
+		public static NSDatePickerElementFlags ToMacValue (this DatePickerStyle style)
+		{
+			switch (style) {
+				case DatePickerStyle.Date:
+					return NSDatePickerElementFlags.YearMonthDateDay;
+				case DatePickerStyle.DateTime:
+					return NSDatePickerElementFlags.YearMonthDateDay | NSDatePickerElementFlags.HourMinuteSecond;
+				case DatePickerStyle.Time:
+					return NSDatePickerElementFlags.HourMinuteSecond;
+			}
+			return NSDatePickerElementFlags.YearMonthDate;
+		}
+
+		public static DatePickerStyle ToXwtValue (this NSDatePickerElementFlags flags)
+		{
+			switch (flags) {
+				case NSDatePickerElementFlags.HourMinuteSecond:
+					return DatePickerStyle.Time;
+				case NSDatePickerElementFlags.YearMonthDate:
+				case NSDatePickerElementFlags.YearMonthDateDay:
+					return DatePickerStyle.Date;
+				default:
+					return DatePickerStyle.DateTime;
+			}
+		}
+
 		public static void DrawWithColorTransform (this NSView view, Color? color, Action drawDelegate)
 		{
 			if (color.HasValue) {

--- a/Xwt/Xwt.Backends/IDatePickerBackend.cs
+++ b/Xwt/Xwt.Backends/IDatePickerBackend.cs
@@ -31,8 +31,8 @@ namespace Xwt.Backends
 	public interface IDatePickerBackend : IWidgetBackend
 	{
 		DateTime DateTime { get; set; }
-		DateTime MinDateTime { get; set; }
-		DateTime MaxDateTime { get; set; }
+		DateTime MinimumDateTime { get; set; }
+		DateTime MaximumDateTime { get; set; }
 		DatePickerStyle Style { get; set; }
 	}
 

--- a/Xwt/Xwt.Backends/IDatePickerBackend.cs
+++ b/Xwt/Xwt.Backends/IDatePickerBackend.cs
@@ -31,6 +31,7 @@ namespace Xwt.Backends
 	public interface IDatePickerBackend : IWidgetBackend
 	{
 		DateTime DateTime { get; set; }
+		DatePickerStyle Style { get; set; }
 	}
 
 	public interface IDatePickerEventSink: IWidgetEventSink

--- a/Xwt/Xwt.Backends/IDatePickerBackend.cs
+++ b/Xwt/Xwt.Backends/IDatePickerBackend.cs
@@ -31,6 +31,8 @@ namespace Xwt.Backends
 	public interface IDatePickerBackend : IWidgetBackend
 	{
 		DateTime DateTime { get; set; }
+		DateTime MinDateTime { get; set; }
+		DateTime MaxDateTime { get; set; }
 		DatePickerStyle Style { get; set; }
 	}
 

--- a/Xwt/Xwt/DatePicker.cs
+++ b/Xwt/Xwt/DatePicker.cs
@@ -38,6 +38,30 @@ namespace Xwt
 	[BackendType (typeof(IDatePickerBackend))]
 	public class DatePicker : Widget
 	{
+		public DatePicker () : this (DatePickerStyle.DateTime, DateTime.Now)
+		{
+		}
+
+		public DatePicker (DateTime initialDateTime) : this (DatePickerStyle.DateTime, initialDateTime)
+		{
+		}
+
+		public DatePicker (DatePickerStyle style) : this (style, DateTime.Now)
+		{
+		}
+
+		public DatePicker (DatePickerStyle style, DateTime initialDateTime)
+		{
+			VerifyConstructorCall (this);
+			Style = style;
+			DateTime = initialDateTime;
+		}
+
+		static DatePicker ()
+		{
+			MapEvent (DatePickerEvent.ValueChanged, typeof (Label), "OnValueChanged");
+		}
+
 		protected new class WidgetBackendHost: Widget.WidgetBackendHost, IDatePickerEventSink
 		{
 			public void ValueChanged ()
@@ -65,8 +89,12 @@ namespace Xwt
 		}
 		
 		public DatePickerStyle Style {
-			get;
-			set;
+			get {
+				return Backend.Style;
+			}
+			set {
+				Backend.Style = value;
+			}
 		}
 		
 		protected virtual void OnValueChanged (EventArgs e)

--- a/Xwt/Xwt/DatePicker.cs
+++ b/Xwt/Xwt/DatePicker.cs
@@ -87,6 +87,24 @@ namespace Xwt
 				Backend.DateTime = value;
 			}
 		}
+
+		public DateTime MinDateTime {
+			get {
+				return Backend.MinDateTime;
+			}
+			set {
+				Backend.MinDateTime = value;
+			}
+		}
+
+		public DateTime MaxDateTime {
+			get {
+				return Backend.MaxDateTime;
+			}
+			set {
+				Backend.MaxDateTime = value;
+			}
+		}
 		
 		public DatePickerStyle Style {
 			get {

--- a/Xwt/Xwt/DatePicker.cs
+++ b/Xwt/Xwt/DatePicker.cs
@@ -88,21 +88,21 @@ namespace Xwt
 			}
 		}
 
-		public DateTime MinDateTime {
+		public DateTime MinimumDateTime {
 			get {
-				return Backend.MinDateTime;
+				return Backend.MinimumDateTime;
 			}
 			set {
-				Backend.MinDateTime = value;
+				Backend.MinimumDateTime = value;
 			}
 		}
 
-		public DateTime MaxDateTime {
+		public DateTime MaximumDateTime {
 			get {
-				return Backend.MaxDateTime;
+				return Backend.MaximumDateTime;
 			}
 			set {
-				Backend.MaxDateTime = value;
+				Backend.MaximumDateTime = value;
 			}
 		}
 		


### PR DESCRIPTION
This PR adds DatePickerStyle support to Gtk and Mac backends, and includes many fixes in the backend implementations.

* GTK:
  * fix component selection
  * fix (keep) seconds when other component chages
  * fix keyboard input (incl. arrow keys and separators)
  * fix mouse selection
  * add internationalization support
    * use localized separators
    * use localized component order
    * no 12/24 support
  * add DatePickerStyle support (show only relevant components)
  * add clipboard support
* MAC:
  * add DatePickerStyle support
  * fix DatePicker timezone conversion

For WPF we still need a useful DateTimePicker component. Maybe something external from NuGet?