### PR TITLE
Add CurrentEventRow to ListView

### DIFF
--- a/TestApps/Samples/Samples/ListView2.cs
+++ b/TestApps/Samples/Samples/ListView2.cs
@@ -20,7 +20,18 @@ namespace Samples
 			list.DataSource = store;
 			list.GridLinesVisible = GridLines.Horizontal;
 
-			list.Columns.Add (new ListViewColumn("Editable", new CheckBoxCellView { Editable = true, ActiveField = editableActiveField }));
+			var checkCellView = new CheckBoxCellView { Editable = true, ActiveField = editableActiveField };
+			checkCellView.Toggled += (sender, e) => {
+
+				if (list.CurrentEventRow == null) {
+					MessageDialog.ShowError("CurrentEventRow is null. This is not supposed to happen");
+				}
+				else {
+					store.SetValue(list.CurrentEventRow, textField, "Toggled");
+				}
+			};
+
+			list.Columns.Add (new ListViewColumn("Editable", checkCellView));
 			list.Columns.Add (new ListViewColumn("Not Editable", new CheckBoxCellView { Editable = false, ActiveField = nonEditableActiveField }));
 			list.Columns.Add (new ListViewColumn("Editable", new TextCellView { Editable = true, TextField = textField }));
 			list.Columns.Add(new ListViewColumn("Somewhat Editable", new CheckBoxCellView { EditableField = editableField, ActiveField = somewhatEditableData }));

--- a/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
@@ -106,6 +106,11 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		public int CurrentEventRow {
+			get;
+			internal set;
+		}
+
 		public bool BorderVisible {
 			get {
 				return ScrolledWindow.ShadowType == Gtk.ShadowType.In;
@@ -162,6 +167,14 @@ namespace Xwt.GtkBackend
 			col.CellGetSize (rect, out x, out y, out w, out h);
 
 			return new Rectangle (x, y, w, h);
+		}
+
+		public override void SetCurrentEventRow (string path)
+		{
+			if (path.Contains (":")) {
+				path = path.Split (':') [0];
+			}
+			CurrentEventRow = int.Parse (path);
 		}
 	}
 }

--- a/Xwt.Mac/Xwt.Mac.CellViews/CheckBoxTableCell.cs
+++ b/Xwt.Mac/Xwt.Mac.CellViews/CheckBoxTableCell.cs
@@ -41,6 +41,7 @@ namespace Xwt.Mac
 		void HandleActivated (object sender, EventArgs e)
 		{
 			var cellView = Frontend;
+			CellContainer.SetCurrentEventRow ();
 			if (cellView.Editable && !cellView.RaiseToggled () && (cellView.StateField != null || cellView.ActiveField != null)) {
 				if (cellView.StateField != null)
 					CellContainer.SetValue (cellView.StateField, State.ToXwtState ());

--- a/Xwt.Mac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.Mac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -79,6 +79,11 @@ namespace Xwt.Mac
 			source.SetValue (tablePosition.Position, field.Index, value);
 		}
 
+		public void SetCurrentEventRow ()
+		{
+			source.SetCurrentEventRow (tablePosition.Position);
+		}
+
 		void ICopiableObject.CopyFrom (object other)
 		{
 			var ob = (CompositeCell)other;

--- a/Xwt.Mac/Xwt.Mac.CellViews/ICellSource.cs
+++ b/Xwt.Mac/Xwt.Mac.CellViews/ICellSource.cs
@@ -37,6 +37,7 @@ namespace Xwt.Mac
 	{
 		object GetValue (object pos, int nField);
 		void SetValue (object pos, int nField, object value);
+		void SetCurrentEventRow (object pos);
 		float RowHeight { get; set; }
 	}
 }

--- a/Xwt.Mac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/ListViewBackend.cs
@@ -121,6 +121,13 @@ namespace Xwt.Mac
 			source.SetValue ((int)pos, nField, value);
 		}
 
+		public int CurrentEventRow { get; internal set; }
+
+		public override void SetCurrentEventRow (object pos)
+		{
+			CurrentEventRow = (int)pos;
+		}
+
 		// TODO
 		public bool BorderVisible { get; set; }
 

--- a/Xwt.Mac/Xwt.Mac/TableViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/TableViewBackend.cs
@@ -236,6 +236,8 @@ namespace Xwt.Mac
 		
 		public abstract void SetValue (object pos, int nField, object value);
 
+		public abstract void SetCurrentEventRow (object pos);
+
 		float ICellSource.RowHeight {
 			get { return Table.RowHeight; }
 			set { Table.RowHeight = value; }

--- a/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
@@ -78,7 +78,7 @@ namespace Xwt.Mac
 			get { return "NSOutlineViewSelectionDidChangeNotification"; }
 		}
 
-		public TreePosition CurrentEventRow { get; set; }
+		public TreePosition CurrentEventRow { get; internal set; }
 
 		public override NSTableColumn AddColumn (ListViewColumn col)
 		{
@@ -116,6 +116,11 @@ namespace Xwt.Mac
 				}
 				return res;
 			}
+		}
+
+		public override void SetCurrentEventRow (object pos)
+		{
+			CurrentEventRow = (TreePosition)pos;
 		}
 
 		public void SelectRow (TreePosition pos)

--- a/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
@@ -54,6 +54,8 @@ namespace Xwt.WPFBackend
 	                return null;
 	        }
         }
+
+        public int CurrentEventRow { get; set;  }
 		
 		public ScrollPolicy VerticalScrollPolicy {
 			get { return ScrollViewer.GetVerticalScrollBarVisibility (this.ListView).ToXwtScrollPolicy (); }

--- a/Xwt/Xwt.Backends/IListViewBackend.cs
+++ b/Xwt/Xwt.Backends/IListViewBackend.cs
@@ -42,6 +42,7 @@ namespace Xwt.Backends
 
 		int GetRowAtPosition (Point p);
 		Rectangle GetCellBounds (int row, CellView cell, bool includeMargin);
+		int CurrentEventRow { get; }
 	}
 	
 	public enum ListViewEvent

--- a/Xwt/Xwt/ListView.cs
+++ b/Xwt/Xwt/ListView.cs
@@ -165,6 +165,20 @@ namespace Xwt
 				Backend.SetSelectionMode (mode);
 			}
 		}
+
+		/// <summary>
+		/// Gets or sets the row the current event applies to.
+		/// The behavior of this property is undefined when used outside an
+		/// event that supports it.
+		/// </summary>
+		/// <value>
+		/// The current event row.
+		/// </value>
+		public int CurrentEventRow {
+			get {
+				return Backend.CurrentEventRow;
+			}
+		}
 		
 		public int SelectedRow {
 			get {


### PR DESCRIPTION
Adds ListView.CurrentEventRow (same as 9b06b9e for TreeView, but for ListView).
This allows event handlers to know which row was changed.
* includes Gtk and Mac implementations
* MAC: adds CurrentEventRow for TreeView, too
TODO: Wpf!