### PR TITLE
[Gtk] context fix for Gtk2 and Gtk3

### DIFF
--- a/Xwt.Gtk/Xwt.CairoBackend/CairoContextBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.CairoBackend/CairoContextBackendHandler.cs
@@ -368,12 +368,9 @@ namespace Xwt.CairoBackend
 		public override Matrix GetCTM (object backend)
 		{
 			var cb = (CairoContextBackend)backend;
-
 			Cairo.Matrix t = cb.Context.Matrix;
-
-			// Adjust CTM OffsetX, OffsetY for ContextBackend Origin
+			// Adjust CTM X0,Y0 for ContextBackend Origin (ensures that new CTM is Identity Matrix)
 			Matrix ctm = new Matrix (t.Xx, t.Yx, t.Xy, t.Yy, t.X0-cb.Origin.X, t.Y0-cb.Origin.Y);
-
 			return ctm;
 		}
 

--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/Gtk2CellRendererCustom.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/Gtk2CellRendererCustom.cs
@@ -31,8 +31,11 @@ namespace Xwt.GtkBackend
 	{
 		protected override void Render (Gdk.Drawable window, Gtk.Widget widget, Gdk.Rectangle background_area, Gdk.Rectangle cell_area, Gdk.Rectangle expose_area, CellRendererState flags)
 		{
-			using (var cr = Gdk.CairoHelper.Create (window))
+			using (var cr = Gdk.CairoHelper.Create (window)) {
+				cr.Rectangle (background_area.X, background_area.Y, background_area.Width, background_area.Height);
+				cr.Clip ();
 				OnRender (cr, widget, background_area, cell_area, flags);
+			}
 		}
 
 		protected abstract void OnRender (Cairo.Context cr, Gtk.Widget widget, Gdk.Rectangle background_area, Gdk.Rectangle cell_area, CellRendererState flags);

--- a/Xwt.Gtk/Xwt.GtkBackend/CanvasBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CanvasBackend.cs
@@ -160,8 +160,7 @@ namespace Xwt.GtkBackend
 		{
 			Backend.ApplicationContext.InvokeUserCode (delegate {
 				using (context) {
-					var r = new Rectangle (dirtyRect.X - context.Origin.X, dirtyRect.Y - context.Origin.Y, dirtyRect.Width, dirtyRect.Height);
-					EventSink.OnDraw (context, r);
+					EventSink.OnDraw (context, dirtyRect);
 				}
 			});
 		}
@@ -171,17 +170,13 @@ namespace Xwt.GtkBackend
 			CairoContextBackend ctx = new CairoContextBackend (Util.GetScaleFactor (this));
 			if (!IsRealized) {
 				Cairo.Surface sf = new Cairo.ImageSurface (Cairo.Format.ARGB32, 1, 1);
-				Cairo.Context c = new Cairo.Context (sf);
-				ctx.Context = c;
+				ctx.Context = new Cairo.Context (sf);
 				ctx.TempSurface = sf;
 			} else {
 				ctx.Context = Gdk.CairoHelper.Create (GdkWindow);
 			}
 			if (!VisibleWindow) {
 				ctx.Context.Translate (Allocation.X, Allocation.Y);
-				// Set ContextBackend Origin
-				ctx.Origin.X = Allocation.X;
-				ctx.Origin.Y = Allocation.Y;
 			}
 			return ctx;
 		}

--- a/Xwt.Gtk/Xwt.GtkBackend/CanvasBackendGtk2.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CanvasBackendGtk2.cs
@@ -39,8 +39,14 @@ namespace Xwt.GtkBackend
 
 		protected override bool OnExposeEvent (Gdk.EventExpose evnt)
 		{
+			var ctx = CreateContext ();
+			// Set context Origin from initial Cairo CTM (to ensure new Xwt CTM is Identity Matrix)
+			ctx.Origin.X = ctx.Context.Matrix.X0;
+			ctx.Origin.Y = ctx.Context.Matrix.Y0;
+			// Gdk Expose event supplies the area to be redrawn - but need to adjust X,Y for context Origin 
 			var a = evnt.Area;
-			OnDraw (new Rectangle (a.X, a.Y, a.Width, a.Height), CreateContext ());
+			Rectangle dirtyRect = new Rectangle (a.X-ctx.Origin.X, a.Y-ctx.Origin.Y, a.Width, a.Height);
+			OnDraw (dirtyRect, ctx);
 			return base.OnExposeEvent (evnt);
 		}
 	}

--- a/Xwt.Gtk/Xwt.GtkBackend/CanvasBackendGtk2.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CanvasBackendGtk2.cs
@@ -39,14 +39,17 @@ namespace Xwt.GtkBackend
 
 		protected override bool OnExposeEvent (Gdk.EventExpose evnt)
 		{
-			var ctx = CreateContext ();
-			// Set context Origin from initial Cairo CTM (to ensure new Xwt CTM is Identity Matrix)
-			ctx.Origin.X = ctx.Context.Matrix.X0;
-			ctx.Origin.Y = ctx.Context.Matrix.Y0;
-			// Gdk Expose event supplies the area to be redrawn - but need to adjust X,Y for context Origin 
 			var a = evnt.Area;
-			Rectangle dirtyRect = new Rectangle (a.X-ctx.Origin.X, a.Y-ctx.Origin.Y, a.Width, a.Height);
-			OnDraw (dirtyRect, ctx);
+			using (var ctx = CreateContext ()) {
+				// Set context Origin from initial Cairo CTM (to ensure new Xwt CTM is Identity Matrix)
+				ctx.Origin.X = ctx.Context.Matrix.X0;
+				ctx.Origin.Y = ctx.Context.Matrix.Y0;
+				// Gdk Expose event supplies the area to be redrawn - but need to adjust X,Y for context Origin 
+				Rectangle dirtyRect = new Rectangle (a.X-ctx.Origin.X, a.Y-ctx.Origin.Y, a.Width, a.Height);
+				ctx.Context.Rectangle (dirtyRect.X, dirtyRect.Y, dirtyRect.Width, dirtyRect.Height);
+				ctx.Context.Clip ();
+				OnDraw (dirtyRect, ctx);
+			}
 			return base.OnExposeEvent (evnt);
 		}
 	}

--- a/Xwt.Gtk/Xwt.GtkBackend/CanvasBackendGtk3.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CanvasBackendGtk3.cs
@@ -39,9 +39,9 @@ namespace Xwt.GtkBackend
 			// Set context Origin from initial Cairo CTM (to ensure new Xwt CTM is Identity Matrix)
 			context.Origin.X = cr.Matrix.X0;
 			context.Origin.Y = cr.Matrix.Y0;
-			// Gtk3 Cairo Context does not supply area to be redrawn, so use Canvas Allocation 
-			var a = Allocation;
-			OnDraw (new Rectangle (a.X, a.Y, a.Width, a.Height), context);
+			// Gtk3 Cairo Context cannot access area to be redrawn, so use full Canvas area.
+			// QueueDraw (rect) sets Clip (rect) internally, so drawing is limited correctly
+			OnDraw (new Rectangle (0, 0, Allocation.Width, Allocation.Height), context);
 			return base.OnDrawn (cr);
 		}
 

--- a/Xwt.Gtk/Xwt.GtkBackend/CanvasBackendGtk3.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CanvasBackendGtk3.cs
@@ -33,10 +33,14 @@ namespace Xwt.GtkBackend
 	{
 		protected override bool OnDrawn (Cairo.Context cr)
 		{
-			var a = Allocation;
 			// ensure cr does not get disposed before it is passed back to Gtk
 			var context = new TempCairoContextBackend (Util.GetScaleFactor (this));
 			context.Context = cr;
+			// Set context Origin from initial Cairo CTM (to ensure new Xwt CTM is Identity Matrix)
+			context.Origin.X = cr.Matrix.X0;
+			context.Origin.Y = cr.Matrix.Y0;
+			// Gtk3 Cairo Context does not supply area to be redrawn, so use Canvas Allocation 
+			var a = Allocation;
 			OnDraw (new Rectangle (a.X, a.Y, a.Width, a.Height), context);
 			return base.OnDrawn (cr);
 		}


### PR DESCRIPTION
Gtk3 DrawingTransforms sample does not draw correctly with Gtk3 at present.  This is because the context origin has to be adjusted, so that the new Context.CTM is always the Identity Matrix.  In addition, the invalidated area supplied to the OnDraw routines needs adjusting for the same reason.