### PR TITLE
[Mac] reload tree/list on data source changes

### DIFF
--- a/TestApps/Samples/Samples/ListView1.cs
+++ b/TestApps/Samples/Samples/ListView1.cs
@@ -52,6 +52,27 @@ namespace Samples
 				}
 			};
 
+			HBox btnBox = new HBox ();
+			Button btnAddItem = new Button ("Add item");
+			btnAddItem.Clicked += delegate {
+				var r = store.InsertRowAfter(list.SelectedRow < 0 ? 0 : list.SelectedRow);
+				store.SetValue (r, icon, png);
+				store.SetValue (r, name, "Value " + (store.RowCount + 1));
+				store.SetValue (r, icon2, png);
+				store.SetValue (r, text, "New Text " + (store.RowCount + 1));
+				store.SetValue (r, progress, new CellData { Value = rand.Next () % 100 });
+				list.ScrollToRow (r);
+				list.SelectRow (r);
+			};
+			btnBox.PackStart (btnAddItem, true);
+			Button btnRemoveItem = new Button ("Remove item");
+			btnRemoveItem.Clicked += delegate {
+				if (list.SelectedRow >= 0)
+					store.RemoveRow(list.SelectedRow);
+			};
+			btnBox.PackStart (btnRemoveItem, true);
+			PackStart (btnBox);
+
 			var but = new Button ("Scroll one line");
 			but.Clicked += delegate {
 				list.VerticalScrollControl.Value += list.VerticalScrollControl.StepIncrement;

--- a/TestApps/Samples/Samples/TreeViews.cs
+++ b/TestApps/Samples/Samples/TreeViews.cs
@@ -119,11 +119,19 @@ namespace Samples
 				var val = store.GetNavigatorAt (e.Position).GetValue (text);
 				Console.WriteLine("Collapsed: " + val);
 			};
-			
+
+			int addCounter = 0;
 			Button addButton = new Button ("Add");
 			addButton.Clicked += delegate(object sender, EventArgs e) {
-				var n = store.AddNode ().SetValue (text, "Added").SetValue (desc, "Desc");
+				addCounter++;
+				TreeNavigator n;
+				if (view.SelectedRow != null)
+					n = store.AddNode (view.SelectedRow).SetValue (text, "Added " + addCounter).SetValue (desc, "Desc");
+				else
+					n = store.AddNode ().SetValue (text, "Added " + addCounter).SetValue (desc, "Desc");
+				view.ExpandToRow (n.CurrentPosition);
 				view.ScrollToRow (n.CurrentPosition);
+				view.SelectRow (n.CurrentPosition);
 			};
 			PackStart (addButton);
 			

--- a/Xwt.Mac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/ListViewBackend.cs
@@ -89,6 +89,12 @@ namespace Xwt.Mac
 			this.source = source;
 			tsource = new ListSource (source);
 			Table.DataSource = tsource;
+
+			//TODO: reloading single rows would be more efficient
+			source.RowInserted += (sender, e) => Table.ReloadData();
+			source.RowDeleted += (sender, e) => Table.ReloadData();
+			source.RowChanged += (sender, e) => Table.ReloadData();
+			source.RowsReordered += (sender, e) => Table.ReloadData();
 		}
 		
 		public int[] SelectedRows {

--- a/Xwt.Mac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/ListViewBackend.cs
@@ -30,7 +30,6 @@
 using System;
 using MonoMac.AppKit;
 using Xwt.Backends;
-using System.Collections.Generic;
 using MonoMac.Foundation;
 
 namespace Xwt.Mac
@@ -90,7 +89,9 @@ namespace Xwt.Mac
 			tsource = new ListSource (source);
 			Table.DataSource = tsource;
 
-			//TODO: reloading single rows would be more efficient
+			//TODO: Reloading single rows would be slightly more efficient.
+			//      According to NSTableView.ReloadData() documentation,
+			//      only the visible rows are reloaded.
 			source.RowInserted += (sender, e) => Table.ReloadData();
 			source.RowDeleted += (sender, e) => Table.ReloadData();
 			source.RowChanged += (sender, e) => Table.ReloadData();

--- a/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
@@ -171,14 +171,13 @@ namespace Xwt.Mac
 		
 		public void ExpandToRow (TreePosition pos)
 		{
-			NSObject it = tsource.GetItem (pos);
-			if (it == null)
-				return;
-			
-			it = Tree.GetParent (it);
-			while (it != null) {
+			var p = source.GetParent (pos);
+			while (p != null) {
+				var it = tsource.GetItem (p);
+				if (it == null)
+					break;
 				Tree.ExpandItem (it, false);
-				it = Tree.GetParent (it);
+				p = source.GetParent (p);
 			}
 		}
 		

--- a/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
@@ -29,7 +29,6 @@ using MonoMac.AppKit;
 using MonoMac.Foundation;
 using Xwt.Backends;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Xwt.Mac
 {
@@ -94,11 +93,10 @@ namespace Xwt.Mac
 			tsource = new TreeSource (source);
 			Tree.DataSource = tsource;
 
-			//TODO: reloading single rows would be more efficient
-			source.NodeInserted += (sender, e) => Tree.ReloadData();
-			source.NodeDeleted += (sender, e) => Tree.ReloadData();
-			source.NodeChanged += (sender, e) => Tree.ReloadData();
-			source.NodesReordered += (sender, e) => Tree.ReloadData();
+			source.NodeInserted += (sender, e) => Tree.ReloadItem (tsource.GetItem (source.GetParent(e.Node)), true);
+			source.NodeDeleted += (sender, e) => Tree.ReloadItem (tsource.GetItem (e.Node), true);
+			source.NodeChanged += (sender, e) => Tree.ReloadItem (tsource.GetItem (e.Node), false);
+			source.NodesReordered += (sender, e) => Tree.ReloadItem (tsource.GetItem (e.Node), true);
 		}
 		
 		public override object GetValue (object pos, int nField)
@@ -242,14 +240,13 @@ namespace Xwt.Mac
 		public TreeSource (ITreeDataSource source)
 		{
 			this.source = source;
-			source.NodeInserted += (sender, e) => items.Clear();
-			source.NodeDeleted += (sender, e) => items.Clear();
-			source.NodeChanged += (sender, e) => items.Clear();
-			source.NodeInserted += (sender, e) => items.Clear();
+			source.NodeInserted += (sender, e) => items.Add (e.Node, new TreeItem { Position = e.Node });
 		}
 		
 		public TreeItem GetItem (TreePosition pos)
 		{
+			if (pos == null)
+				return null;
 			TreeItem it;
 			items.TryGetValue (pos, out it);
 			return it;

--- a/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
@@ -93,6 +93,12 @@ namespace Xwt.Mac
 			this.source = source;
 			tsource = new TreeSource (source);
 			Tree.DataSource = tsource;
+
+			//TODO: reloading single rows would be more efficient
+			source.NodeInserted += (sender, e) => Tree.ReloadData();
+			source.NodeDeleted += (sender, e) => Tree.ReloadData();
+			source.NodeChanged += (sender, e) => Tree.ReloadData();
+			source.NodesReordered += (sender, e) => Tree.ReloadData();
 		}
 		
 		public override object GetValue (object pos, int nField)
@@ -236,6 +242,10 @@ namespace Xwt.Mac
 		public TreeSource (ITreeDataSource source)
 		{
 			this.source = source;
+			source.NodeInserted += (sender, e) => items.Clear();
+			source.NodeDeleted += (sender, e) => items.Clear();
+			source.NodeChanged += (sender, e) => items.Clear();
+			source.NodeInserted += (sender, e) => items.Clear();
 		}
 		
 		public TreeItem GetItem (TreePosition pos)

--- a/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
@@ -239,7 +239,11 @@ namespace Xwt.Mac
 		public TreeSource (ITreeDataSource source)
 		{
 			this.source = source;
-			source.NodeInserted += (sender, e) => items.Add (e.Node, new TreeItem { Position = e.Node });
+
+			source.NodeInserted += (sender, e) => {
+				if (!items.ContainsKey (e.Node))
+					items.Add (e.Node, new TreeItem { Position = e.Node });
+			};
 		}
 		
 		public TreeItem GetItem (TreePosition pos)

--- a/Xwt/Xwt/TreeStore.cs
+++ b/Xwt/Xwt/TreeStore.cs
@@ -278,7 +278,7 @@ namespace Xwt
 		public TreePosition GetNext (TreePosition pos)
 		{
 			NodePosition np = GetPosition (pos);
-			if (np.NodeIndex >= np.ParentList.Count)
+			if (np.NodeIndex >= np.ParentList.Count - 1)
 				return null;
 			Node n = np.ParentList[np.NodeIndex + 1];
 			return new NodePosition () { ParentList = np.ParentList, NodeId = n.NodeId, NodeIndex = np.NodeIndex + 1, StoreVersion = version };


### PR DESCRIPTION
This is the same as ##316, but reloads the views not only on row changes, but also on  deletion/insertion.

(closes #314, closes #316)