### PR TITLE
Add tree filtering through proxy stores

### DIFF
--- a/TestApps/Samples/MainWindow.cs
+++ b/TestApps/Samples/MainWindow.cs
@@ -83,6 +83,7 @@ namespace Samples
 			AddSample (w, "ListBox", typeof(ListBoxSample));
 			AddSample (w, "LinkLabels", typeof(LinkLabels));
 			var listView = AddSample (w, "ListView", typeof(ListView1));
+			AddSample (listView, "Filter", typeof(ListViewFilter));
 			AddSample (listView, "Editable checkboxes", typeof(ListView2));
 			AddSample (w, "Markdown", typeof (MarkDownSample));
 			AddSample (w, "Menu", typeof(MenuSamples));
@@ -99,7 +100,8 @@ namespace Samples
 			AddSample (w, "Tables", typeof (Tables));
 			AddSample (w, "Text Entry", typeof (TextEntries));
 			AddSample (w, "Password Entry", typeof (PasswordEntries));
-			AddSample (w, "TreeView", typeof(TreeViews));
+			var t = AddSample (w, "TreeView", typeof(TreeViews));
+			AddSample (t, "TreeView Filter", typeof(TreeViewFilter));
 			AddSample (w, "WebView", typeof(WebViewSample));
 
 			var n = AddSample (null, "Drawing", null);

--- a/TestApps/Samples/Samples.csproj
+++ b/TestApps/Samples/Samples.csproj
@@ -106,6 +106,8 @@
     <Compile Include="Samples\MouseCursors.cs" />
     <Compile Include="Samples\MessageDialogs.cs" />
     <Compile Include="Samples\MultithreadingSample.cs" />
+    <Compile Include="Samples\TreeViewFilter.cs" />
+    <Compile Include="Samples\ListViewFilter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/TestApps/Samples/Samples/ListViewFilter.cs
+++ b/TestApps/Samples/Samples/ListViewFilter.cs
@@ -1,0 +1,137 @@
+﻿//
+// ListViewFilter.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt;
+using Xwt.Drawing;
+
+namespace Samples
+{
+	public class ListViewFilter: VBox
+	{
+		DataField<string> name = new DataField<string> ();
+		DataField<Image> icon = new DataField<Image> ();
+		DataField<string> text = new DataField<string> ();
+		DataField<Image> icon2 = new DataField<Image> ();
+		DataField<CellData> progress = new DataField<CellData> ();
+
+		public ListViewFilter ()
+		{
+			PackStart (new Label ("The listview should have a red background"));
+			ListView list = new ListView ();
+			list.GridLinesVisible = GridLines.Both;
+			ListStore store = new ListStore (name, icon, text, icon2, progress);
+			ListStoreFilter filter = new ListStoreFilter (store);
+
+			list.DataSource = filter;
+			list.Columns.Add ("Name", icon, name);
+			list.Columns.Add ("Text", icon2, text);
+			list.Columns.Add ("Progress", new TextCellView () { TextField = text }, new CustomCell () { ValueField = progress });
+
+			var png = Image.FromResource (typeof(App), "class.png");
+
+			Random rand = new Random ();
+
+			for (int n=0; n<100; n++) {
+				var r = store.AddRow ();
+				store.SetValue (r, icon, png);
+				store.SetValue (r, name, "Value " + n);
+				store.SetValue (r, icon2, png);
+				store.SetValue (r, text, "Text " + n);
+				store.SetValue (r, progress, new CellData { Value = rand.Next () % 100 });
+			}
+			PackStart (list, true);
+
+			list.RowActivated += delegate(object sender, ListViewRowEventArgs e) {
+				int storeRow = filter.ConvertPositionToChildPosition(e.RowIndex);
+				var valName = store.GetValue (storeRow, name);
+				var valText = store.GetValue (storeRow, text);
+				var valProgress = store.GetValue (storeRow, progress).Value;
+				MessageDialog.ShowMessage ("Row " + e.RowIndex + " activated", 
+				                           "Name: " + valName + "\nText: " + valText + "\nProgress: " + valProgress);
+			};
+
+			Menu contextMenu = new Menu ();
+			contextMenu.Items.Add (new MenuItem ("Test menu"));
+			list.ButtonPressed += delegate(object sender, ButtonEventArgs e) {
+				int row = list.GetRowAtPosition(new Point(e.X, e.Y));
+				if (e.Button == PointerButton.Right && row >= 0) {
+					// Set actual row to selected
+					list.SelectRow(row);
+					contextMenu.Popup(list, e.X, e.Y);
+				}
+			};
+
+			var spnValue = new SpinButton ();
+			spnValue.MinimumValue = 0;
+			spnValue.MaximumValue = 99;
+			spnValue.IncrementValue = 1;
+			spnValue.Digits = 0;
+			var btnScrollVal = new Button ("Name");
+			btnScrollVal.Clicked += (sender, e) =>
+				list.ScrollToRow(filter.ConvertChildPositionToPosition((int)spnValue.Value));
+
+			var btnScrollRow = new Button ("Row");
+			btnScrollRow.Clicked += (sender, e) =>
+				list.ScrollToRow((int)spnValue.Value);
+
+			HBox scrollActBox = new HBox ();
+			scrollActBox.PackStart (new Label("Scroll to: "));
+			scrollActBox.PackStart (spnValue);
+			scrollActBox.PackStart (btnScrollVal);
+			scrollActBox.PackStart (btnScrollRow);
+			PackStart (scrollActBox);
+
+			var txtFilter = new TextEntry ();
+			txtFilter.Changed += (sender, e) => filter.Refilter ();
+			var spnFilter = new SpinButton ();
+			spnFilter.Digits = 0;
+			spnFilter.MinimumValue = 0;
+			spnFilter.MaximumValue = 100;
+			spnFilter.IncrementValue = 1;
+			spnFilter.Value = 100;
+			spnFilter.ValueChanged += (sender, e) => filter.Refilter ();
+
+			filter.FilterFunction = delegate(int pos) {
+				var valText = store.GetValue (pos, text);
+				if (!valText.Contains (txtFilter.Text))
+					return true;
+
+				var valProgress = store.GetValue (pos, progress).Value;
+				if (valProgress > spnFilter.Value)
+					return true;
+				return false;
+			};
+
+			var boxFilter = new HBox ();
+			boxFilter.PackStart (new Label ("Filter Text:"));
+			boxFilter.PackStart (txtFilter, true);
+			boxFilter.PackStart (new Label (" & %Max:"));
+			boxFilter.PackStart (spnFilter);
+			PackStart (boxFilter);
+		}
+	}
+}
+

--- a/TestApps/Samples/Samples/TreeViewFilter.cs
+++ b/TestApps/Samples/Samples/TreeViewFilter.cs
@@ -1,0 +1,221 @@
+﻿//
+// TreeViewFilter.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt;
+
+namespace Samples
+{
+	public class TreeViewFilter: VBox
+	{
+		int valueCount;
+		DataField<string> text = new DataField<string> ();
+		DataField<bool> check = new DataField<bool>();
+		DataField<string> action = new DataField<string> ();
+		DataField<string> position = new DataField<string> ();
+
+		public TreeViewFilter ()
+		{
+			TreeView view = new TreeView ();
+			TreeView fview = new TreeView ();
+			TreeStore store = new TreeStore (check, text, action, position);
+
+			var checkCellView = new CheckBoxCellView (check) { Editable = true };
+			view.Columns.Add ("Item", text);
+			view.Columns.Add ("Check", checkCellView);
+			view.Columns.Add ("State", new TextCellView (check));
+			view.Columns.Add ("Pos", position);
+			view.Columns.Add ("Action", action);
+
+			var checkCellView2 = new CheckBoxCellView (check) { Editable = true };
+			fview.Columns.Add ("Item", text);
+			fview.Columns.Add ("Check", checkCellView2);
+			fview.Columns.Add ("State", new TextCellView (check));
+			fview.Columns.Add ("Pos", position);
+			fview.Columns.Add ("Action", action);
+
+			store.AddNode ().SetValue (text, "Value 1").SetValue(position, "1");
+			store.AddNode ().SetValue (text, "Value 2").SetValue(position, "2").AddChild ()
+				.SetValue (text, "Value 3").SetValue(position, "2.2");
+			store.AddNode ().SetValue (text, "Value 4").SetValue(position, "3").AddChild ()
+				.SetValue (text, "Value 5").SetValue(position, "3.3");
+			valueCount = 6;
+
+			TreeStoreFilter filter = new TreeStoreFilter (store);
+
+			checkCellView.Toggled += (object sender, WidgetEventArgs e) => {
+				if (view.CurrentEventRow == null) {
+					MessageDialog.ShowError("CurrentEventRow is null. This is not supposed to happen");
+				}
+				else {
+					var newstate = !store.GetNavigatorAt(view.CurrentEventRow).GetValue (check);
+					string saction = newstate ? "Checked" : "Unchecked";
+					store.GetNavigatorAt(view.CurrentEventRow).SetValue(action, saction);
+					store.GetNavigatorAt(view.CurrentEventRow).SetValue (check, newstate);
+					e.Handled = true;
+				}
+			};
+
+			checkCellView2.Toggled += (object sender, WidgetEventArgs e) => {
+				if (fview.CurrentEventRow == null) {
+					MessageDialog.ShowError("CurrentEventRow is null. This is not supposed to happen");
+				}
+				else {
+					var newstate = !store.GetNavigatorAt(filter.ConvertPositionToChildPosition (fview.CurrentEventRow)).GetValue (check);
+					string saction = newstate ? "Checked" : "Unchecked";
+					store.GetNavigatorAt(filter.ConvertPositionToChildPosition (fview.CurrentEventRow)).SetValue(action, saction);
+					store.GetNavigatorAt(filter.ConvertPositionToChildPosition (fview.CurrentEventRow)).SetValue (check, newstate);
+					e.Handled = true;
+				}
+			};
+
+			var chkFilter = new CheckBox ("Checked");
+			chkFilter.AllowMixed = true;
+			chkFilter.State = CheckBoxState.Mixed;
+			chkFilter.Toggled += (sender, e) => filter.Refilter ();
+
+			var txtFilter = new TextEntry ();
+			txtFilter.Changed += (sender, e) => filter.Refilter ();
+
+			filter.FilterFunction = delegate(TreePosition arg)
+			{
+				var checkedval = store.GetNavigatorAt (arg).GetValue (check);
+
+				if (chkFilter.State == CheckBoxState.On && !checkedval)
+					return true;
+				if (chkFilter.State == CheckBoxState.Off && checkedval)
+					return true;
+
+				var val = store.GetNavigatorAt (arg).GetValue (text);
+				if (val == null)
+					return false;
+				return !val.ToUpper ().Contains (txtFilter.Text.ToUpper ());
+			};
+
+			var filterBox = new HBox ();
+			filterBox.PackStart (new Label("Filter:"));
+			filterBox.PackStart (chkFilter);
+			filterBox.PackStart (txtFilter, true);
+
+
+			view.DataSource = store;
+			fview.DataSource = filter;
+
+			Label la = new Label ();
+
+			view.SetDragDropTarget (DragDropAction.All, TransferDataType.Text);
+			view.SetDragSource (DragDropAction.All, TransferDataType.Text);
+
+			view.DragDrop += delegate(object sender, DragEventArgs e) {
+				TreePosition node;
+				RowDropPosition pos;
+				view.GetDropTargetRow (e.Position.X, e.Position.Y, out pos, out node);
+				var nav = store.GetNavigatorAt (node);
+				var dest = nav.GetValue (text);
+
+				string loc = String.Empty;
+				if (pos == RowDropPosition.Before) 
+					nav.MoveNext();
+				else if (pos == RowDropPosition.After)
+					nav.MovePrevious();
+				else
+					nav.MoveToParent();
+				loc = pos + " \"" + nav.GetValue (text) + "\"";
+				la.Text = "Dropped \"" + e.Data.Text + "\" into \"" + dest + "\" " + loc;
+				e.Success = true;
+			};
+			view.DragOver += delegate(object sender, DragOverEventArgs e) {
+				TreePosition node;
+				RowDropPosition pos;
+				view.GetDropTargetRow (e.Position.X, e.Position.Y, out pos, out node);
+				if (pos == RowDropPosition.Into)
+					e.AllowedAction = DragDropAction.None;
+				else
+					e.AllowedAction = e.Action;
+			};
+			view.DragStarted += delegate(object sender, DragStartedEventArgs e) {
+				var val = store.GetNavigatorAt (view.SelectedRow).GetValue (text);
+				e.DragOperation.Data.AddValue (val);
+				e.DragOperation.SetDragImage (StockIcons.Add, 0, 0);
+				e.DragOperation.Finished += delegate(object s, DragFinishedEventArgs args) {
+					Console.WriteLine ("D:" + args.DeleteSource);
+				};
+			};
+			view.RowExpanding += delegate(object sender, TreeViewRowEventArgs e) {
+				var val = store.GetNavigatorAt (e.Position).GetValue (text);
+				Console.WriteLine("Expanding: " + val);
+			};
+			view.RowExpanded += delegate(object sender, TreeViewRowEventArgs e) {
+				var val = store.GetNavigatorAt (e.Position).GetValue (text);
+				Console.WriteLine("Expanded: " + val);
+			};
+			view.RowCollapsing += delegate(object sender, TreeViewRowEventArgs e) {
+				var val = store.GetNavigatorAt (e.Position).GetValue (text);
+				Console.WriteLine("Collapsing: " + val);
+			};
+			view.RowCollapsed += delegate(object sender, TreeViewRowEventArgs e) {
+				var val = store.GetNavigatorAt (e.Position).GetValue (text);
+				Console.WriteLine("Collapsed: " + val);
+			};
+			Button addButton = new Button ("Add");
+			addButton.Clicked += delegate(object sender, EventArgs e) {
+				TreeNavigator n;
+				if (view.SelectedRow != null)
+					n = store.AddNode (view.SelectedRow);
+				else
+					n = store.AddNode ();
+				n.SetValue (text, "Value " + valueCount++);
+				view.ScrollToRow (n.CurrentPosition);
+			};
+
+			Button removeButton = new Button ("Remove Selection");
+			removeButton.Clicked += delegate(object sender, EventArgs e) {
+				foreach (TreePosition row in view.SelectedRows) {
+					store.GetNavigatorAt (row).Remove ();
+				}
+			};
+
+			PackStart (view, true);
+			PackStart (la);
+			PackStart (removeButton);
+			PackStart (addButton);
+			PackStart (fview, true);
+
+			PackStart (filterBox);
+
+			var label = new Label ();
+			PackStart (label);
+
+			view.RowExpanded += (sender, e) => label.Text = "Row expanded: " + store.GetNavigatorAt (e.Position).GetValue (text);
+		}
+
+		void HandleDragOver (object sender, DragOverEventArgs e)
+		{
+			e.AllowedAction = e.Action;
+		}
+	}
+
+}
+

--- a/Xwt.Gtk/Xwt.Gtk.csproj
+++ b/Xwt.Gtk/Xwt.Gtk.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Xwt.GtkBackend\ListViewBackend.cs" />
     <Compile Include="Xwt.GtkBackend\TableViewBackend.cs" />
     <Compile Include="Xwt.GtkBackend\ListStoreBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\ListStoreFilterBackend.cs" />
     <Compile Include="Xwt.GtkBackend\TableStoreBackend.cs" />
     <Compile Include="Xwt.GtkBackend\MenuBackend.cs" />
     <Compile Include="Xwt.GtkBackend\MenuItemBackend.cs" />

--- a/Xwt.Gtk/Xwt.Gtk.csproj
+++ b/Xwt.Gtk/Xwt.Gtk.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Xwt.GtkBackend\ButtonBackend.cs" />
     <Compile Include="Xwt.GtkBackend\NotebookBackend.cs" />
     <Compile Include="Xwt.GtkBackend\TreeStoreBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\TreeStoreFilterBackend.cs" />
     <Compile Include="Xwt.GtkBackend\TreeViewBackend.cs" />
     <Compile Include="Xwt.GtkBackend.CellViews\CellUtil.cs" />
     <Compile Include="Xwt.GtkBackend\ImageHandler.cs" />

--- a/Xwt.Gtk/Xwt.Gtk3.csproj
+++ b/Xwt.Gtk/Xwt.Gtk3.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Xwt.GtkBackend.CellViews\CellUtil.cs" />
     <Compile Include="Xwt.GtkBackend.CellViews\CellViewBackend.cs" />
     <Compile Include="Xwt.GtkBackend\TreeStoreBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\TreeStoreFilterBackend.cs" />
     <Compile Include="Xwt.GtkBackend\TableStoreBackend.cs" />
     <Compile Include="Xwt.GtkBackend\CustomTreeModel.cs" />
     <Compile Include="Xwt.GtkBackend.CellViews\CustomCellRenderer.cs" />

--- a/Xwt.Gtk/Xwt.Gtk3.csproj
+++ b/Xwt.Gtk/Xwt.Gtk3.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Xwt.GtkBackend\CustomListModel.cs" />
     <Compile Include="Xwt.GtkBackend\ListBoxBackend.cs" />
     <Compile Include="Xwt.GtkBackend\ListStoreBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\ListStoreFilterBackend.cs" />
     <Compile Include="Xwt.GtkBackend\ListViewBackend.cs" />
     <Compile Include="Xwt.GtkBackend\ComboBoxBackend.cs" />
     <Compile Include="Xwt.GtkBackend\ComboBoxEntryBackend.cs" />

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
@@ -53,6 +53,7 @@ namespace Xwt.GtkBackend
 			RegisterBackend<INotebookBackend, NotebookBackend> ();
 			RegisterBackend<ITreeViewBackend, TreeViewBackend> ();
 			RegisterBackend<ITreeStoreBackend, TreeStoreBackend> ();
+			RegisterBackend<ITreeStoreFilterBackend, TreeStoreFilterBackend> ();
 			RegisterBackend<IListViewBackend, ListViewBackend> ();
 			RegisterBackend<IListStoreBackend, ListStoreBackend> ();
 			RegisterBackend<ICanvasBackend, CanvasBackend> ();

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
@@ -56,6 +56,7 @@ namespace Xwt.GtkBackend
 			RegisterBackend<ITreeStoreFilterBackend, TreeStoreFilterBackend> ();
 			RegisterBackend<IListViewBackend, ListViewBackend> ();
 			RegisterBackend<IListStoreBackend, ListStoreBackend> ();
+			RegisterBackend<IListStoreFilterBackend, ListStoreFilterBackend> ();
 			RegisterBackend<ICanvasBackend, CanvasBackend> ();
 			RegisterBackend<ImageBackendHandler, ImageHandler> ();
 			RegisterBackend<Xwt.Backends.ContextBackendHandler, CairoContextBackendHandler> ();

--- a/Xwt.Gtk/Xwt.GtkBackend/ListStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListStoreBackend.cs
@@ -40,14 +40,10 @@ namespace Xwt.GtkBackend
 		public event EventHandler<ListRowEventArgs> RowChanged;
 		public event EventHandler<ListRowOrderEventArgs> RowsReordered;
 
-		public Gtk.ListStore List {
-			get { return (Gtk.ListStore) Store; }
-		}
-
 		public object GetValue (int row, int column)
 		{
 			Gtk.TreeIter it;
-			if (!List.IterNthChild (out it, row))
+			if (!Store.IterNthChild (out it, row))
 				return null;
 			return GetValue (it, column);
 		}
@@ -55,14 +51,14 @@ namespace Xwt.GtkBackend
 		public void SetValue (int row, int column, object value)
 		{
 			Gtk.TreeIter it;
-			if (!List.IterNthChild (out it, row))
+			if (!Store.IterNthChild (out it, row))
 				return;
 			SetValue (it, column, value);
 		}
 
 		public int RowCount {
 			get {
-				return List.IterNChildren ();
+				return Store.IterNChildren ();
 			}
 		}
 
@@ -101,6 +97,10 @@ namespace Xwt.GtkBackend
 
 	public class ListStoreBackend: ListStoreBackendBase, IListStoreBackend
 	{
+		public Gtk.ListStore List {
+			get { return (Gtk.ListStore) Store; }
+		}
+
 		public override TreeModel InitializeModel (Type[] columnTypes)
 		{
 			var store = new Gtk.ListStore (columnTypes);

--- a/Xwt.Gtk/Xwt.GtkBackend/ListStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListStoreBackend.cs
@@ -26,7 +26,6 @@
 
 using System;
 using Xwt.Backends;
-using Xwt.Drawing;
 using Gtk;
 #if XWT_GTK3
 using TreeModel = Gtk.ITreeModel;
@@ -36,12 +35,8 @@ namespace Xwt.GtkBackend
 {
 	public class ListStoreBackend: TableStoreBackend, IListStoreBackend
 	{
-		Type[] columnTypes;
-
-
 		public override TreeModel InitializeModel (Type[] columnTypes)
 		{
-			this.columnTypes = columnTypes;
 			var store = new Gtk.ListStore (columnTypes);
 			store.RowInserted += (o, args) => {
 				if (RowInserted != null)
@@ -86,12 +81,6 @@ namespace Xwt.GtkBackend
 		public int RowCount {
 			get {
 				return List.IterNChildren ();
-			}
-		}
-		
-		public Type[] ColumnTypes {
-			get {
-				return columnTypes;
 			}
 		}
 		

--- a/Xwt.Gtk/Xwt.GtkBackend/ListStoreFilterBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListStoreFilterBackend.cs
@@ -1,0 +1,114 @@
+﻿//
+// ListStoreFilterBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt.Backends;
+using Xwt.Drawing;
+using Gtk;
+#if XWT_GTK3
+using TreeModel = Gtk.ITreeModel;
+#endif
+
+namespace Xwt.GtkBackend
+{
+	public class ListStoreFilterBackend: ListStoreBackendBase, IListStoreFilterBackend
+	{
+		public CustomTreeModelFilter FilterTree {
+			get { return (CustomTreeModelFilter) Store; }
+		}
+
+		public TreeModel ChildModel {
+			get;
+			private set;
+		}
+
+		public void Initialize (IListDataSource store)
+		{
+			var xwtComponent = store as XwtComponent;
+			if (xwtComponent != null) {
+				var backend = xwtComponent.GetBackend () as ListStoreBackendBase;
+				if (backend != null)
+					ChildModel = backend.Store;
+			}
+			if (ChildModel == null)
+				throw new InvalidOperationException ("No custom list stores supported");
+
+			base.Initialize (store.ColumnTypes);
+		}
+
+		public override TreeModel InitializeModel (Type[] columnTypes)
+		{
+			if (ChildModel == null) {
+				var def = new ListStoreBackend ();
+				def.Initialize (columnTypes);
+				ChildModel = def.Store;
+			}
+
+			var filterTree = new CustomTreeModelFilter(ChildModel, null);
+			filterTree.VisibleFunc = VisibleFunc;
+			return filterTree;
+		}
+
+		public void Refilter ()
+		{
+			FilterTree.Refilter ();
+		}
+
+		Func<int, bool> filterFunct;
+		public Func<int, bool> FilterFunction {
+			set {
+				filterFunct = value;
+			}
+		}
+
+		bool VisibleFunc (TreeModel rawModel, TreeIter iter)
+		{
+			if (filterFunct != null) {
+				var path = ChildModel.GetPath (iter);
+				return !filterFunct (path.Indices[0]);
+			}
+			return true;
+		}
+
+		public int ConvertChildPositionToPosition (int row)
+		{
+			Gtk.TreePath childPath = new Gtk.TreePath (new [] { row });
+			var path = FilterTree.ConvertChildPathToPath (childPath);
+			if (path == null)
+				return -1;
+			return path.Indices [0];
+		}
+
+		public int ConvertPositionToChildPosition (int row)
+		{
+			Gtk.TreePath path = new Gtk.TreePath (new [] { row });
+			var childPath = FilterTree.ConvertPathToChildPath (path);
+			if (path == null)
+				return -1;
+			return path.Indices [0];
+		}
+	}
+}
+

--- a/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
@@ -64,7 +64,7 @@ namespace Xwt.GtkBackend
 
 		public void SetSource (IListDataSource source, IBackend sourceBackend)
 		{
-			ListStoreBackend b = sourceBackend as ListStoreBackend;
+			ListStoreBackendBase b = sourceBackend as ListStoreBackendBase;
 			if (b == null) {
 				CustomListModel model = new CustomListModel (source, Widget);
 				Widget.Model = model.Store;

--- a/Xwt.Gtk/Xwt.GtkBackend/TableStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TableStoreBackend.cs
@@ -37,13 +37,14 @@ namespace Xwt.GtkBackend
 {
 	public abstract class TableStoreBackend
 	{
-		TreeModel store;
-		Type[] types;
+		public Type[] ColumnTypes {
+			get;
+			private set;
+		}
 
 		public TreeModel Store {
-			get {
-				return store;
-			}
+			get;
+			protected set;
 		}
 
 		public ApplicationContext ApplicationContext {
@@ -53,16 +54,16 @@ namespace Xwt.GtkBackend
 
 		public void Initialize (Type[] columnTypes)
 		{
-			types = new Type[columnTypes.Length];
-			for (int n=0; n<types.Length; n++) {
+			ColumnTypes = new Type[columnTypes.Length];
+			for (int n=0; n<ColumnTypes.Length; n++) {
 				if (columnTypes [n] == typeof(Gtk.Image))
-					types [n] = typeof(ImageDescription);
+					ColumnTypes [n] = typeof(ImageDescription);
 				else if (columnTypes [n] == typeof(object))
-					types [n] = typeof(ObjectWrapper);
+					ColumnTypes [n] = typeof(ObjectWrapper);
 				else
-					types [n] = columnTypes [n];
+					ColumnTypes [n] = columnTypes [n];
 			}
-			store = InitializeModel (types);
+			Store = InitializeModel (ColumnTypes);
 		}
 
 		public abstract TreeModel InitializeModel (Type[] columnTypes);
@@ -74,12 +75,12 @@ namespace Xwt.GtkBackend
 
 		public void SetValue (Gtk.TreeIter it, int column, object value)
 		{
-			CellUtil.SetModelValue (store, it, column, types [column], value);
+			CellUtil.SetModelValue (Store, it, column, ColumnTypes [column], value);
 		}
 
 		public object GetValue (Gtk.TreeIter it, int column)
 		{
-			return CellUtil.GetModelValue (store, it, column);
+			return CellUtil.GetModelValue (Store, it, column);
 		}
 	}
 	

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
@@ -64,10 +64,6 @@ namespace Xwt.GtkBackend
 			}
 		}
 
-		public Gtk.TreeStore Tree {
-			get { return (Gtk.TreeStore) Store; }
-		}
-
 		public event EventHandler<TreeNodeEventArgs> NodeInserted;
 		public event EventHandler<TreeNodeChildEventArgs> NodeDeleted;
 		public event EventHandler<TreeNodeEventArgs> NodeChanged;
@@ -96,14 +92,14 @@ namespace Xwt.GtkBackend
 			if (index == 0) {
 				if (tpos != null) {
 					Gtk.TreeIter it;
-					if (Tree.IterChildren (out it, tpos.Iter)) {
+					if (Store.IterChildren (out it, tpos.Iter)) {
 						tpos.LastChildIter = it;
 						tpos.LastChildIndex = 0;
 						return new IterPos (version, it);
 					}
 				} else {
 					Gtk.TreeIter it;
-					if (Tree.GetIterFirst (out it))
+					if (Store.GetIterFirst (out it))
 						return new IterPos (version, it);
 				}
 				return null;
@@ -111,7 +107,7 @@ namespace Xwt.GtkBackend
 			
 			if (tpos == null) {
 				Gtk.TreeIter it;
-				if (Tree.IterNthChild (out it, index))
+				if (Store.IterNthChild (out it, index))
 					return new IterPos (version, it);
 				else
 					return null;
@@ -119,7 +115,7 @@ namespace Xwt.GtkBackend
 			
 			if (tpos.LastChildIndex == -1 || tpos.LastChildIndex > index) {
 				Gtk.TreeIter it;
-				if (Tree.IterNthChild (out it, tpos.Iter, index)) {
+				if (Store.IterNthChild (out it, tpos.Iter, index)) {
 					tpos.LastChildIter = it;
 					tpos.LastChildIndex = index;
 					return new IterPos (version, it);
@@ -131,7 +127,7 @@ namespace Xwt.GtkBackend
 			
 			Gtk.TreeIter iter = tpos.LastChildIter;
 			for (int n = tpos.LastChildIndex; n < index; n++) {
-				if (!Tree.IterNext (ref iter))
+				if (!Store.IterNext (ref iter))
 					return null;
 			}
 			tpos.LastChildIter = iter;
@@ -142,14 +138,14 @@ namespace Xwt.GtkBackend
 		public int GetChildrenCount (TreePosition pos)
 		{
 			if (pos == null)
-				return Tree.IterNChildren ();
+				return Store.IterNChildren ();
 			
 			IterPos tpos = GetIterPos (pos);
 			
 			if (tpos.ChildrenCount != -1)
 				return tpos.ChildrenCount;
 			
-			return tpos.ChildrenCount = Tree.IterNChildren (tpos.Iter);
+			return tpos.ChildrenCount = Store.IterNChildren (tpos.Iter);
 		}
 
 		public int GetParentChildIndex (TreePosition pos)
@@ -158,7 +154,7 @@ namespace Xwt.GtkBackend
 				return -1;
 
 			IterPos tpos = GetIterPos (pos);
-			var path = Tree.GetPath (tpos.Iter);
+			var path = Store.GetPath (tpos.Iter);
 			if (path != null)
 				return path.Indices [path.Depth - 1];
 			return -1;
@@ -182,7 +178,7 @@ namespace Xwt.GtkBackend
 		{
 			IterPos tpos = GetIterPos (pos);
 			Gtk.TreeIter it = tpos.Iter;
-			if (!Tree.IterNext (ref it))
+			if (!Store.IterNext (ref it))
 				return null;
 			return new IterPos (version, it);
 		}
@@ -190,14 +186,14 @@ namespace Xwt.GtkBackend
 		public TreePosition GetPrevious (TreePosition pos)
 		{
 			IterPos tpos = GetIterPos (pos);
-			Gtk.TreePath path = Tree.GetPath (tpos.Iter);
+			Gtk.TreePath path = Store.GetPath (tpos.Iter);
 			int [] indices = path.Indices;
 			if (indices.Length < 1 || indices [indices.Length - 1] == 0)
 				return null;
 			indices [indices.Length - 1] --;
 			Gtk.TreePath previousPath = new Gtk.TreePath (indices);
 			Gtk.TreeIter previous;
-			if (!Tree.GetIter (out previous, previousPath))
+			if (!Store.GetIter (out previous, previousPath))
 				return null;
 			return new IterPos (version, previous);
 		}
@@ -206,7 +202,7 @@ namespace Xwt.GtkBackend
 		{
 			IterPos tpos = GetIterPos (pos);
 			Gtk.TreeIter it;
-			if (!Tree.IterParent (out it, tpos.Iter))
+			if (!Store.IterParent (out it, tpos.Iter))
 				return null;
 			return new IterPos (version, it);
 		}
@@ -246,6 +242,9 @@ namespace Xwt.GtkBackend
 	
 	public class TreeStoreBackend: TreeStoreBackendBase, ITreeStoreBackend
 	{
+		public Gtk.TreeStore Tree {
+			get { return (Gtk.TreeStore) Store; }
+		}
 
 		public override TreeModel InitializeModel (Type[] columnTypes)
 		{

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
@@ -56,7 +56,6 @@ namespace Xwt.GtkBackend
 	
 	public class TreeStoreBackend: TableStoreBackend, ITreeStoreBackend
 	{
-		Type[] columnTypes;
 		int version;
 		
 		public Gtk.TreeStore Tree {
@@ -64,9 +63,7 @@ namespace Xwt.GtkBackend
 		}
 
 		public override TreeModel InitializeModel (Type[] columnTypes)
-
 		{
-			this.columnTypes = columnTypes;
 			return new Gtk.TreeStore (columnTypes);
 		}
 		
@@ -171,6 +168,8 @@ namespace Xwt.GtkBackend
 		{
 			IterPos tpos = GetIterPos (pos);
 			SetValue (tpos.Iter, column, value);
+			if (NodeChanged != null)
+				NodeChanged (this, new TreeNodeEventArgs (pos));
 		}
 
 		public object GetValue (TreePosition pos, int column)
@@ -184,7 +183,11 @@ namespace Xwt.GtkBackend
 			version++;
 			IterPos tpos = GetIterPos (pos);
 			var p = Tree.InsertNodeBefore (tpos.Iter);
-			return new IterPos (version, p);
+
+			var node = new IterPos (version, p);
+			if (NodeInserted != null)
+				NodeInserted (this, new TreeNodeEventArgs (node));
+			return node;
 		}
 
 		public TreePosition InsertAfter (TreePosition pos)
@@ -192,7 +195,11 @@ namespace Xwt.GtkBackend
 			version++;
 			IterPos tpos = GetIterPos (pos);
 			var p = Tree.InsertNodeAfter (tpos.Iter);
-			return new IterPos (version, p);
+
+			var node = new IterPos (version, p);
+			if (NodeInserted != null)
+				NodeInserted (this, new TreeNodeEventArgs (node));
+			return node;
 		}
 
 		public TreePosition AddChild (TreePosition pos)
@@ -204,7 +211,11 @@ namespace Xwt.GtkBackend
 				it = Tree.AppendNode ();
 			else
 				it = Tree.AppendNode (tpos.Iter);
-			return new IterPos (version, it);
+
+			var node = new IterPos (version, it);
+			if (NodeInserted != null)
+				NodeInserted (this, new TreeNodeEventArgs (node));
+			return node;
 		}
 		
 		public void Remove (TreePosition pos)
@@ -212,7 +223,10 @@ namespace Xwt.GtkBackend
 			version++;
 			IterPos tpos = GetIterPos (pos);
 			Gtk.TreeIter it = tpos.Iter;
+			var eventArgs = new TreeNodeChildEventArgs (GetParent (tpos), -1);
 			Tree.Remove (ref it);
+			if (NodeDeleted != null)
+				NodeDeleted (this, eventArgs);
 		}
 
 		public TreePosition GetNext (TreePosition pos)
@@ -246,12 +260,6 @@ namespace Xwt.GtkBackend
 			if (!Tree.IterParent (out it, tpos.Iter))
 				return null;
 			return new IterPos (version, it);
-		}
-		
-		public Type[] ColumnTypes {
-			get {
-				return columnTypes;
-			}
 		}
 		
 		public void EnableEvent (object eventId)

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
@@ -155,6 +155,18 @@ namespace Xwt.GtkBackend
 			return tpos.ChildrenCount = Tree.IterNChildren (tpos.Iter);
 		}
 
+		public int GetParentChildIndex (TreePosition pos)
+		{
+			if (pos == null)
+				return -1;
+
+			IterPos tpos = GetIterPos (pos);
+			var path = Store.GetPath (tpos.Iter);
+			if (path != null)
+				return path.Indices [path.Depth - 1];
+			return -1;
+		}
+
 		public void SetValue (TreePosition pos, int column, object value)
 		{
 			IterPos tpos = GetIterPos (pos);

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeStoreFilterBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeStoreFilterBackend.cs
@@ -1,0 +1,189 @@
+﻿//
+// TreeStoreFilterBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Gtk;
+using Xwt.Backends;
+
+
+#if XWT_GTK3
+using TreeDragDest = Gtk.ITreeDragDest;
+using TreeDragDestImplementor = Gtk.ITreeDragDestImplementor;
+using TreeModel = Gtk.ITreeModel;
+#endif
+
+namespace Xwt.GtkBackend
+{
+	public class TreeStoreFilterBackend: TreeStoreBackendBase, ITreeStoreFilterBackend
+	{
+		public CustomTreeModelFilter FilterTree {
+			get { return (CustomTreeModelFilter) Store; }
+		}
+
+		public TreeModel ChildModel {
+			get;
+			private set;
+		}
+
+		public void Initialize (ITreeDataSource store)
+		{
+			var xwtComponent = store as XwtComponent;
+			if (xwtComponent != null) {
+				var backend = xwtComponent.GetBackend () as TreeStoreBackend;
+				if (backend != null)
+					ChildModel = backend.Store;
+			}
+			if (ChildModel == null)
+				ChildModel = new CustomTreeModel (store).Store;
+
+			base.Initialize (store.ColumnTypes);
+		}
+
+		public override TreeModel InitializeModel (Type[] columnTypes)
+		{
+			if (ChildModel == null) {
+				var def = new TreeStoreBackend ();
+				def.Initialize (columnTypes);
+				ChildModel = def.Store;
+			}
+
+			var filterTree = new CustomTreeModelFilter(ChildModel, null);
+
+			filterTree.VisibleFunc = VisibleFunc;
+
+			ChildModel.RowDeleted += (o, args) => InvalidateTree ();
+			ChildModel.RowInserted += (o, args) => InvalidateTree ();
+			ChildModel.RowsReordered += (o, args) => InvalidateTree ();
+
+			return filterTree;
+		}
+
+		Func<TreePosition, bool> filterFunct;
+		public Func<TreePosition, bool> FilterFunction {
+			set {
+				filterFunct = value;
+			}
+		}
+
+		bool VisibleFunc (TreeModel rawModel, TreeIter iter)
+		{
+			if (filterFunct != null)
+				return !filterFunct (new IterPos(-1, iter));
+			return true;
+		}
+
+		public void Refilter ()
+		{
+			FilterTree.Refilter ();
+		}
+
+		public TreePosition ConvertChildPositionToPosition (TreePosition pos)
+		{
+			var iter = FilterTree.ConvertChildIterToIter (((IterPos) pos).Iter);
+			if (iter.Equals (Gtk.TreeIter.Zero))
+				return null;
+			return new IterPos(Version, iter);
+		}
+
+		public TreePosition ConvertPositionToChildPosition (TreePosition pos)
+		{
+			var iter = ((IterPos)pos).Iter;
+			if (iter.Equals (Gtk.TreeIter.Zero))
+				return null;
+			iter = FilterTree.ConvertIterToChildIter (iter);
+			if (iter.Equals (Gtk.TreeIter.Zero))
+				return null;
+			return new IterPos(-1, iter);
+		}
+	}
+
+	public class CustomTreeModelFilter : Gtk.TreeModelFilter, TreeDragDestImplementor, TreeModel
+	{
+		public CustomTreeModelFilter (TreeModel childModel, TreePath root) : base (childModel, root)
+		{
+		}
+
+		void TreeModel.SetValue (TreeIter iter, int column, object value)
+		{
+			var it = ConvertIterToChildIter (iter);
+			ChildModel.SetValue (it, column, value);
+		}
+
+		void TreeModel.SetValue (TreeIter iter, int column, double value)
+		{
+			var it = ConvertIterToChildIter (iter);
+			ChildModel.SetValue (it, column, value);
+		}
+
+		void TreeModel.SetValue (TreeIter iter, int column, bool value)
+		{
+			var it = ConvertIterToChildIter (iter);
+			ChildModel.SetValue (it, column, value);
+		}
+
+		void TreeModel.SetValue (TreeIter iter, int column, string value)
+		{
+			var it = ConvertIterToChildIter (iter);
+			ChildModel.SetValue (it, column, value);
+		}
+
+		void TreeModel.SetValue (TreeIter iter, int column, float value)
+		{
+			var it = ConvertIterToChildIter (iter);
+			ChildModel.SetValue (it, column, value);
+		}
+
+		void TreeModel.SetValue (TreeIter iter, int column, uint value)
+		{
+			var it = ConvertIterToChildIter (iter);
+			ChildModel.SetValue (it, column, value);
+		}
+
+		void TreeModel.SetValue (TreeIter iter, int column, int value)
+		{
+			var it = ConvertIterToChildIter (iter);
+			ChildModel.SetValue (it, column, value);
+		}
+
+		public bool DragDataReceived (TreePath dest, SelectionData selection_data)
+		{
+			var child = Model as TreeDragDest;
+
+			if (child != null)
+				return child.DragDataReceived (ConvertPathToChildPath (dest), selection_data);
+			return false;
+		}
+
+		public bool RowDropPossible (TreePath dest_path, SelectionData selection_data)
+		{
+			var child = ChildModel as TreeDragDest;
+
+			if (child != null)
+				return child.DragDataReceived (ConvertPathToChildPath (dest_path), selection_data);
+			return false;
+		}
+	}
+}
+

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
@@ -193,7 +193,7 @@ namespace Xwt.GtkBackend
 		
 		public void SetSource (ITreeDataSource source, IBackend sourceBackend)
 		{
-			TreeStoreBackend b = sourceBackend as TreeStoreBackend;
+			TreeStoreBackendBase b = sourceBackend as TreeStoreBackendBase;
 			if (b == null) {
 				CustomTreeModel model = new CustomTreeModel (source);
 				Widget.Model = model.Store;

--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -102,7 +102,10 @@ namespace Xwt.Mac
 			RegisterBackend <Xwt.Backends.IAlertDialogBackend, AlertDialogBackend> ();
 			RegisterBackend <Xwt.Backends.IStatusIconBackend, StatusIconBackend> ();
 			RegisterBackend <Xwt.Backends.IProgressBarBackend, ProgressBarBackend> ();
+			RegisterBackend <Xwt.Backends.ITreeStoreBackend, Xwt.DefaultTreeStoreBackend> ();
+			RegisterBackend <Xwt.Backends.ITreeStoreFilterBackend, Xwt.DefaultTreeStoreFilterBackend> ();
 			RegisterBackend <Xwt.Backends.IListStoreBackend, Xwt.DefaultListStoreBackend> ();
+			RegisterBackend <Xwt.Backends.IListStoreFilterBackend, Xwt.DefaultListStoreFilterBackend> ();
 			RegisterBackend <Xwt.Backends.ILinkLabelBackend, LinkLabelBackend> ();
 			RegisterBackend <Xwt.Backends.ISpinnerBackend, SpinnerBackend> ();
 			RegisterBackend <Xwt.Backends.ISpinButtonBackend, SpinButtonBackend> ();

--- a/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
@@ -85,6 +85,16 @@ namespace Xwt.WPFBackend
 			return GetListForNode ((TreeStoreNode) pos).Count;
 		}
 
+		public int GetParentChildIndex (TreePosition pos)
+		{
+			var node = (TreeStoreNode) pos;
+
+			var list = GetContainingList (node);
+			int index = list.IndexOf (node);
+
+			return index;
+		}
+
 		public object GetValue (TreePosition pos, int column)
 		{
 			return ((TreeStoreNode) pos)[column];

--- a/Xwt/Xwt.Backends/IListStoreBackend.cs
+++ b/Xwt/Xwt.Backends/IListStoreBackend.cs
@@ -87,5 +87,40 @@ namespace Xwt.Backends
 		/// </summary>
 		void Clear ();
 	}
+
+	public interface IListStoreFilterBackend: IListDataSource, IBackend
+	{
+		/// <summary>
+		/// Initializes the backend with the given <paramref name="store"/>.
+		/// </summary>
+		/// <param name="store">The list data store to pass through the filter.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="store"/> is <c>null</c>.</exception>
+		void Initialize (IListDataSource store);
+
+		/// <summary>
+		/// Sets the filter function to filter displayed rows.
+		/// </summary>
+		/// <value>The filter function.</value>
+		Func<int, bool> FilterFunction { set; }
+
+		/// <summary>
+		/// Refilter this instance.
+		/// </summary>
+		void Refilter();
+
+		/// <summary>
+		/// Converts the row index from the child store to its index inside the filter store.
+		/// </summary>
+		/// <returns>The index of the row inside the filtered store, or -1 if the row has been filtered.</returns>
+		/// <param name="row">The child store index to convert</param>
+		int ConvertChildPositionToPosition (int row);
+
+		/// <summary>
+		/// Converts the row index from the filter store to its index inside the child store.
+		/// </summary>
+		/// <returns>The index of the row inside the child store.</returns>
+		/// <param name="row">The filter store index to convert.</param>
+		int ConvertPositionToChildPosition (int row);
+	}
 }
 

--- a/Xwt/Xwt.Backends/ITreeStoreBackend.cs
+++ b/Xwt/Xwt.Backends/ITreeStoreBackend.cs
@@ -41,8 +41,6 @@ namespace Xwt.Backends
 		TreePosition InsertAfter (TreePosition pos);
 		TreePosition AddChild (TreePosition pos);
 		void Remove (TreePosition pos);
-		TreePosition GetNext (TreePosition pos);
-		TreePosition GetPrevious (TreePosition pos);
 		void Clear ();
 	}
 }

--- a/Xwt/Xwt.Backends/ITreeStoreBackend.cs
+++ b/Xwt/Xwt.Backends/ITreeStoreBackend.cs
@@ -43,5 +43,43 @@ namespace Xwt.Backends
 		void Remove (TreePosition pos);
 		void Clear ();
 	}
+
+	public interface ITreeStoreFilterBackend: ITreeDataSource, IBackend
+	{
+		/// <summary>
+		/// Initializes the backend with the given <paramref name="store"/>.
+		/// </summary>
+		/// <param name="store">The tree data store to pass through the filter.</param>
+		/// <exception cref="ArgumentNullException"><paramref name="store"/> is <c>null</c>.</exception>
+		void Initialize (ITreeDataSource store);
+
+		/// <summary>
+		/// Sets the filter function, which should be used to filter single nodes.
+		/// </summary>
+		/// <value>The filter function.</value>
+		/// <remarks>
+		/// The function must return <c>true</c> for nodes to be filtered (hidden).
+		/// The position of the node to apply the filter function on is passed as the parameter to the function.
+		Func<TreePosition, bool> FilterFunction { set; }
+
+		/// <summary>
+		/// Forces the filter store to re-evaluate all nodes in the child store.
+		/// </summary>
+		void Refilter();
+
+		/// <summary>
+		/// Converts the node position from the child store to its position inside the filter store.
+		/// </summary>
+		/// <returns>The position of the node inside the filtered store, or null if the row has been filtered.</returns>
+		/// <param name="pos">The child store position to convert</param>
+		TreePosition ConvertChildPositionToPosition (TreePosition pos);
+
+		/// <summary>
+		/// Converts the node position from the filter store to its position inside the child store.
+		/// </summary>
+		/// <returns>The position of the node inside the child store.</returns>
+		/// <param name="pos">The filter store position to convert.</param>
+		TreePosition ConvertPositionToChildPosition (TreePosition pos);
+	}
 }
 

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -327,6 +327,7 @@
     <Compile Include="Xwt\XwtSynchronizationContext.cs" />
     <Compile Include="Xwt\TreeViewNavigator.cs" />
     <Compile Include="Xwt\ListStoreBase.cs" />
+    <Compile Include="Xwt\TreeStoreBase.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -328,6 +328,7 @@
     <Compile Include="Xwt\TreeViewNavigator.cs" />
     <Compile Include="Xwt\ListStoreBase.cs" />
     <Compile Include="Xwt\TreeStoreBase.cs" />
+    <Compile Include="Xwt\ListStoreFilter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -329,6 +329,7 @@
     <Compile Include="Xwt\ListStoreBase.cs" />
     <Compile Include="Xwt\TreeStoreBase.cs" />
     <Compile Include="Xwt\ListStoreFilter.cs" />
+    <Compile Include="Xwt\TreeStoreFilter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -325,6 +325,7 @@
     <Compile Include="Xwt\ColorPicker.cs" />
     <Compile Include="Xwt.Backends\IColorPickerBackend.cs" />
     <Compile Include="Xwt\XwtSynchronizationContext.cs" />
+    <Compile Include="Xwt\TreeViewNavigator.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -326,6 +326,7 @@
     <Compile Include="Xwt.Backends\IColorPickerBackend.cs" />
     <Compile Include="Xwt\XwtSynchronizationContext.cs" />
     <Compile Include="Xwt\TreeViewNavigator.cs" />
+    <Compile Include="Xwt\ListStoreBase.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt/ITreeDataSource.cs
+++ b/Xwt/Xwt/ITreeDataSource.cs
@@ -35,7 +35,10 @@ namespace Xwt
 	{
 		TreePosition GetParent (TreePosition pos);
 		TreePosition GetChild (TreePosition pos, int index);
+		TreePosition GetNext (TreePosition pos);
+		TreePosition GetPrevious (TreePosition pos);
 		int GetChildrenCount (TreePosition pos);
+		int GetParentChildIndex (TreePosition pos);
 		object GetValue (TreePosition pos, int column);
 		void SetValue (TreePosition pos, int column, object value);
 		Type[] ColumnTypes { get; }

--- a/Xwt/Xwt/ListStore.cs
+++ b/Xwt/Xwt/ListStore.cs
@@ -25,18 +25,18 @@
 // THE SOFTWARE.
 
 using System;
-using Xwt.Backends;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
+using Xwt.Backends;
 
 
 namespace Xwt
 {
 	[BackendType (typeof(IListStoreBackend))]
-	public class ListStore: XwtComponent, IListDataSource
+	public class ListStore: ListStoreBase
 	{
 		IDataField[] fields;
-		
+
 		class ListStoreBackendHost: BackendHost<ListStore,IListStoreBackend>
 		{
 			protected override IBackend OnCreateBackend ()
@@ -54,7 +54,7 @@ namespace Xwt
 			}
 		}
 		
-		protected override Xwt.Backends.BackendHost CreateBackendHost ()
+		protected override BackendHost CreateBackendHost ()
 		{
 			return new ListStoreBackendHost ();
 		}
@@ -76,212 +76,15 @@ namespace Xwt
 		public ListStore ()
 		{
 		}
-		
-		public int RowCount {
-			get {
-				return Backend.RowCount;
-			}
-		}
-		
-		public T GetValue<T> (int row, IDataField<T> column)
+
+		protected override Type[] GetColumnTypes ()
 		{
-			return (T) Backend.GetValue (row, column.Index);
-		}
-		
-		public void SetValue<T> (int row, IDataField<T> column, T value)
-		{
-			Backend.SetValue (row, column.Index, value);
-		}
-		
-		object IListDataSource.GetValue (int row, int column)
-		{
-			return Backend.GetValue (row, column);
-		}
-		
-		void IListDataSource.SetValue (int row, int column, object value)
-		{
-			Backend.SetValue (row, column, value);
-		}
-		
-		Type[] IListDataSource.ColumnTypes {
-			get {
-				return Backend.ColumnTypes;
-			}
-		}
-		
-		event EventHandler<ListRowEventArgs> IListDataSource.RowInserted {
-			add { Backend.RowInserted += value; }
-			remove { Backend.RowInserted -= value; }
-		}
-		event EventHandler<ListRowEventArgs> IListDataSource.RowDeleted {
-			add { Backend.RowDeleted += value; }
-			remove { Backend.RowDeleted -= value; }
-		}
-		event EventHandler<ListRowEventArgs> IListDataSource.RowChanged {
-			add { Backend.RowChanged += value; }
-			remove { Backend.RowChanged -= value; }
-		}
-		event EventHandler<ListRowOrderEventArgs> IListDataSource.RowsReordered {
-			add { Backend.RowsReordered += value; }
-			remove { Backend.RowsReordered -= value; }
+			return fields.Select (f => f.FieldType).ToArray ();
 		}
 		
 		public int AddRow ()
 		{
 			return Backend.AddRow ();
-		}
-		
-		public void SetValues<T1,T2> (int row, IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2)
-		{
-			SetValue (row, column1, value1);
-			SetValue (row, column2, value2);
-		}
-
-		public void SetValues<T1,T2,T3> (int row, IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2, IDataField<T3> column3, T3 value3)
-		{
-			SetValue (row, column1, value1);
-			SetValue (row, column2, value2);
-			SetValue (row, column3, value3);
-		}
-
-		public void SetValues<T1,T2,T3,T4> (
-			int row, 
-			IDataField<T1> column1, T1 value1, 
-			IDataField<T2> column2, T2 value2, 
-			IDataField<T3> column3, T3 value3,
-			IDataField<T4> column4, T4 value4
-		)
-		{
-			SetValue (row, column1, value1);
-			SetValue (row, column2, value2);
-			SetValue (row, column3, value3);
-			SetValue (row, column4, value4);
-		}
-
-		public void SetValues<T1,T2,T3,T4,T5> (
-			int row, 
-			IDataField<T1> column1, T1 value1, 
-			IDataField<T2> column2, T2 value2, 
-			IDataField<T3> column3, T3 value3,
-			IDataField<T4> column4, T4 value4,
-			IDataField<T5> column5, T5 value5
-		)
-		{
-			SetValue (row, column1, value1);
-			SetValue (row, column2, value2);
-			SetValue (row, column3, value3);
-			SetValue (row, column4, value4);
-			SetValue (row, column5, value5);
-		}
-
-		public void SetValues<T1,T2,T3,T4,T5,T6> (
-			int row, 
-			IDataField<T1> column1, T1 value1, 
-			IDataField<T2> column2, T2 value2, 
-			IDataField<T3> column3, T3 value3,
-			IDataField<T4> column4, T4 value4,
-			IDataField<T5> column5, T5 value5,
-			IDataField<T6> column6, T6 value6
-		)
-		{
-			SetValue (row, column1, value1);
-			SetValue (row, column2, value2);
-			SetValue (row, column3, value3);
-			SetValue (row, column4, value4);
-			SetValue (row, column5, value5);
-			SetValue (row, column6, value6);
-		}
-
-		public void SetValues<T1,T2,T3,T4,T5,T6,T7> (
-			int row, 
-			IDataField<T1> column1, T1 value1, 
-			IDataField<T2> column2, T2 value2, 
-			IDataField<T3> column3, T3 value3,
-			IDataField<T4> column4, T4 value4,
-			IDataField<T5> column5, T5 value5,
-			IDataField<T6> column6, T6 value6,
-			IDataField<T7> column7, T7 value7
-		)
-		{
-			SetValue (row, column1, value1);
-			SetValue (row, column2, value2);
-			SetValue (row, column3, value3);
-			SetValue (row, column4, value4);
-			SetValue (row, column5, value5);
-			SetValue (row, column6, value6);
-			SetValue (row, column7, value7);
-		}
-
-		public void SetValues<T1,T2,T3,T4,T5,T6,T7,T8> (
-			int row, 
-			IDataField<T1> column1, T1 value1, 
-			IDataField<T2> column2, T2 value2, 
-			IDataField<T3> column3, T3 value3,
-			IDataField<T4> column4, T4 value4,
-			IDataField<T5> column5, T5 value5,
-			IDataField<T6> column6, T6 value6,
-			IDataField<T7> column7, T7 value7,
-			IDataField<T8> column8, T8 value8
-		)
-		{
-			SetValue (row, column1, value1);
-			SetValue (row, column2, value2);
-			SetValue (row, column3, value3);
-			SetValue (row, column4, value4);
-			SetValue (row, column5, value5);
-			SetValue (row, column6, value6);
-			SetValue (row, column7, value7);
-			SetValue (row, column8, value8);
-		}
-
-		public void SetValues<T1,T2,T3,T4,T5,T6,T7,T8,T9> (
-			int row, 
-			IDataField<T1> column1, T1 value1, 
-			IDataField<T2> column2, T2 value2, 
-			IDataField<T3> column3, T3 value3,
-			IDataField<T4> column4, T4 value4,
-			IDataField<T5> column5, T5 value5,
-			IDataField<T6> column6, T6 value6,
-			IDataField<T7> column7, T7 value7,
-			IDataField<T8> column8, T8 value8,
-			IDataField<T9> column9, T9 value9
-		)
-		{
-			SetValue (row, column1, value1);
-			SetValue (row, column2, value2);
-			SetValue (row, column3, value3);
-			SetValue (row, column4, value4);
-			SetValue (row, column5, value5);
-			SetValue (row, column6, value6);
-			SetValue (row, column7, value7);
-			SetValue (row, column8, value8);
-			SetValue (row, column9, value9);
-		}
-
-		public void SetValues<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10> (
-			int row, 
-			IDataField<T1> column1, T1 value1, 
-			IDataField<T2> column2, T2 value2, 
-			IDataField<T3> column3, T3 value3,
-			IDataField<T4> column4, T4 value4,
-			IDataField<T5> column5, T5 value5,
-			IDataField<T6> column6, T6 value6,
-			IDataField<T7> column7, T7 value7,
-			IDataField<T8> column8, T8 value8,
-			IDataField<T9> column9, T9 value9,
-			IDataField<T10> column10, T10 value10
-		)
-		{
-			SetValue (row, column1, value1);
-			SetValue (row, column2, value2);
-			SetValue (row, column3, value3);
-			SetValue (row, column4, value4);
-			SetValue (row, column5, value5);
-			SetValue (row, column6, value6);
-			SetValue (row, column7, value7);
-			SetValue (row, column8, value8);
-			SetValue (row, column9, value9);
-			SetValue (row, column10, value10);
 		}
 
 		public int InsertRowAfter (int row)

--- a/Xwt/Xwt/ListStore.cs
+++ b/Xwt/Xwt/ListStore.cs
@@ -39,6 +39,14 @@ namespace Xwt
 		
 		class ListStoreBackendHost: BackendHost<ListStore,IListStoreBackend>
 		{
+			protected override IBackend OnCreateBackend ()
+			{
+				var b = base.OnCreateBackend ();
+				if (b == null)
+					b = new DefaultListStoreBackend ();
+				return b;
+			}
+
 			protected override void OnBackendCreated ()
 			{
 				Backend.Initialize (Parent.fields.Select (f => f.FieldType).ToArray ());

--- a/Xwt/Xwt/ListStoreBase.cs
+++ b/Xwt/Xwt/ListStoreBase.cs
@@ -1,0 +1,241 @@
+﻿//
+// ListStoreBase.cs
+//
+// Author:
+//       Lluis Sanchez <lluis@xamarin.com>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace Xwt
+{
+	public abstract class ListStoreBase: XwtComponent, IListDataSource
+	{
+		protected abstract Type[] GetColumnTypes();
+		
+		IListDataSource Backend {
+			get { return (IListDataSource) BackendHost.Backend; }
+		}
+		
+		public int RowCount {
+			get {
+				return Backend.RowCount;
+			}
+		}
+		
+		public T GetValue<T> (int row, IDataField<T> column)
+		{
+			return (T) Backend.GetValue (row, column.Index);
+		}
+		
+		public void SetValue<T> (int row, IDataField<T> column, T value)
+		{
+			Backend.SetValue (row, column.Index, value);
+		}
+		
+		object IListDataSource.GetValue (int row, int column)
+		{
+			return Backend.GetValue (row, column);
+		}
+		
+		void IListDataSource.SetValue (int row, int column, object value)
+		{
+			Backend.SetValue (row, column, value);
+		}
+		
+		Type[] IListDataSource.ColumnTypes {
+			get {
+				return GetColumnTypes();
+			}
+		}
+		
+		event EventHandler<ListRowEventArgs> IListDataSource.RowInserted {
+			add { Backend.RowInserted += value; }
+			remove { Backend.RowInserted -= value; }
+		}
+		event EventHandler<ListRowEventArgs> IListDataSource.RowDeleted {
+			add { Backend.RowDeleted += value; }
+			remove { Backend.RowDeleted -= value; }
+		}
+		event EventHandler<ListRowEventArgs> IListDataSource.RowChanged {
+			add { Backend.RowChanged += value; }
+			remove { Backend.RowChanged -= value; }
+		}
+		event EventHandler<ListRowOrderEventArgs> IListDataSource.RowsReordered {
+			add { Backend.RowsReordered += value; }
+			remove { Backend.RowsReordered -= value; }
+		}
+
+		public void SetValues<T1,T2> (int row, IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2)
+		{
+			SetValue (row, column1, value1);
+			SetValue (row, column2, value2);
+		}
+
+		public void SetValues<T1,T2,T3> (int row, IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2, IDataField<T3> column3, T3 value3)
+		{
+			SetValue (row, column1, value1);
+			SetValue (row, column2, value2);
+			SetValue (row, column3, value3);
+		}
+
+		public void SetValues<T1,T2,T3,T4> (
+			int row, 
+			IDataField<T1> column1, T1 value1, 
+			IDataField<T2> column2, T2 value2, 
+			IDataField<T3> column3, T3 value3,
+			IDataField<T4> column4, T4 value4
+		)
+		{
+			SetValue (row, column1, value1);
+			SetValue (row, column2, value2);
+			SetValue (row, column3, value3);
+			SetValue (row, column4, value4);
+		}
+
+		public void SetValues<T1,T2,T3,T4,T5> (
+			int row, 
+			IDataField<T1> column1, T1 value1, 
+			IDataField<T2> column2, T2 value2, 
+			IDataField<T3> column3, T3 value3,
+			IDataField<T4> column4, T4 value4,
+			IDataField<T5> column5, T5 value5
+		)
+		{
+			SetValue (row, column1, value1);
+			SetValue (row, column2, value2);
+			SetValue (row, column3, value3);
+			SetValue (row, column4, value4);
+			SetValue (row, column5, value5);
+		}
+
+		public void SetValues<T1,T2,T3,T4,T5,T6> (
+			int row, 
+			IDataField<T1> column1, T1 value1, 
+			IDataField<T2> column2, T2 value2, 
+			IDataField<T3> column3, T3 value3,
+			IDataField<T4> column4, T4 value4,
+			IDataField<T5> column5, T5 value5,
+			IDataField<T6> column6, T6 value6
+		)
+		{
+			SetValue (row, column1, value1);
+			SetValue (row, column2, value2);
+			SetValue (row, column3, value3);
+			SetValue (row, column4, value4);
+			SetValue (row, column5, value5);
+			SetValue (row, column6, value6);
+		}
+
+		public void SetValues<T1,T2,T3,T4,T5,T6,T7> (
+			int row, 
+			IDataField<T1> column1, T1 value1, 
+			IDataField<T2> column2, T2 value2, 
+			IDataField<T3> column3, T3 value3,
+			IDataField<T4> column4, T4 value4,
+			IDataField<T5> column5, T5 value5,
+			IDataField<T6> column6, T6 value6,
+			IDataField<T7> column7, T7 value7
+		)
+		{
+			SetValue (row, column1, value1);
+			SetValue (row, column2, value2);
+			SetValue (row, column3, value3);
+			SetValue (row, column4, value4);
+			SetValue (row, column5, value5);
+			SetValue (row, column6, value6);
+			SetValue (row, column7, value7);
+		}
+
+		public void SetValues<T1,T2,T3,T4,T5,T6,T7,T8> (
+			int row, 
+			IDataField<T1> column1, T1 value1, 
+			IDataField<T2> column2, T2 value2, 
+			IDataField<T3> column3, T3 value3,
+			IDataField<T4> column4, T4 value4,
+			IDataField<T5> column5, T5 value5,
+			IDataField<T6> column6, T6 value6,
+			IDataField<T7> column7, T7 value7,
+			IDataField<T8> column8, T8 value8
+		)
+		{
+			SetValue (row, column1, value1);
+			SetValue (row, column2, value2);
+			SetValue (row, column3, value3);
+			SetValue (row, column4, value4);
+			SetValue (row, column5, value5);
+			SetValue (row, column6, value6);
+			SetValue (row, column7, value7);
+			SetValue (row, column8, value8);
+		}
+
+		public void SetValues<T1,T2,T3,T4,T5,T6,T7,T8,T9> (
+			int row, 
+			IDataField<T1> column1, T1 value1, 
+			IDataField<T2> column2, T2 value2, 
+			IDataField<T3> column3, T3 value3,
+			IDataField<T4> column4, T4 value4,
+			IDataField<T5> column5, T5 value5,
+			IDataField<T6> column6, T6 value6,
+			IDataField<T7> column7, T7 value7,
+			IDataField<T8> column8, T8 value8,
+			IDataField<T9> column9, T9 value9
+		)
+		{
+			SetValue (row, column1, value1);
+			SetValue (row, column2, value2);
+			SetValue (row, column3, value3);
+			SetValue (row, column4, value4);
+			SetValue (row, column5, value5);
+			SetValue (row, column6, value6);
+			SetValue (row, column7, value7);
+			SetValue (row, column8, value8);
+			SetValue (row, column9, value9);
+		}
+
+		public void SetValues<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10> (
+			int row, 
+			IDataField<T1> column1, T1 value1, 
+			IDataField<T2> column2, T2 value2, 
+			IDataField<T3> column3, T3 value3,
+			IDataField<T4> column4, T4 value4,
+			IDataField<T5> column5, T5 value5,
+			IDataField<T6> column6, T6 value6,
+			IDataField<T7> column7, T7 value7,
+			IDataField<T8> column8, T8 value8,
+			IDataField<T9> column9, T9 value9,
+			IDataField<T10> column10, T10 value10
+		)
+		{
+			SetValue (row, column1, value1);
+			SetValue (row, column2, value2);
+			SetValue (row, column3, value3);
+			SetValue (row, column4, value4);
+			SetValue (row, column5, value5);
+			SetValue (row, column6, value6);
+			SetValue (row, column7, value7);
+			SetValue (row, column8, value8);
+			SetValue (row, column9, value9);
+			SetValue (row, column10, value10);
+		}
+	}
+}
+

--- a/Xwt/Xwt/ListStoreFilter.cs
+++ b/Xwt/Xwt/ListStoreFilter.cs
@@ -1,0 +1,280 @@
+﻿//
+// ListStoreFilter.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt.Backends;
+using System.Collections.Generic;
+
+namespace Xwt
+{
+	/// <summary>
+	/// List store filter.
+	/// </summary>
+	[BackendType (typeof(IListStoreFilterBackend))]
+	public class ListStoreFilter: ListStoreBase
+	{
+		public IListDataSource ChildStore {
+			get;
+			private set;
+		}
+
+		class ListStoreFilterBackendHost: BackendHost<ListStoreFilter,IListStoreFilterBackend>
+		{
+			protected override IBackend OnCreateBackend ()
+			{
+				var b = base.OnCreateBackend ();
+				if (b == null)
+					b = new DefaultListStoreFilterBackend ();
+				((IListStoreFilterBackend)b).Initialize (Parent.ChildStore);
+				return b;
+			}
+
+			protected override void OnBackendCreated ()
+			{
+				Backend.Initialize (Parent.ChildStore);
+				base.OnBackendCreated ();
+			}
+		}
+
+		protected override BackendHost CreateBackendHost ()
+		{
+			return new ListStoreFilterBackendHost ();
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.ListStoreFilter"/> class.
+		/// </summary>
+		/// <param name="store">The list data store to pass through the filter.</param>
+		public ListStoreFilter (IListDataSource store)
+		{
+			ChildStore = store;
+		}
+
+		IListStoreFilterBackend Backend {
+			get { return (IListStoreFilterBackend) BackendHost.Backend; }
+		}
+
+		protected override Type[] GetColumnTypes ()
+		{
+			return ChildStore.ColumnTypes;
+		}
+
+		/// <summary>
+		/// Sets the filter function, which should be used to filter single rows.
+		/// </summary>
+		/// <value>The filter function.</value>
+		/// <remarks>
+		/// The function must return <c>true</c> for rows to be filtered (hidden).
+		/// The index of the row to apply the filter function on is passed as the parameter to the function.
+		/// </remarks>
+		public Func<int, bool> FilterFunction {
+			set {
+				Backend.FilterFunction = value;
+			}
+		}
+
+		/// <summary>
+		/// Converts the row index from the child store to its index inside the filter store.
+		/// </summary>
+		/// <returns>The index of the row inside the filtered store, or -1 if the row has been filtered.</returns>
+		/// <param name="row">The child store index to convert</param>
+		public int ConvertChildPositionToPosition (int row)
+		{
+			return Backend.ConvertChildPositionToPosition (row);
+		}
+
+		/// <summary>
+		/// Converts the row index from the filter store to its index inside the child store.
+		/// </summary>
+		/// <returns>The index of the row inside the child store.</returns>
+		/// <param name="row">The filter store index to convert.</param>
+		public int ConvertPositionToChildPosition (int row)
+		{
+			return Backend.ConvertPositionToChildPosition (row);
+		}
+
+		/// <summary>
+		/// Forces the filter store to re-evaluate all rows in the child store.
+		/// </summary>
+		public void Refilter()
+		{
+			Backend.Refilter ();
+		}
+	}
+
+	public class DefaultListStoreFilterBackend: IListStoreFilterBackend
+	{
+
+		List<int> list = new List<int> ();
+
+		public event EventHandler<ListRowEventArgs> RowInserted;
+		public event EventHandler<ListRowEventArgs> RowDeleted;
+		public event EventHandler<ListRowEventArgs> RowChanged;
+		public event EventHandler<ListRowOrderEventArgs> RowsReordered;
+
+		public void InitializeBackend (object frontend, ApplicationContext context)
+		{
+		}
+
+		IListDataSource childStore;
+		public IListDataSource ChildStore {
+			get {
+				return childStore;
+			}
+		}
+
+		public void Initialize (IListDataSource store)
+		{
+			if (store == null)
+				throw new ArgumentNullException ("store");
+			childStore = store;
+			childStore.RowChanged += HandleRowChanged;
+			childStore.RowDeleted += HandleRowDeleted;
+			childStore.RowInserted += HandleRowInserted;
+			childStore.RowsReordered += HandleRowsReordered;
+			Refilter ();
+		}
+
+		void HandleRowsReordered (object sender, ListRowOrderEventArgs e)
+		{
+			Refilter();
+			int row = ConvertChildPositionToPosition (e.Row);
+			if (row >= 0 && RowChanged != null)
+				RowChanged (this, new ListRowEventArgs (row));
+		}
+
+		void HandleRowInserted (object sender, ListRowEventArgs e)
+		{
+			Refilter();
+			int row = ConvertChildPositionToPosition (e.Row);
+			if (row >= 0 && RowInserted != null)
+				RowInserted (this, new ListRowEventArgs (row));
+		}
+
+		void HandleRowDeleted (object sender, ListRowEventArgs e)
+		{
+			int row = ConvertChildPositionToPosition (e.Row);
+			Refilter ();
+			if (row >= 0 && RowDeleted != null)
+				RowDeleted (this, new ListRowEventArgs (row));
+		}
+
+		void HandleRowChanged (object sender, ListRowEventArgs e)
+		{
+			if (filterFunction == null)
+				return;
+
+			int row = ConvertChildPositionToPosition (e.Row);
+			bool filter = filterFunction (e.Row);
+			if (row < 0 && !filter) {
+				for (int i = 0; i <= list.Count; i++) {
+					if (i == list.Count || list [i] > e.Row) {
+						list.Insert (i, e.Row);
+						if (RowInserted != null)
+							RowInserted (this, new ListRowEventArgs (i));
+					}
+				}
+			}else if (row >= 0 && filter) {
+				list.RemoveAt (row);
+				if (RowDeleted != null)
+					RowDeleted (this, new ListRowEventArgs (row));
+			} else 
+				if (row >= 0 && RowChanged != null)
+					RowChanged (this, new ListRowEventArgs (row));
+		}
+
+		public void Refilter ()
+		{
+
+			list.Clear ();
+
+			for (int i = 0; i < ChildStore.RowCount; i++) {
+				if (filterFunction != null && !filterFunction(i)) {
+					list.Add (i);
+				}
+			}
+			if (RowsReordered != null)
+				RowsReordered (this, new ListRowOrderEventArgs (-1, new int[] {}));
+		}
+
+		Func<int, bool> filterFunction;
+		public Func<int, bool> FilterFunction {
+			set {
+				filterFunction = value;
+				Refilter ();
+			}
+		}
+
+		public int ConvertChildPositionToPosition (int row)
+		{
+			return list.IndexOf (row);
+		}
+
+		public int ConvertPositionToChildPosition (int row)
+		{
+			if (row >= 0 && row < list.Count)
+				return list [row];
+			return -1;
+		}
+
+		public object GetValue (int row, int column)
+		{
+			var childPos = ConvertPositionToChildPosition (row);
+			if (childPos >= 0)
+				return ChildStore.GetValue (childPos, column);
+			return null;
+		}
+
+		public void SetValue (int row, int column, object value)
+		{
+			var childPos = ConvertPositionToChildPosition (row);
+			if (childPos >= 0)
+				ChildStore.SetValue(childPos, column, value);
+			if (RowChanged != null)
+				RowChanged (this, new ListRowEventArgs (row));
+		}
+
+		public int RowCount {
+			get {
+				return list.Count;
+			}
+		}
+
+		public Type[] ColumnTypes {
+			get {
+				return ChildStore.ColumnTypes;
+			}
+		}
+
+		public void EnableEvent (object eventId)
+		{
+		}
+
+		public void DisableEvent (object eventId)
+		{
+		}
+	}
+}
+

--- a/Xwt/Xwt/TreeNavigator.cs
+++ b/Xwt/Xwt/TreeNavigator.cs
@@ -26,9 +26,6 @@
 
 
 using System;
-using Xwt.Drawing;
-using System.Collections.ObjectModel;
-using System.Collections.Generic;
 using Xwt.Backends;
 
 namespace Xwt
@@ -39,92 +36,49 @@ namespace Xwt
 		internal int Index;
 	}
 	
-	public class TreeNavigator
+	public class TreeNavigator: TreeViewNavigator
 	{
-		ITreeStoreBackend backend;
-		TreePosition pos;
-		
-		internal TreeNavigator (ITreeStoreBackend backend, TreePosition pos)
-		{
-			this.backend = backend;
-			this.pos = pos;
-		}
-		
-		public TreePosition CurrentPosition {
-			get { return pos; }
-		}
-		
-		public TreeNavigator Clone ()
-		{
-			return new TreeNavigator (backend, pos);
-		}
-		
-		bool CommitPos (TreePosition newPosition)
-		{
-			if (newPosition != null) {
-				pos = newPosition;
-				return true;
+		protected new ITreeStoreBackend Backend {
+			get {
+				return (ITreeStoreBackend)base.Backend;
 			}
-			else
-				return false;
-		}
-		
-		public bool MoveToFirst ()
-		{
-			return CommitPos (backend.GetChild (null, 0));
 		}
 
-		public bool MoveNext ()
+		[Obsolete]
+		internal TreeNavigator (ITreeStoreBackend backend, TreePosition pos) : base (backend, pos)
 		{
-			return CommitPos (backend.GetNext (pos));
 		}
 
-		public bool MovePrevious ()
+		internal TreeNavigator (ITreeDataSource backend, TreePosition pos, int index) : base (backend, pos, index)
 		{
-			return CommitPos (backend.GetPrevious (pos));
 		}
 
-		public bool MoveToChild ()
+		public new TreeNavigator Clone ()
 		{
-			return CommitPos (backend.GetChild (pos, 0));
-		}
-
-		public bool MoveToParent ()
-		{
-			return CommitPos (backend.GetParent (pos));
-		}
-
-		public bool MoveToFirstSibling ()
-		{
-			return CommitPos (backend.GetChild (backend.GetParent (pos), 0));
-		}
-
-		public bool MoveToLastSibling ()
-		{
-			return CommitPos (backend.GetChild (backend.GetParent (pos), backend.GetChildrenCount (backend.GetParent (pos)) - 1));
+			return new TreeNavigator (Backend, CurrentPosition, CurrentIndex);
 		}
 
 		public TreeNavigator InsertBefore ()
 		{
-			pos = backend.InsertBefore (pos);
+			CommitPos (Backend.InsertBefore (CurrentPosition));
 			return this;
 		}
 		
 		public TreeNavigator InsertAfter ()
 		{
-			pos = backend.InsertAfter (pos);
+			CommitPos (Backend.InsertAfter (CurrentPosition));
 			return this;
 		}
 		
 		public TreeNavigator AddChild ()
 		{
-			pos = backend.AddChild (pos);
+			CommitPos (Backend.AddChild (CurrentPosition));
 			return this;
 		}
 		
 		public TreeNavigator SetValue<T> (IDataField<T> field, T data)
 		{
-			backend.SetValue (pos, field.Index, data);
+			Backend.SetValue (CurrentPosition, field.Index, data);
 			return this;
 		}
 		
@@ -283,24 +237,18 @@ namespace Xwt
 			SetValue (column10, value10);
 			return this;
 		}
-
-		public T GetValue<T> (IDataField<T> field)
-		{
-			var value = backend.GetValue (pos, field.Index);
-			return value == null ? default(T) : (T)value;
-		}
 		
 		public void Remove ()
 		{
-			backend.Remove (pos);
+			Backend.Remove (CurrentPosition);
 		}
 		
 		public void RemoveChildren ()
 		{
-			TreePosition child = backend.GetChild (pos, 0);
+			TreePosition child = Backend.GetChild (CurrentPosition, 0);
 			while (child != null) {
-				backend.Remove (child);
-				child = backend.GetChild (pos, 0);
+				Backend.Remove (child);
+				child = Backend.GetChild (CurrentPosition, 0);
 			}
 		}
 	}

--- a/Xwt/Xwt/TreeStore.cs
+++ b/Xwt/Xwt/TreeStore.cs
@@ -26,19 +26,18 @@
 
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using Xwt.Backends;
-using System.ComponentModel;
 
 
 namespace Xwt
 {
 	[BackendType (typeof(ITreeStoreBackend))]
-	public class TreeStore: XwtComponent, ITreeDataSource
+	public class TreeStore: TreeStoreBase
 	{
 		IDataField[] fields;
-		
+
 		class TreeStoreBackendHost: BackendHost<TreeStore,ITreeStoreBackend>
 		{
 			protected override IBackend OnCreateBackend ()
@@ -51,7 +50,7 @@ namespace Xwt
 			}
 		}
 		
-		protected override Xwt.Backends.BackendHost CreateBackendHost ()
+		protected override BackendHost CreateBackendHost ()
 		{
 			return new TreeStoreBackendHost ();
 		}
@@ -110,73 +109,15 @@ namespace Xwt
 			var i = Backend.GetParentChildIndex (position);
 			return new TreeNavigator (Backend, pos, i);
 		}
+
+		protected override Type[] GetColumnTypes ()
+		{
+			return fields.Select (f => f.FieldType).ToArray ();
+		}
 		
 		public void Clear ()
 		{
 			Backend.Clear ();
-		}
-
-		event EventHandler<TreeNodeEventArgs> ITreeDataSource.NodeInserted {
-			add { Backend.NodeInserted += value; }
-			remove { Backend.NodeInserted -= value; }
-		}
-		event EventHandler<TreeNodeChildEventArgs> ITreeDataSource.NodeDeleted {
-			add { Backend.NodeDeleted += value; }
-			remove { Backend.NodeDeleted -= value; }
-		}
-		event EventHandler<TreeNodeEventArgs> ITreeDataSource.NodeChanged {
-			add { Backend.NodeChanged += value; }
-			remove { Backend.NodeChanged -= value; }
-		}
-		event EventHandler<TreeNodeOrderEventArgs> ITreeDataSource.NodesReordered {
-			add { Backend.NodesReordered += value; }
-			remove { Backend.NodesReordered -= value; }
-		}
-		
-		TreePosition ITreeDataSource.GetChild (TreePosition pos, int index)
-		{
-			return Backend.GetChild (pos, index);
-		}
-
-		TreePosition ITreeDataSource.GetNext (TreePosition pos)
-		{
-			return Backend.GetNext (pos);
-		}
-
-		TreePosition ITreeDataSource.GetPrevious (TreePosition pos)
-		{
-			return Backend.GetPrevious (pos);
-		}
-
-		TreePosition ITreeDataSource.GetParent (TreePosition pos)
-		{
-			return Backend.GetParent (pos);
-		}
-
-		int ITreeDataSource.GetChildrenCount (TreePosition pos)
-		{
-			return Backend.GetChildrenCount (pos);
-		}
-
-		int ITreeDataSource.GetParentChildIndex (TreePosition pos)
-		{
-			return Backend.GetParentChildIndex (pos);
-		}
-
-		object ITreeDataSource.GetValue (TreePosition pos, int column)
-		{
-			return Backend.GetValue (pos, column);
-		}
-
-		void ITreeDataSource.SetValue (TreePosition pos, int column, object val)
-		{
-			Backend.SetValue (pos, column, val);
-		}
-		
-		Type[] ITreeDataSource.ColumnTypes {
-			get {
-				return fields.Select (f => f.FieldType).ToArray ();
-			}
 		}
 	}
 	

--- a/Xwt/Xwt/TreeStore.cs
+++ b/Xwt/Xwt/TreeStore.cs
@@ -72,37 +72,43 @@ namespace Xwt
 		
 		public TreeNavigator GetFirstNode ()
 		{
-			var p = Backend.GetChild (null, 0);
-			return new TreeNavigator (Backend, p);
+			var pos = Backend.GetChild (null, 0);
+			var i = Backend.GetParentChildIndex (null);
+			return new TreeNavigator (Backend, pos, i);
 		}
 		
 		public TreeNavigator GetNavigatorAt (TreePosition pos)
 		{
-			return new TreeNavigator (Backend, pos);
+			var i = Backend.GetParentChildIndex (pos);
+			return new TreeNavigator (Backend, pos, i);
 		}
 		
 		public TreeNavigator AddNode ()
 		{
 			var pos = Backend.AddChild (null);
-			return new TreeNavigator (Backend, pos);
+			var i = Backend.GetParentChildIndex (null);
+			return new TreeNavigator (Backend, pos, i);
 		}
 
 		public TreeNavigator AddNode (TreePosition position)
 		{
 			var pos = Backend.AddChild (position);
-			return new TreeNavigator (Backend, pos);
+			var i = Backend.GetParentChildIndex (position);
+			return new TreeNavigator (Backend, pos, i);
 		}
 
-		public TreeNavigator InsertNodeAfter (TreePosition positon)
+		public TreeNavigator InsertNodeAfter (TreePosition position)
 		{
-			var pos = Backend.InsertAfter (positon);
-			return new TreeNavigator (Backend, pos);
+			var pos = Backend.InsertAfter (position);
+			var i = Backend.GetParentChildIndex (position);
+			return new TreeNavigator (Backend, pos, i);
 		}
 
-		public TreeNavigator InsertNodeBefore (TreePosition positon)
+		public TreeNavigator InsertNodeBefore (TreePosition position)
 		{
-			var pos = Backend.InsertBefore (positon);
-			return new TreeNavigator (Backend, pos);
+			var pos = Backend.InsertBefore (position);
+			var i = Backend.GetParentChildIndex (position);
+			return new TreeNavigator (Backend, pos, i);
 		}
 		
 		public void Clear ()
@@ -132,6 +138,16 @@ namespace Xwt
 			return Backend.GetChild (pos, index);
 		}
 
+		TreePosition ITreeDataSource.GetNext (TreePosition pos)
+		{
+			return Backend.GetNext (pos);
+		}
+
+		TreePosition ITreeDataSource.GetPrevious (TreePosition pos)
+		{
+			return Backend.GetPrevious (pos);
+		}
+
 		TreePosition ITreeDataSource.GetParent (TreePosition pos)
 		{
 			return Backend.GetParent (pos);
@@ -140,6 +156,11 @@ namespace Xwt
 		int ITreeDataSource.GetChildrenCount (TreePosition pos)
 		{
 			return Backend.GetChildrenCount (pos);
+		}
+
+		int ITreeDataSource.GetParentChildIndex (TreePosition pos)
+		{
+			return Backend.GetParentChildIndex (pos);
 		}
 
 		object ITreeDataSource.GetValue (TreePosition pos, int column)
@@ -301,6 +322,12 @@ namespace Xwt
 			NodePosition np = GetPosition (pos);
 			Node n = np.ParentList[np.NodeIndex];
 			return n.Children != null ? n.Children.Count : 0;
+		}
+
+		public int GetParentChildIndex (TreePosition pos)
+		{
+			NodePosition np = GetPosition (pos);
+			return np.NodeIndex;
 		}
 
 		public TreePosition InsertBefore (TreePosition pos)

--- a/Xwt/Xwt/TreeStoreBase.cs
+++ b/Xwt/Xwt/TreeStoreBase.cs
@@ -1,0 +1,103 @@
+﻿//
+// TreeStoreBase.cs
+//
+// Author:
+//       Lluis Sanchez <lluis@xamarin.com>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Linq;
+
+namespace Xwt
+{
+	public abstract class TreeStoreBase: XwtComponent, ITreeDataSource
+	{
+		protected abstract Type[] GetColumnTypes();
+
+		ITreeDataSource Backend {
+			get { return (ITreeDataSource) BackendHost.Backend; }
+		}
+
+		event EventHandler<TreeNodeEventArgs> ITreeDataSource.NodeInserted {
+			add { Backend.NodeInserted += value; }
+			remove { Backend.NodeInserted -= value; }
+		}
+		event EventHandler<TreeNodeChildEventArgs> ITreeDataSource.NodeDeleted {
+			add { Backend.NodeDeleted += value; }
+			remove { Backend.NodeDeleted -= value; }
+		}
+		event EventHandler<TreeNodeEventArgs> ITreeDataSource.NodeChanged {
+			add { Backend.NodeChanged += value; }
+			remove { Backend.NodeChanged -= value; }
+		}
+		event EventHandler<TreeNodeOrderEventArgs> ITreeDataSource.NodesReordered {
+			add { Backend.NodesReordered += value; }
+			remove { Backend.NodesReordered -= value; }
+		}
+
+		TreePosition ITreeDataSource.GetChild (TreePosition pos, int index)
+		{
+			return Backend.GetChild (pos, index);
+		}
+
+		TreePosition ITreeDataSource.GetNext (TreePosition pos)
+		{
+			return Backend.GetNext (pos);
+		}
+
+		TreePosition ITreeDataSource.GetPrevious (TreePosition pos)
+		{
+			return Backend.GetPrevious (pos);
+		}
+
+		TreePosition ITreeDataSource.GetParent (TreePosition pos)
+		{
+			return Backend.GetParent (pos);
+		}
+
+		int ITreeDataSource.GetChildrenCount (TreePosition pos)
+		{
+			return Backend.GetChildrenCount (pos);
+		}
+
+		int ITreeDataSource.GetParentChildIndex (TreePosition pos)
+		{
+			return Backend.GetParentChildIndex (pos);
+		}
+
+		object ITreeDataSource.GetValue (TreePosition pos, int column)
+		{
+			return Backend.GetValue (pos, column);
+		}
+
+		void ITreeDataSource.SetValue (TreePosition pos, int column, object val)
+		{
+			Backend.SetValue (pos, column, val);
+		}
+
+		Type[] ITreeDataSource.ColumnTypes {
+			get {
+				return GetColumnTypes();
+			}
+		}
+	}
+}
+

--- a/Xwt/Xwt/TreeStoreFilter.cs
+++ b/Xwt/Xwt/TreeStoreFilter.cs
@@ -1,0 +1,516 @@
+﻿//
+// TreeFilterStore.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt.Backends;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Remoting;
+
+namespace Xwt
+{
+	[BackendType (typeof(ITreeStoreFilterBackend))]
+	public class TreeStoreFilter: TreeStoreBase
+	{
+		ITreeDataSource childStore;
+
+		public ITreeDataSource ChildStore {
+			get {
+				return childStore;
+			}
+		}
+
+		class TreeFilterStoreBackendHost: BackendHost<TreeStoreFilter,ITreeStoreFilterBackend>
+		{
+			protected override IBackend OnCreateBackend ()
+			{
+				var b = base.OnCreateBackend ();
+				if (b == null)
+					b = new DefaultTreeStoreFilterBackend ();
+				((ITreeStoreFilterBackend)b).Initialize (Parent.ChildStore);
+				return b;
+			}
+		}
+
+		protected override BackendHost CreateBackendHost ()
+		{
+			return new TreeFilterStoreBackendHost ();
+		}
+
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.TreeStoreFilter"/> class.
+		/// </summary>
+		/// <param name="store">The tree data store to pass through the filter.</param>
+		public TreeStoreFilter (ITreeDataSource store)
+		{
+			if (store == null)
+				throw new ArgumentNullException ("store");
+			childStore = store;
+		}
+
+		ITreeStoreFilterBackend Backend {
+			get { return (ITreeStoreFilterBackend)BackendHost.Backend; }
+		}
+
+		/// <summary>
+		/// Sets the filter function, which should be used to filter single nodes.
+		/// </summary>
+		/// <value>The filter function.</value>
+		/// <remarks>
+		/// The function must return <c>true</c> for nodes to be filtered (hidden).
+		/// The position of the node to apply the filter function on is passed as the parameter to the function.
+		/// </remarks>
+		public Func<TreePosition, bool> FilterFunction {
+			set {
+				Backend.FilterFunction = value;
+			}
+		}
+
+		/// <summary>
+		/// Converts the node position from the child store to its position inside the filter store.
+		/// </summary>
+		/// <returns>The position of the node inside the filtered store, or null if the row has been filtered.</returns>
+		/// <param name="pos">The child store position to convert</param>
+		public TreePosition ConvertChildPositionToPosition (TreePosition pos)
+		{
+			return Backend.ConvertChildPositionToPosition (pos);
+		}
+
+		/// <summary>
+		/// Converts the node position from the filter store to its position inside the child store.
+		/// </summary>
+		/// <returns>The position of the node inside the child store.</returns>
+		/// <param name="pos">The filter store position to convert.</param>
+		public TreePosition ConvertPositionToChildPosition (TreePosition pos)
+		{
+			return Backend.ConvertPositionToChildPosition (pos);
+		}
+
+		/// <summary>
+		/// Forces the filter store to re-evaluate all nodes in the child store.
+		/// </summary>
+		public void Refilter()
+		{
+			Backend.Refilter ();
+		}
+
+		public TreeViewNavigator GetFirstNode ()
+		{
+			var p = Backend.GetChild (null, 0);
+			var i = Backend.GetParentChildIndex (null);
+			return new TreeViewNavigator (Backend, p, i);
+		}
+
+		public TreeViewNavigator GetNavigatorAt (TreePosition pos)
+		{
+			var i = Backend.GetParentChildIndex (pos);
+			return new TreeViewNavigator (Backend, pos, i);
+		}
+
+		protected override Type[] GetColumnTypes ()
+		{
+			return ChildStore.ColumnTypes;
+		}
+	}
+
+	class DefaultTreeStoreFilterBackend: ITreeStoreFilterBackend
+	{
+		public TreePosition ConvertChildPositionToPosition (TreePosition pos)
+		{
+			if (!childToFilterPos.ContainsKey (pos))
+				return null;
+			return childToFilterPos [pos];
+		}
+
+		public TreePosition ConvertPositionToChildPosition (TreePosition pos)
+		{
+			var tpos = GetPosition (pos);
+			if (!filterToChildPos.ContainsKey (tpos))
+				return null;
+			return filterToChildPos [tpos];
+		}
+
+		struct FilterNode {
+			public TreePosition ChildStorePosition;
+			public NodeList Children;
+			public int NodeId;
+		}
+
+		class NodePosition: TreePosition
+		{
+			public NodeList ParentList;
+			public int NodeIndex;
+			public int NodeId;
+			public int StoreVersion;
+
+			public override bool Equals (object obj)
+			{
+				NodePosition other = (NodePosition) obj;
+				if (other == null)
+					return false;
+				return ParentList == other.ParentList && NodeId == other.NodeId;
+			}
+
+			public override int GetHashCode ()
+			{
+				return ParentList.GetHashCode () ^ NodeId;
+			}
+		}
+
+		class NodeList: List<FilterNode>
+		{
+			public NodePosition Parent;
+		}
+
+
+
+		ITreeDataSource childStore;
+
+		NodeList rootNodes = new NodeList ();
+		int version;
+		int nextNodeId;
+
+		Dictionary<TreePosition, NodePosition> childToFilterPos = new Dictionary<TreePosition, NodePosition>();
+		Dictionary<NodePosition, TreePosition> filterToChildPos = new Dictionary<NodePosition, TreePosition>();
+
+		public event EventHandler<TreeNodeEventArgs> NodeInserted;
+		public event EventHandler<TreeNodeChildEventArgs> NodeDeleted;
+		public event EventHandler<TreeNodeEventArgs> NodeChanged;
+		public event EventHandler<TreeNodeOrderEventArgs> NodesReordered;
+
+		public ITreeDataSource ChildStore {
+			get {
+				return childStore;
+			}
+		}
+
+		Func<TreePosition, bool> filterFunction;
+		public Func<TreePosition, bool> FilterFunction {
+			set {
+				filterFunction = value;
+				Refilter ();
+			}
+		}
+
+		public void Initialize (ITreeDataSource store)
+		{
+			childStore = store;
+			childStore.NodeChanged += HandleChildNodeChanged;
+			childStore.NodeDeleted += HandleChildNodeDeleted;
+			childStore.NodeInserted += HandleChildNodeInserted;
+			childStore.NodesReordered += HandleChildNodesReordered;
+			Refilter ();
+		}
+
+		public void Initialize (Type[] columnTypes)
+		{
+			var defaultStore = new DefaultTreeStoreBackend ();
+			defaultStore.Initialize (columnTypes);
+			Initialize (defaultStore);
+		}
+
+		void HandleChildNodesReordered (object sender, TreeNodeOrderEventArgs e)
+		{
+			if (childToFilterPos.ContainsKey (e.Node)) {
+				ScanChildNode (childToFilterPos[e.Node], e.Node);
+			}
+		}
+
+		void HandleChildNodeInserted (object sender, TreeNodeEventArgs e)
+		{
+			if (filterFunction (e.Node))
+				return;
+			var parentChild = ChildStore.GetParent (e.Node);
+			if (parentChild != null && childToFilterPos.ContainsKey (parentChild))
+				parentChild = childToFilterPos [parentChild];
+			//if (childToFilterPos.ContainsKey (parentChild)) {
+
+			TreePosition newNode = null;
+			var next = ChildStore.GetNext (e.Node);
+			if (next != null && childToFilterPos.ContainsKey (next))
+				newNode = InsertBefore (childToFilterPos [next]);
+
+			var prev = ChildStore.GetPrevious (e.Node);
+			if (prev != null && childToFilterPos.ContainsKey (prev))
+				newNode = InsertAfter (childToFilterPos [prev]);
+
+			if (newNode == null)
+				newNode = AddChild (parentChild);
+
+			NodePosition newNPos = GetPosition (newNode);
+			childToFilterPos [e.Node] = newNPos;
+			filterToChildPos [newNPos] = e.Node;
+			ScanChildNode (newNode, e.Node);
+			//}
+		}
+
+		void HandleChildNodeDeleted (object sender, TreeNodeChildEventArgs e)
+		{
+			Refilter ();
+		}
+
+		void HandleChildNodeChanged (object sender, TreeNodeEventArgs e)
+		{
+			Refilter ();
+		}
+
+		public void Refilter ()
+		{
+			nextNodeId = 0;
+			version = 0;
+			rootNodes.Clear ();
+			childToFilterPos.Clear ();
+			filterToChildPos.Clear ();
+
+			ScanChildNode (null, null);
+		}
+
+		void ScanChildNode (TreePosition pos, TreePosition childPos)
+		{
+			for (int i = 0; i < childStore.GetChildrenCount (childPos); i++) {
+				var node = childStore.GetChild (childPos, i);
+				if (node == null || filterFunction == null || filterFunction (node)) {
+					if (childToFilterPos.ContainsKey (node)) {
+						if (filterToChildPos.ContainsKey (childToFilterPos [node]))
+							filterToChildPos.Remove (childToFilterPos [node]);
+						childToFilterPos.Remove (node);
+					}
+					continue;
+				}
+
+				TreePosition newPos = AddChild (pos);
+				NodePosition newNPos = GetPosition (newPos);
+				childToFilterPos [node] = newNPos;
+				filterToChildPos [newNPos] = node;
+				ScanChildNode (newPos, node);
+			}
+		}
+
+		public void SetValue (TreePosition pos, int column, object value)
+		{
+			var childPos = ConvertPositionToChildPosition (pos);
+			if (childPos != null)
+				ChildStore.SetValue(childPos, column, value);
+			if (NodeChanged != null)
+				NodeChanged (this, new TreeNodeEventArgs (pos));
+		}
+
+		TreePosition AddChild (TreePosition pos)
+		{
+			NodePosition np = GetPosition (pos);
+
+			FilterNode nn = new FilterNode ();
+			nn.NodeId = nextNodeId++;
+
+			NodeList list;
+
+			if (pos == null) {
+				list = rootNodes;
+			} else {
+				FilterNode n = np.ParentList [np.NodeIndex];
+				if (n.Children == null) {
+					n.Children = new NodeList ();
+					n.Children.Parent = new NodePosition () { ParentList = np.ParentList, NodeId = n.NodeId, NodeIndex = np.NodeIndex, StoreVersion = version };
+					np.ParentList [np.NodeIndex] = n;
+				}
+				list = n.Children;
+			}
+			list.Add (nn);
+			version++;
+
+			// The provided position is unafected by this change. Keep it valid.
+			if (np != null)
+				np.StoreVersion = version;
+
+			var node = new NodePosition () { ParentList = list, NodeId = nn.NodeId, NodeIndex = list.Count - 1, StoreVersion = version };
+			if (NodeInserted != null)
+				NodeInserted (this, new TreeNodeEventArgs (node));
+			return node;
+		}
+
+
+		TreePosition InsertBefore (TreePosition pos)
+		{
+			NodePosition np = GetPosition (pos);
+			FilterNode nn = new FilterNode ();
+			nn.NodeId = nextNodeId++;
+
+			np.ParentList.Insert (np.NodeIndex, nn);
+			version++;
+
+			// Update the NodePosition since it is now invalid
+			np.NodeIndex++;
+			np.StoreVersion = version;
+
+			var node = new NodePosition () { ParentList = np.ParentList, NodeId = nn.NodeId, NodeIndex = np.NodeIndex - 1, StoreVersion = version };
+			if (NodeInserted != null)
+				NodeInserted (this, new TreeNodeEventArgs (node));
+			return node;
+		}
+
+		TreePosition InsertAfter (TreePosition pos)
+		{
+			NodePosition np = GetPosition (pos);
+			FilterNode nn = new FilterNode ();
+			nn.NodeId = nextNodeId++;
+
+			np.ParentList.Insert (np.NodeIndex + 1, nn);
+			version++;
+
+			// Update the provided position is still valid
+			np.StoreVersion = version;
+
+			var node = new NodePosition () { ParentList = np.ParentList, NodeId = nn.NodeId, NodeIndex = np.NodeIndex + 1, StoreVersion = version };
+			if (NodeInserted != null)
+				NodeInserted (this, new TreeNodeEventArgs (node));
+			return node;
+		}
+
+
+		NodePosition GetPosition (TreePosition pos)
+		{
+			if (pos == null)
+				return null;
+			NodePosition np = (NodePosition)pos;
+			if (np.StoreVersion != version) {
+				np.NodeIndex = -1;
+				for (int i=0; i<np.ParentList.Count; i++) {
+					if (np.ParentList [i].NodeId == np.NodeId) {
+						np.NodeIndex = i;
+						break;
+					}
+				}
+				//if (np.NodeIndex == -1)
+				//throw new InvalidOperationException ("Invalid node position");
+				np.StoreVersion = version;
+			}
+			return np;
+		}
+
+		object ITreeDataSource.GetValue (TreePosition pos, int column)
+		{
+			var childPos = ConvertPositionToChildPosition (pos);
+			if (childPos != null)
+				return ChildStore.GetValue (childPos, column);
+			return null;
+		}
+
+		TreePosition ITreeDataSource.GetChild (TreePosition pos, int index)
+		{
+			if (pos == null) {
+				if (rootNodes.Count == 0)
+					return null;
+				FilterNode n = rootNodes[index];
+				return new NodePosition () { ParentList = rootNodes, NodeId = n.NodeId, NodeIndex = index, StoreVersion = version };
+			} else {
+				NodePosition np = GetPosition (pos);
+				FilterNode n = np.ParentList[np.NodeIndex];
+				if (n.Children == null || index >= n.Children.Count)
+					return null;
+				return new NodePosition () { ParentList = n.Children, NodeId = n.Children[index].NodeId, NodeIndex = index, StoreVersion = version };
+			}
+		}
+
+		TreePosition ITreeDataSource.GetParent (TreePosition pos)
+		{
+			NodePosition np = GetPosition (pos);
+			if (np.ParentList == rootNodes)
+				return null;
+			var parent = np.ParentList.Parent;
+			return new NodePosition () { ParentList = parent.ParentList, NodeId = parent.NodeId, NodeIndex = parent.NodeIndex, StoreVersion = version };
+		}
+
+		TreePosition ITreeDataSource.GetNext (TreePosition pos)
+		{
+			NodePosition np = GetPosition (pos);
+			if (np.NodeIndex >= np.ParentList.Count)
+				return null;
+			FilterNode n = np.ParentList[np.NodeIndex + 1];
+			return new NodePosition () { ParentList = np.ParentList, NodeId = n.NodeId, NodeIndex = np.NodeIndex + 1, StoreVersion = version };
+		}
+
+		TreePosition ITreeDataSource.GetPrevious (TreePosition pos)
+		{
+			NodePosition np = GetPosition (pos);
+			if (np.NodeIndex <= 0)
+				return null;
+			FilterNode n = np.ParentList[np.NodeIndex - 1];
+			return new NodePosition () { ParentList = np.ParentList, NodeId = n.NodeId, NodeIndex = np.NodeIndex - 1, StoreVersion = version };
+		}
+
+		int ITreeDataSource.GetChildrenCount (TreePosition pos)
+		{
+			if (pos == null)
+				return rootNodes.Count;
+
+			NodePosition np = GetPosition (pos);
+			FilterNode n = np.ParentList[np.NodeIndex];
+			return n.Children != null ? n.Children.Count : 0;
+		}
+
+		int ITreeDataSource.GetParentChildIndex (TreePosition pos)
+		{
+			NodePosition np = GetPosition (pos);
+			return np.NodeIndex;
+		}
+
+		void Remove (TreePosition pos)
+		{
+			NodePosition np = GetPosition (pos);
+			if (np == null)
+				return;
+
+			if (filterToChildPos.ContainsKey (np)) {
+				childToFilterPos.Remove (filterToChildPos[np]);
+				filterToChildPos.Remove (np);
+			}
+
+			np.ParentList.RemoveAt (np.NodeIndex);
+			var parent = np.ParentList.Parent;
+			var index = np.NodeIndex;
+			version++;
+			if (NodeDeleted != null)
+				NodeDeleted (this, new TreeNodeChildEventArgs (parent, index));
+		}
+
+		public Type[] ColumnTypes {
+			get {
+				return ChildStore.ColumnTypes;
+			}
+		}
+
+		public void InitializeBackend (object frontend, ApplicationContext context)
+		{
+		}
+		public void EnableEvent (object eventId)
+		{
+		}
+		public void DisableEvent (object eventId)
+		{
+		}
+	}
+}
+

--- a/Xwt/Xwt/TreeViewNavigator.cs
+++ b/Xwt/Xwt/TreeViewNavigator.cs
@@ -1,0 +1,123 @@
+﻿//
+// TreeViewNavigator.cs
+//
+// Author:
+//       Lluis Sanchez <lluis@xamarin.com>
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2014 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace Xwt
+{
+	public class TreeViewNavigator
+	{
+		readonly ITreeDataSource backend;
+		protected ITreeDataSource Backend {
+			get {
+				return backend;
+			}
+		}
+
+		[Obsolete]
+		internal TreeViewNavigator (ITreeDataSource backend, TreePosition pos)
+		{
+			this.backend = backend;
+			this.CurrentPosition = pos;
+			CurrentIndex = backend.GetParentChildIndex (pos);
+		}
+
+		internal TreeViewNavigator (ITreeDataSource backend, TreePosition pos, int index)
+		{
+			this.backend = backend;
+			this.CurrentPosition = pos;
+			this.CurrentIndex = index;
+		}
+
+		public TreePosition CurrentPosition {
+			get;
+			private set;
+		}
+
+		public int CurrentIndex {
+			get;
+			protected set;
+		}
+
+		public TreeViewNavigator Clone ()
+		{
+			return new TreeViewNavigator (backend, CurrentPosition, CurrentIndex);
+		}
+
+		protected bool CommitPos (TreePosition newPosition)
+		{
+			if (newPosition != null) {
+				CurrentPosition = newPosition;
+				CurrentIndex = Backend.GetParentChildIndex (CurrentPosition);
+				return true;
+			}
+			else
+				return false;
+		}
+
+		public bool MoveToFirst ()
+		{
+			return CommitPos (backend.GetChild (null, 0));
+		}
+
+		public bool MoveNext ()
+		{
+			return CommitPos (backend.GetNext (CurrentPosition));
+		}
+
+		public bool MovePrevious ()
+		{
+			return CommitPos (backend.GetPrevious (CurrentPosition));
+		}
+
+		public bool MoveToChild ()
+		{
+			return CommitPos (backend.GetChild (CurrentPosition, 0));
+		}
+
+		public bool MoveToParent ()
+		{
+			return CommitPos (backend.GetParent (CurrentPosition));
+		}
+
+		public bool MoveToFirstSibling ()
+		{
+			return CommitPos (backend.GetChild (backend.GetParent (CurrentPosition), 0));
+		}
+
+		public bool MoveToLastSibling ()
+		{
+			return CommitPos (backend.GetChild (backend.GetParent (CurrentPosition), backend.GetChildrenCount (backend.GetParent (CurrentPosition)) - 1));
+		}
+
+		public T GetValue<T> (IDataField<T> field)
+		{
+			var value = backend.GetValue (CurrentPosition, field.Index);
+			return value == null ? default(T) : (T)value;
+		}
+	}
+}
+


### PR DESCRIPTION
This PR adds new ListStoreFilter and TreeStoreFilter stores, which can be used to filter other stores (IListDataSource, ITreeDataSource). For this purpose they wrap around an other store and pass a filtered version to a view (similar to Gtk implementation). A filter function can be specified, which will be called for every node/row to evaluate whether to filter (hide) it or not.

Exaples for a filtered ListView and TreeView are included.

Backends:
Gtk: native implementation using Gtk.TreeModelFilter
Wpf: ~~works out of the box~~ works partially (needs review)
Mac: uses default Xwt backends (both included), needs #426 (!)

Other changes:
* depends on / includes #428, (partially) #429
* Xwt: ITreeDataSource / IListDataSource implementations moved to Xwt.*StoreBase classes
* Gtk: ITreeDataSource / IListDataSource implementations moved to *StoreBase classes