### PR TITLE
[Gtk3] fix sizing for different SizeRequestModes

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -306,26 +306,6 @@ namespace Xwt.GtkBackend
 			y += a.Y;
 			return new Point (x + widgetCoordinates.X, y + widgetCoordinates.Y);
 		}
-
-		public void SetMinSize (double width, double height)
-		{
-			if (width != -1 || height != -1) {
-				EnableSizeCheckEvents ();
-				minSizeSet = true;
-				Widget.QueueResize ();
-			}
-			else {
-				minSizeSet = false;
-				DisableSizeCheckEvents ();
-				Widget.QueueResize ();
-			}
-		}
-		
-		public void SetSizeRequest (double width, double height)
-		{
-			Widget.WidthRequest = (int)width;
-			Widget.HeightRequest = (int)height;
-		}
 		
 		Pango.FontDescription customFont;
 		

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackendGtk2.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackendGtk2.cs
@@ -91,6 +91,26 @@ namespace Xwt.GtkBackend
 			args.Requisition = req;
 		}
 
+		public void SetMinSize (double width, double height)
+		{
+			if (width != -1 || height != -1) {
+				EnableSizeCheckEvents ();
+				minSizeSet = true;
+				Widget.QueueResize ();
+			}
+			else {
+				minSizeSet = false;
+				DisableSizeCheckEvents ();
+				Widget.QueueResize ();
+			}
+		}
+
+		public void SetSizeRequest (double width, double height)
+		{
+			Widget.WidthRequest = (int)width;
+			Widget.HeightRequest = (int)height;
+		}
+
 		double opacity = 1d;
 		public double Opacity {
 			get { return opacity; }


### PR DESCRIPTION
This PR fixes some Gtk3 sizing issues, especially for vertical widgets like Sliders with vertical orientation. Fixes additionally cases when widgets had a zero size initially or min sizes without effect.

 * request widget size based on Gtk.SizeRequestMode
 * always set Gtk size requests