### PR TITLE
[Gtk] add virtual event args conversion methods

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -627,6 +627,18 @@ namespace Xwt.GtkBackend
 		[GLib.ConnectBefore]
 		void HandleKeyReleaseEvent (object o, Gtk.KeyReleaseEventArgs args)
 		{
+			KeyEventArgs kargs = GetKeyReleaseEventArgs (args);
+			if (kargs == null)
+				return;
+			ApplicationContext.InvokeUserCode (delegate {
+				EventSink.OnKeyReleased (kargs);
+			});
+			if (kargs.Handled)
+				args.RetVal = true;
+		}
+
+		protected virtual KeyEventArgs GetKeyReleaseEventArgs (Gtk.KeyReleaseEventArgs args)
+		{
 			Key k = (Key)args.Event.KeyValue;
 			ModifierKeys m = ModifierKeys.None;
 			if ((args.Event.State & Gdk.ModifierType.ShiftMask) != 0)
@@ -635,20 +647,16 @@ namespace Xwt.GtkBackend
 				m |= ModifierKeys.Control;
 			if ((args.Event.State & Gdk.ModifierType.Mod1Mask) != 0)
 				m |= ModifierKeys.Alt;
-			KeyEventArgs kargs = new KeyEventArgs (k, m, false, (long)args.Event.Time);
-			ApplicationContext.InvokeUserCode (delegate {
-				EventSink.OnKeyReleased (kargs);
-			});
-			if (kargs.Handled)
-				args.RetVal = true;
+
+			return new KeyEventArgs (k, m, false, (long)args.Event.Time);
 		}
 
 		[GLib.ConnectBefore]
 		void HandleKeyPressEvent (object o, Gtk.KeyPressEventArgs args)
 		{
-			Key k = (Key)args.Event.KeyValue;
-			ModifierKeys m = args.Event.State.ToXwtValue ();
-			KeyEventArgs kargs = new KeyEventArgs (k, m, false, (long)args.Event.Time);
+			KeyEventArgs kargs = GetKeyPressEventArgs (args);
+			if (kargs == null)
+				return;
 			ApplicationContext.InvokeUserCode (delegate {
 				EventSink.OnKeyPressed (kargs);
 			});
@@ -656,18 +664,32 @@ namespace Xwt.GtkBackend
 				args.RetVal = true;
 		}
 
+		protected virtual KeyEventArgs GetKeyPressEventArgs (Gtk.KeyPressEventArgs args)
+		{
+			Key k = (Key)args.Event.KeyValue;
+			ModifierKeys m = args.Event.State.ToXwtValue ();
+
+			return new KeyEventArgs (k, m, false, (long)args.Event.Time);
+		}
+
         [GLib.ConnectBefore]
         void HandleScrollEvent(object o, Gtk.ScrollEventArgs args)
         {
-			var direction = args.Event.Direction.ToXwtValue ();
-
-            var a = new MouseScrolledEventArgs ((long) args.Event.Time, args.Event.X, args.Event.Y, direction);
+			var a = GetScrollEventArgs (args);
+			if (a == null)
+				return;
             ApplicationContext.InvokeUserCode (delegate {
                 EventSink.OnMouseScrolled(a);
             });
             if (a.Handled)
                 args.RetVal = true;
-        }
+		}
+
+		protected virtual MouseScrolledEventArgs GetScrollEventArgs (Gtk.ScrollEventArgs args)
+		{
+			var direction = args.Event.Direction.ToXwtValue ();
+			return new MouseScrolledEventArgs ((long) args.Event.Time, args.Event.X, args.Event.Y, direction);
+		}
         
 
 		void HandleWidgetFocusOutEvent (object o, Gtk.FocusOutEventArgs args)
@@ -704,9 +726,13 @@ namespace Xwt.GtkBackend
 			});
 		}
 
+		protected virtual void OnEnterNotifyEvent (Gtk.EnterNotifyEventArgs args) {}
+
 		void HandleMotionNotifyEvent (object o, Gtk.MotionNotifyEventArgs args)
 		{
-			var a = new MouseMovedEventArgs ((long) args.Event.Time, args.Event.X, args.Event.Y);
+			var a = GetMouseMovedEventArgs (args);
+			if (a == null)
+				return;
 			ApplicationContext.InvokeUserCode (delegate {
 				EventSink.OnMouseMoved (a);
 			});
@@ -714,12 +740,16 @@ namespace Xwt.GtkBackend
 				args.RetVal = true;
 		}
 
+		protected virtual MouseMovedEventArgs GetMouseMovedEventArgs (Gtk.MotionNotifyEventArgs args)
+		{
+			return new MouseMovedEventArgs ((long) args.Event.Time, args.Event.X, args.Event.Y);
+		}
+
 		void HandleButtonReleaseEvent (object o, Gtk.ButtonReleaseEventArgs args)
 		{
-			var a = new ButtonEventArgs ();
-			a.X = args.Event.X;
-			a.Y = args.Event.Y;
-			a.Button = (PointerButton) args.Event.Button;
+			var a = GetButtonReleaseEventArgs (args);
+			if (a == null)
+				return;
 			ApplicationContext.InvokeUserCode (delegate {
 				EventSink.OnButtonReleased (a);
 			});
@@ -727,8 +757,29 @@ namespace Xwt.GtkBackend
 				args.RetVal = true;
 		}
 
+		protected virtual ButtonEventArgs GetButtonReleaseEventArgs (Gtk.ButtonReleaseEventArgs args)
+		{
+			var a = new ButtonEventArgs ();
+			a.X = args.Event.X;
+			a.Y = args.Event.Y;
+			a.Button = (PointerButton) args.Event.Button;
+			return a;
+		}
+
 		[GLib.ConnectBeforeAttribute]
 		void HandleButtonPressEvent (object o, Gtk.ButtonPressEventArgs args)
+		{
+			var a = GetButtonPressEventArgs (args);
+			if (a == null)
+				return;
+			ApplicationContext.InvokeUserCode (delegate {
+				EventSink.OnButtonPressed (a);
+			});
+			if (a.Handled)
+				args.RetVal = true;
+		}
+
+		protected virtual ButtonEventArgs GetButtonPressEventArgs (Gtk.ButtonPressEventArgs args)
 		{
 			var a = new ButtonEventArgs ();
 			a.X = args.Event.X;
@@ -741,11 +792,7 @@ namespace Xwt.GtkBackend
 				a.MultiplePress = 3;
 			else
 				a.MultiplePress = 1;
-			ApplicationContext.InvokeUserCode (delegate {
-				EventSink.OnButtonPressed (a);
-			});
-			if (a.Handled)
-				args.RetVal = true;
+			return a;
 		}
 		
 		[GLib.ConnectBefore]


### PR DESCRIPTION
This one adds virtual event args conversion methods (Gtk to Xwt) to the WigetBackend base class.

Many event arguments have private members, that can not be modified after creation. Virtual conversion methods make it possible to modify the arguments before they are passed to the frontend.