### PR TITLE
Extend Tree/List cell bounds API, various Gtk fixes, Mac impl.

### DIFF
--- a/TestApps/Samples/MainWindow.cs
+++ b/TestApps/Samples/MainWindow.cs
@@ -84,6 +84,7 @@ namespace Samples
 			AddSample (w, "LinkLabels", typeof(LinkLabels));
 			var listView = AddSample (w, "ListView", typeof(ListView1));
 			AddSample (listView, "Editable checkboxes", typeof(ListView2));
+			AddSample (listView, "Cell Bounds", typeof(ListViewCellBounds));
 			AddSample (w, "Markdown", typeof (MarkDownSample));
 			AddSample (w, "Menu", typeof(MenuSamples));
 			AddSample (w, "Mnemonics", typeof (Mnemonics));
@@ -99,7 +100,8 @@ namespace Samples
 			AddSample (w, "Tables", typeof (Tables));
 			AddSample (w, "Text Entry", typeof (TextEntries));
 			AddSample (w, "Password Entry", typeof (PasswordEntries));
-			AddSample (w, "TreeView", typeof(TreeViews));
+			var treeview = AddSample (w, "TreeView", typeof(TreeViews));
+			AddSample (treeview, "Cell Bounds", typeof(TreeViewCellBounds));
 			AddSample (w, "WebView", typeof(WebViewSample));
 
 			var n = AddSample (null, "Drawing", null);

--- a/TestApps/Samples/Samples.csproj
+++ b/TestApps/Samples/Samples.csproj
@@ -107,6 +107,8 @@
     <Compile Include="Samples\MessageDialogs.cs" />
     <Compile Include="Samples\MultithreadingSample.cs" />
     <Compile Include="Samples\WidgetFocus.cs" />
+    <Compile Include="Samples\ListViewCellBounds.cs" />
+    <Compile Include="Samples\TreeViewCellBounds.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/TestApps/Samples/Samples/ListView1.cs
+++ b/TestApps/Samples/Samples/ListView1.cs
@@ -120,9 +120,19 @@ namespace Samples
 	{
 		public IDataField<CellData> ValueField { get; set; }
 
+		public Size Size {
+			get;
+			set;
+		}
+
+		public CustomCell ()
+		{
+			Size = new Size (200, 10);
+		}
+
 		protected override Size OnGetRequiredSize ()
 		{
-			return new Size (200, 10);
+			return Size;
 		}
 
 		protected override void OnDraw (Context ctx, Rectangle cellArea)

--- a/TestApps/Samples/Samples/ListViewCellBounds.cs
+++ b/TestApps/Samples/Samples/ListViewCellBounds.cs
@@ -1,0 +1,208 @@
+﻿//
+// ListViewCellBounds.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt;
+using Xwt.Drawing;
+
+namespace Samples
+{
+	public class ListViewCellBounds: Canvas
+	{
+		ListTrackingCanvas tracker;
+		ListTrackingCanvas drawer;
+		Rectangle drawerBounds;
+		VBox container;
+
+		Image drawerBg;
+		public Image DrawerBg {
+			get {
+				return drawerBg;
+			}
+			set {
+				drawerBg = value;
+				drawer.TrackerBg = drawerBg;
+				if (tracker != null && !Toolkit.CurrentEngine.SupportedFeatures.HasFlag (ToolkitFeatures.WidgetOpacity))
+					tracker.TrackerBg = drawerBg;
+			}
+		}
+
+		int currentRow;
+		public int CurrentRow {
+			get {
+				return currentRow;
+			}
+			private set {
+				if (currentRow != value)
+					DrawerBg =  Toolkit.CurrentEngine.RenderWidget (ListView);
+				currentRow = value;
+				QueueForReallocate ();
+			}
+		}
+
+		public ListView ListView { get; private set; }
+		public ListStore ListStore { get; private set; }
+
+		DataField<string> name = new DataField<string> ();
+		DataField<Image> icon = new DataField<Image> ();
+		DataField<bool> check = new DataField<bool> ();
+		DataField<string> text = new DataField<string> ();
+		DataField<CellData> progress = new DataField<CellData> ();
+
+		public ListViewCellBounds ()
+		{
+			MinHeight = 120;
+			MinWidth = 100;
+
+			container = new VBox ();
+			ListView = new ListView();
+
+			ListView.GridLinesVisible = GridLines.Both;
+			ListStore = new ListStore (name, icon, text, check, progress);
+			ListView.DataSource = ListStore;
+			ListView.Columns.Add ("Name", icon, name);
+			ListView.Columns.Add ("Check", new TextCellView () { TextField = text }, new CustomCell () { ValueField = progress, Size = new Size(20, 20) }, new CheckBoxCellView() { ActiveField = check });
+			//list.Columns.Add ("Progress", new TextCellView () { TextField = text }, new CustomCell () { ValueField = progress }, new TextCellView () { TextField = text } );
+			ListView.Columns.Add ("Progress", new CustomCell () { ValueField = progress });
+
+			var png = Image.FromResource (typeof(App), "class.png");
+
+			Random rand = new Random ();
+
+			for (int n=0; n<100; n++) {
+				var r = ListStore.AddRow ();
+				ListStore.SetValue (r, icon, png);
+				if (rand.Next (50) > 25) {
+					ListStore.SetValue (r, name, "Value \n" + n);
+					ListStore.SetValue (r, check, false);
+				} else {
+					ListStore.SetValue (r, name, "Value " + n);
+					ListStore.SetValue (r, check, true);
+				}
+				ListStore.SetValue (r, text, "Text " + n);
+				ListStore.SetValue (r, progress, new CellData { Value = rand.Next () % 100 });
+			}
+
+			ListView.SelectionChanged += (sender, e) => UpdateTracker (ListView.SelectedRow);
+			ListView.MouseMoved += (sender, e) => UpdateTracker (ListView.GetRowAtPosition (e.X, e.Y));
+
+			drawer = new ListTrackingCanvas (this);
+
+			container.PackStart (ListView, true);
+			container.PackStart (drawer);
+			AddChild (container);
+		}
+
+		void InitTracker()
+		{
+			if (tracker == null) {
+				tracker = new ListTrackingCanvas (this);
+				AddChild (tracker);
+				QueueForReallocate ();
+			}
+		}
+
+		void UpdateTracker(int row)
+		{
+			if (row < 0)
+				return;
+			if (Toolkit.CurrentEngine.SupportedFeatures.HasFlag (ToolkitFeatures.WidgetOpacity))
+				InitTracker();
+			CurrentRow = row;
+		}
+
+		protected override void OnReallocate ()
+		{
+			var rowBounds = ListView.GetRowBounds (CurrentRow, true);
+			SetChildBounds (container, Bounds);
+			container.Remove (drawer);
+			container.PackStart (drawer);
+			if (tracker != null)
+				SetChildBounds (tracker, rowBounds);
+		}
+	}
+
+	class ListTrackingCanvas : Canvas
+	{
+		readonly ListViewCellBounds parent;
+
+		public Image TrackerBg { get; set; }
+
+		public ListTrackingCanvas(ListViewCellBounds parent)
+		{
+			this.parent = parent;
+		}
+
+		protected override Size OnGetPreferredSize (SizeConstraint widthConstraint, SizeConstraint heightConstraint)
+		{
+			var row_bg_bounds = parent.ListView.GetRowBounds (parent.CurrentRow, true);
+			return new Size (row_bg_bounds.Width, row_bg_bounds.Height);
+		}
+
+		protected override void OnDraw (Context ctx, Rectangle dirtyRect)
+		{
+			base.OnDraw (ctx, dirtyRect);
+			ctx.Save ();
+
+			if (parent.CurrentRow < 0)
+				return;
+
+			var row_bounds = parent.ListView.GetRowBounds (parent.CurrentRow, false);
+			var row_bg_bounds = parent.ListView.GetRowBounds (parent.CurrentRow, true);
+
+			if (TrackerBg != null) {
+				ctx.DrawImage (TrackerBg, row_bg_bounds, new Rectangle (0, 0, row_bg_bounds.Width, row_bg_bounds.Height));
+			}
+
+			foreach (var col in parent.ListView.Columns) {
+				foreach (var cell in col.Views) {
+					var cell_bg_bounds = parent.ListView.GetCellBounds (parent.CurrentRow, cell, true);
+					var cell_bounds = parent.ListView.GetCellBounds (parent.CurrentRow, cell, false);
+					cell_bounds.Y -= row_bg_bounds.Y;
+					cell_bounds.X += parent.ListView.HorizontalScrollControl.Value;
+					cell_bg_bounds.Y -= row_bg_bounds.Y;
+					cell_bg_bounds.X += parent.ListView.HorizontalScrollControl.Value;
+					ctx.SetColor (Colors.Red);
+					ctx.Rectangle (cell_bg_bounds);
+					ctx.Stroke ();
+					ctx.SetColor (Colors.Green);
+					ctx.Rectangle (cell_bounds);
+					ctx.Stroke ();
+				}
+			}
+
+			row_bounds.Y -= row_bg_bounds.Y;
+			row_bounds.X += parent.ListView.HorizontalScrollControl.Value;
+			row_bg_bounds.Y = 0;
+			row_bg_bounds.X += parent.ListView.HorizontalScrollControl.Value;
+
+			ctx.SetColor (Colors.Red);
+			ctx.Rectangle (row_bg_bounds);
+			ctx.Stroke ();
+			ctx.Restore ();
+		}
+	}
+}
+

--- a/TestApps/Samples/Samples/ListViewCellBounds.cs
+++ b/TestApps/Samples/Samples/ListViewCellBounds.cs
@@ -55,10 +55,13 @@ namespace Samples
 				return currentRow;
 			}
 			private set {
-				if (currentRow != value)
-					DrawerBg =  Toolkit.CurrentEngine.RenderWidget (ListView);
-				currentRow = value;
-				QueueForReallocate ();
+				if (currentRow != value) {
+					try {
+						DrawerBg = Toolkit.CurrentEngine.RenderWidget (ListView);
+					} catch {}
+					currentRow = value;
+					QueueForReallocate ();
+				}
 			}
 		}
 
@@ -139,8 +142,10 @@ namespace Samples
 			SetChildBounds (container, Bounds);
 			container.Remove (drawer);
 			container.PackStart (drawer);
-			if (tracker != null)
+			if (tracker != null) {
 				SetChildBounds (tracker, rowBounds);
+				tracker.QueueDraw ();
+			}
 		}
 	}
 
@@ -200,6 +205,10 @@ namespace Samples
 
 			ctx.SetColor (Colors.Red);
 			ctx.Rectangle (row_bg_bounds);
+			ctx.Stroke ();
+
+			ctx.SetColor (Colors.Blue);
+			ctx.Rectangle (row_bounds);
 			ctx.Stroke ();
 			ctx.Restore ();
 		}

--- a/TestApps/Samples/Samples/TreeViewCellBounds.cs
+++ b/TestApps/Samples/Samples/TreeViewCellBounds.cs
@@ -55,10 +55,14 @@ namespace Samples
 				return currentRow;
 			}
 			private set {
-				if (currentRow != value)
-					DrawerBg =  Toolkit.CurrentEngine.RenderWidget (TreeView);
-				currentRow = value;
-				QueueForReallocate ();
+				if (currentRow != value) {
+					try {
+						DrawerBg = Toolkit.CurrentEngine.RenderWidget (TreeView);
+					} catch {
+					}
+					currentRow = value;
+					QueueForReallocate ();
+				}
 			}
 		}
 		public TreeView TreeView { get; private set; }
@@ -136,8 +140,11 @@ namespace Samples
 			SetChildBounds (container, Bounds);
 			container.Remove (drawer);
 			container.PackStart (drawer);
-			if (tracker != null)
+			container.QueueForReallocate ();
+			if (tracker != null) {
 				SetChildBounds (tracker, rowBounds);
+				tracker.QueueDraw ();
+			}
 		}
 	}
 
@@ -155,8 +162,10 @@ namespace Samples
 		protected override Size OnGetPreferredSize (SizeConstraint widthConstraint, SizeConstraint heightConstraint)
 		{
 			if (parent.CurrentRow == null)
-				return new Size (0, 0);
+				return new Size (20, 100);
 			var row_bg_bounds = parent.TreeView.GetRowBounds (parent.CurrentRow.CurrentPosition, true);
+			if (row_bg_bounds == Rectangle.Zero)
+				return new Size (20, 100);
 			return new Size (row_bg_bounds.Width, row_bg_bounds.Height);
 		}
 
@@ -197,6 +206,10 @@ namespace Samples
 
 			ctx.SetColor (Colors.Red);
 			ctx.Rectangle (row_bg_bounds);
+			ctx.Stroke ();
+
+			ctx.SetColor (Colors.Blue);
+			ctx.Rectangle (row_bounds);
 			ctx.Stroke ();
 			ctx.Restore ();
 		}

--- a/TestApps/Samples/Samples/TreeViewCellBounds.cs
+++ b/TestApps/Samples/Samples/TreeViewCellBounds.cs
@@ -1,0 +1,205 @@
+﻿//
+// TreeViewCellBounds.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt;
+using Xwt.Drawing;
+
+namespace Samples
+{
+	public class TreeViewCellBounds: Canvas
+	{
+		TreeTrackingCanvas tracker;
+		TreeTrackingCanvas drawer;
+		Rectangle drawerBounds;
+		VBox container;
+
+		Image drawerBg;
+		public Image DrawerBg {
+			get {
+				return drawerBg;
+			}
+			set {
+				drawerBg = value;
+				drawer.TrackerBg = drawerBg;
+				if (tracker != null && !Toolkit.CurrentEngine.SupportedFeatures.HasFlag (ToolkitFeatures.WidgetOpacity))
+					tracker.TrackerBg = drawerBg;
+			}
+		}
+
+		TreeNavigator currentRow;
+		public TreeNavigator CurrentRow {
+			get {
+				return currentRow;
+			}
+			private set {
+				if (currentRow != value)
+					DrawerBg =  Toolkit.CurrentEngine.RenderWidget (TreeView);
+				currentRow = value;
+				QueueForReallocate ();
+			}
+		}
+		public TreeView TreeView { get; private set; }
+		public TreeStore TreeStore { get; private set; }
+
+		DataField<CheckBoxState> triState = new DataField<CheckBoxState>();
+		DataField<bool> check = new DataField<bool>();
+		DataField<string> text = new DataField<string> ();
+		DataField<string> desc = new DataField<string> ();
+
+		public TreeViewCellBounds ()
+		{
+			MinHeight = 120;
+			MinWidth = 100;
+
+			container = new VBox ();
+			TreeView = new TreeView ();
+			TreeStore = new TreeStore (triState, check, text, desc);
+			TreeView.GridLinesVisible = GridLines.Both;
+
+			TreeView.Columns.Add ("TriCheck", triState);
+			TreeView.Columns.Add ("Check", check);
+			TreeView.Columns.Add ("Item", text);
+			TreeView.Columns.Add ("Desc", desc, check, text);
+
+			TreeView.DataSource = TreeStore;
+
+			TreeStore.AddNode ().SetValue (text, "One").SetValue (desc, "First").SetValue (triState, CheckBoxState.Mixed);
+			TreeStore.AddNode ().SetValue (text, "Two").SetValue (desc, "Second").AddChild ()
+				.SetValue (text, "Sub two").SetValue (desc, "Sub second");
+			TreeStore.AddNode ().SetValue (text, "Three").SetValue (desc, "Third").AddChild ()
+				.SetValue (text, "Sub three").SetValue (desc, "Sub third");
+
+			TreeView.ExpandAll ();
+
+
+			TreeView.SelectionChanged += (sender, e) => UpdateTracker (TreeView.SelectedRow);
+			TreeView.MouseMoved += (sender, e) => UpdateTracker (TreeView.GetRowAtPosition (e.X, e.Y));
+
+			drawer = new TreeTrackingCanvas (this);
+
+			container.PackStart (TreeView, true);
+			container.PackStart (drawer);
+			AddChild (container);
+
+			if (currentRow == null)
+				currentRow = TreeStore.GetFirstNode ();
+		}
+
+		void InitTracker()
+		{
+			if (tracker == null) {
+				tracker = new TreeTrackingCanvas (this);
+				AddChild (tracker);
+				QueueForReallocate ();
+			}
+		}
+
+		void UpdateTracker(TreePosition row)
+		{
+			if (row == null)
+				return;
+			if (Toolkit.CurrentEngine.SupportedFeatures.HasFlag (ToolkitFeatures.WidgetOpacity))
+				InitTracker();
+			CurrentRow = TreeStore.GetNavigatorAt (row);
+		}
+
+		protected override void OnReallocate ()
+		{
+			if (CurrentRow == null)
+				CurrentRow = TreeStore.GetFirstNode ();
+
+			var rowBounds = TreeView.GetRowBounds (CurrentRow.CurrentPosition, true);
+
+			SetChildBounds (container, Bounds);
+			container.Remove (drawer);
+			container.PackStart (drawer);
+			if (tracker != null)
+				SetChildBounds (tracker, rowBounds);
+		}
+	}
+
+	class TreeTrackingCanvas : Canvas
+	{
+		readonly TreeViewCellBounds parent;
+
+		public Image TrackerBg { get; set; }
+
+		public TreeTrackingCanvas(TreeViewCellBounds parent)
+		{
+			this.parent = parent;
+		}
+
+		protected override Size OnGetPreferredSize (SizeConstraint widthConstraint, SizeConstraint heightConstraint)
+		{
+			if (parent.CurrentRow == null)
+				return new Size (0, 0);
+			var row_bg_bounds = parent.TreeView.GetRowBounds (parent.CurrentRow.CurrentPosition, true);
+			return new Size (row_bg_bounds.Width, row_bg_bounds.Height);
+		}
+
+		protected override void OnDraw (Context ctx, Rectangle dirtyRect)
+		{
+			base.OnDraw (ctx, dirtyRect);
+			ctx.Save ();
+			if (parent.CurrentRow == null)
+				return;
+
+			var row_bounds = parent.TreeView.GetRowBounds (parent.CurrentRow.CurrentPosition, false);
+			var row_bg_bounds = parent.TreeView.GetRowBounds (parent.CurrentRow.CurrentPosition, true);
+
+			if (TrackerBg != null)
+				ctx.DrawImage (TrackerBg, row_bg_bounds, new Rectangle (0, 0, row_bg_bounds.Width, row_bg_bounds.Height));
+
+			foreach (var col in parent.TreeView.Columns) {
+				foreach (var cell in col.Views) {
+					var cell_bg_bounds = parent.TreeView.GetCellBounds (parent.CurrentRow.CurrentPosition, cell, true);
+					var cell_bounds = parent.TreeView.GetCellBounds (parent.CurrentRow.CurrentPosition, cell, false);
+					cell_bounds.Y -= row_bg_bounds.Y;
+					cell_bounds.X += parent.TreeView.HorizontalScrollControl.Value;
+					cell_bg_bounds.Y -= row_bg_bounds.Y;
+					cell_bg_bounds.X += parent.TreeView.HorizontalScrollControl.Value;
+					ctx.SetColor (Colors.Red);
+					ctx.Rectangle (cell_bg_bounds);
+					ctx.Stroke ();
+					ctx.SetColor (Colors.Green);
+					ctx.Rectangle (cell_bounds);
+					ctx.Stroke ();
+				}
+			}
+
+			row_bounds.Y -= row_bg_bounds.Y;
+			row_bounds.X += parent.TreeView.HorizontalScrollControl.Value;
+			row_bg_bounds.Y = 0;
+			row_bg_bounds.X += parent.TreeView.HorizontalScrollControl.Value;
+
+			ctx.SetColor (Colors.Red);
+			ctx.Rectangle (row_bg_bounds);
+			ctx.Stroke ();
+			ctx.Restore ();
+		}
+	}
+}
+

--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/Gtk3CellRendererCustom.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/Gtk3CellRendererCustom.cs
@@ -27,8 +27,17 @@ using System;
 
 namespace Xwt.GtkBackend
 {
-	public class GtkCellRendererCustom : Gtk.CellRenderer
+	public abstract class GtkCellRendererCustom : Gtk.CellRenderer
 	{
+		public GtkCellRendererCustom()
+		{
+			// set default padding used by native renderers like Gtk.CellRendererText
+			// which is used by Gtk3 to determine the cell area position. This is required, because
+			// the background area is always 2-3px larger then the cell area. This is not the same
+			// offset used in OnGetSize which has to be 0 (!).
+			SetPadding (1, 0);
+			SetAlignment (0.0f, 0.0f);
+		}
 	}
 }
 

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk3Extensions.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk3Extensions.cs
@@ -171,6 +171,19 @@ namespace Xwt.GtkBackend
 			return Gtk.StateFlags.Normal;
 		}
 
+		public static void GetSize (this Gtk.CellRenderer cr, Gtk.Widget widget, ref Gdk.Rectangle cell_area, out int x_offset, out int y_offset, out int width, out int height)
+		{
+			cr.GetPadding(out x_offset, out y_offset);
+			var minimum_size = Gtk.Requisition.Zero;
+			var natural_size = Gtk.Requisition.Zero;
+			cr.GetPreferredHeightForWidth (widget, cell_area.Width, out minimum_size.Height, out natural_size.Height);
+			cr.GetPreferredWidthForHeight (widget, cell_area.Height, out minimum_size.Width, out natural_size.Width);
+			width = Math.Max (minimum_size.Width, natural_size.Width);
+			height = Math.Max (minimum_size.Height, natural_size.Height);
+			x_offset += (int)(cr.Xalign * (cell_area.Width - width));
+			y_offset += (int)(cr.Yalign * (cell_area.Height - height));
+		}
+
 		public static string GetText (this Gtk.TextInsertedArgs args)
 		{
 			return args.NewText;

--- a/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
@@ -172,15 +172,10 @@ namespace Xwt.GtkBackend
 			if (!Widget.Model.GetIterFromString (out iter, path.ToString ()))
 				return Rectangle.Zero;
 
-			col.CellSetCellData (Widget.Model, iter, false, false);
-
-			Gdk.Rectangle rect = includeMargin ? Widget.GetBackgroundArea (path, col) : Widget.GetCellArea (path, col);
-
-			int x, y, w, h;
-			col.CellGetPosition (cr, out x, out w);
-			col.CellGetSize (rect, out x, out y, out w, out h);
-
-			return new Rectangle (x, y, w, h);
+			if (includeMargin)
+				return ((ICellRendererTarget)this).GetCellBackgroundBounds (col, cr, iter);
+			else
+				return ((ICellRendererTarget)this).GetCellBounds (col, cr, iter);
 		}
 
 		public Rectangle GetRowBounds (int row, bool includeMargin)

--- a/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
@@ -184,6 +184,11 @@ namespace Xwt.GtkBackend
 			return new Rectangle (x, y, w, h);
 		}
 
+		public Rectangle GetRowBounds (int row, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
+
 		public override void SetCurrentEventRow (string path)
 		{
 			if (path.Contains (":")) {

--- a/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
@@ -156,11 +156,10 @@ namespace Xwt.GtkBackend
 
 		public int GetRowAtPosition (Point p)
 		{
-			Gtk.TreePath path;
-			if (Widget.GetPathAtPos ((int)p.X, (int)p.Y, out path))
+			Gtk.TreePath path = GetPathAtPosition (p);
+			if (path != null)
 				return path.Indices [0];
-			else
-				return -1;
+			return -1;
 		}
 
 		public Rectangle GetCellBounds (int row, CellView cell, bool includeMargin)
@@ -186,7 +185,15 @@ namespace Xwt.GtkBackend
 
 		public Rectangle GetRowBounds (int row, bool includeMargin)
 		{
-			throw new NotImplementedException ();
+			Gtk.TreePath path = new Gtk.TreePath (new [] { row });
+			Gtk.TreeIter iter;
+			if (!Widget.Model.GetIterFromString (out iter, path.ToString ()))
+				return Rectangle.Zero;
+
+			if (includeMargin)
+				return GetRowBackgroundBounds (iter);
+			else
+				return GetRowBounds (iter);
 		}
 
 		public override void SetCurrentEventRow (string path)

--- a/Xwt.Gtk/Xwt.GtkBackend/TableViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TableViewBackend.cs
@@ -319,6 +319,50 @@ namespace Xwt.GtkBackend
 			return new Rectangle (a.X + x, a.Y + y, w, h);
 		}
 
+		protected Rectangle GetRowBounds (Gtk.TreeIter iter)
+		{
+			var rect = Rectangle.Zero;
+
+			foreach (var col in Widget.Columns) {
+				foreach (var cr in col.GetCellRenderers()) {
+					Rectangle cell_rect = ((ICellRendererTarget)this).GetCellBounds (col, cr, iter);
+					if (rect == Rectangle.Zero)
+						rect = new Rectangle (cell_rect.X, cell_rect.Y, cell_rect.Width, cell_rect.Height);
+					else
+						rect = rect.Union (new Rectangle (cell_rect.X, cell_rect.Y, cell_rect.Width, cell_rect.Height));
+				}
+			}
+			return rect;
+		}
+
+		protected Rectangle GetRowBackgroundBounds (Gtk.TreeIter iter)
+		{
+			var path = Widget.Model.GetPath (iter);
+			var rect = Rectangle.Zero;
+
+			foreach (var col in Widget.Columns) {
+				Gdk.Rectangle cell_rect = Widget.GetBackgroundArea (path, col);
+				Widget.ConvertBinWindowToWidgetCoords (cell_rect.X, cell_rect.Y, out cell_rect.X, out cell_rect.Y);
+
+				if (rect == Rectangle.Zero)
+					rect = new Rectangle (cell_rect.X, cell_rect.Y, cell_rect.Width, cell_rect.Height);
+				else
+					rect = rect.Union (new Rectangle (cell_rect.X, cell_rect.Y, cell_rect.Width, cell_rect.Height));
+			}
+			return rect;
+		}
+
+		protected Gtk.TreePath GetPathAtPosition (Point p)
+		{
+			Gtk.TreePath path;
+			int x, y;
+			Widget.ConvertWidgetToBinWindowCoords ((int)p.X, (int)p.Y, out x, out y);
+
+			if (Widget.GetPathAtPos (x, y, out path))
+				return path;
+			return null;
+		}
+
 		public virtual void SetCurrentEventRow (string path)
 		{
 		}

--- a/Xwt.Gtk/Xwt.GtkBackend/TableViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TableViewBackend.cs
@@ -408,6 +408,33 @@ namespace Xwt.GtkBackend
 			return null;
 		}
 
+		protected override ButtonEventArgs GetButtonPressEventArgs (ButtonPressEventArgs args)
+		{
+			int x, y;
+			Widget.ConvertBinWindowToWidgetCoords ((int)args.Event.X, (int)args.Event.Y, out x, out y);
+			var xwt_args = base.GetButtonPressEventArgs (args);
+			xwt_args.X = x;
+			xwt_args.Y = y;
+			return xwt_args;
+		}
+
+		protected override ButtonEventArgs GetButtonReleaseEventArgs (ButtonReleaseEventArgs args)
+		{
+			int x, y;
+			Widget.ConvertBinWindowToWidgetCoords ((int)args.Event.X, (int)args.Event.Y, out x, out y);
+			var xwt_args = base.GetButtonReleaseEventArgs (args);
+			xwt_args.X = x;
+			xwt_args.Y = y;
+			return xwt_args;
+		}
+
+		protected override MouseMovedEventArgs GetMouseMovedEventArgs (MotionNotifyEventArgs args)
+		{
+			int x, y;
+			Widget.ConvertBinWindowToWidgetCoords ((int)args.Event.X, (int)args.Event.Y, out x, out y);
+			return new MouseMovedEventArgs ((long) args.Event.Time, x, y);
+		}
+
 		public virtual void SetCurrentEventRow (string path)
 		{
 		}

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
@@ -310,17 +310,30 @@ namespace Xwt.GtkBackend
 
 		public TreePosition GetRowAtPosition (Point p)
 		{
-			throw new NotImplementedException ();
+			Gtk.TreePath path = GetPathAtPosition (p);
+			if (path != null) {
+				Gtk.TreeIter iter;
+				Widget.Model.GetIter (out iter, path);
+				return new IterPos (-1, iter);
+			}
+			return null;
 		}
 
 		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)
 		{
-			throw new NotImplementedException ();
+			var col = GetCellColumn (cell);
+			var cr = GetCellRenderer (cell);
+			Gtk.TreeIter iter = ((IterPos)pos).Iter;
+
+			var rect = includeMargin ? ((ICellRendererTarget)this).GetCellBackgroundBounds (col, cr, iter) : ((ICellRendererTarget)this).GetCellBounds (col, cr, iter);
+			return rect;
 		}
 
 		public Rectangle GetRowBounds (TreePosition pos, bool includeMargin)
 		{
-			throw new NotImplementedException ();
+			Gtk.TreeIter iter = ((IterPos)pos).Iter;
+			Rectangle rect = includeMargin ? GetRowBackgroundBounds (iter) : GetRowBounds (iter);
+			return rect;
 		}
 
 		public override void SetCurrentEventRow (string path)

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
@@ -308,6 +308,21 @@ namespace Xwt.GtkBackend
 			return true;
 		}
 
+		public TreePosition GetRowAtPosition (Point p)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Rectangle GetRowBounds (TreePosition pos, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
+
 		public override void SetCurrentEventRow (string path)
 		{
 			var treeFrontend = (TreeView)Frontend;

--- a/Xwt.WPF/Xwt.WPFBackend/ListBoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListBoxBackend.cs
@@ -215,5 +215,15 @@ namespace Xwt.WPFBackend
 		protected IListBoxEventSink ListBoxEventSink {
 			get { return (IListBoxEventSink) EventSink; }
 		}
+
+		public int GetRowAtPosition(Point p)
+		{
+			throw new NotImplementedException();
+		}
+
+		public Rectangle GetRowBounds (int row, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
@@ -283,7 +283,6 @@ namespace Xwt.WPFBackend
 		private static readonly Setter GridHorizontalSetter = new Setter (ListViewItem.BorderThicknessProperty, new Thickness (0, 0, 0, 1));
 		private static readonly Setter BorderBrushSetter = new Setter (ListViewItem.BorderBrushProperty, System.Windows.Media.Brushes.LightGray);
 
-
         public int GetRowAtPosition(Point p)
         {
             throw new NotImplementedException();
@@ -292,6 +291,11 @@ namespace Xwt.WPFBackend
         public Rectangle GetCellBounds(int row, CellView cell, bool includeMargin)
         {
             throw new NotImplementedException();
-        }
+		}
+
+		public Rectangle GetRowBounds (int row, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
     }
 }

--- a/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 using Xwt.WPFBackend.Utilities;
 using SWC = System.Windows.Controls;
@@ -39,6 +40,14 @@ namespace Xwt.WPFBackend
 	public class ListViewBackend
 		: WidgetBackend, IListViewBackend
 	{
+		Dictionary<CellView,CellInfo> cellViews = new Dictionary<CellView, CellInfo> ();
+
+		class CellInfo {
+			public ListViewColumn Column;
+			public int CellIndex;
+			public int ColumnIndex;
+		}
+
 		public ListViewBackend()
 		{
 			ListView = new ExListView();
@@ -165,6 +174,8 @@ namespace Xwt.WPFBackend
 
 			this.view.Columns.Add (column);
 
+			MapColumn (col, column);
+
 			return column;
 		}
 
@@ -181,6 +192,25 @@ namespace Xwt.WPFBackend
                 column.HeaderTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundCellRenderer(Context, Frontend, col.HeaderView) };
 			else
 				column.Header = col.Title;
+
+			MapColumn (col, column);
+		}
+
+		void MapColumn (ListViewColumn col, GridViewColumn handle)
+		{
+			foreach (var k in cellViews.Where (e => e.Value.Column == col).Select (e => e.Key).ToArray ())
+				cellViews.Remove (k);
+
+			var colindex = view.Columns.IndexOf (handle);
+			for (int i = 0; i < col.Views.Count; i++) {
+				var v = col.Views [i];
+				var cellindex = col.Views.IndexOf (v);
+				cellViews [v] = new CellInfo {
+					Column = col,
+					CellIndex = cellindex,
+					ColumnIndex = colindex
+				};
+			}
 		}
 
 		public void SetSelectionMode (SelectionMode mode)
@@ -284,18 +314,116 @@ namespace Xwt.WPFBackend
 		private static readonly Setter BorderBrushSetter = new Setter (ListViewItem.BorderBrushProperty, System.Windows.Media.Brushes.LightGray);
 
         public int GetRowAtPosition(Point p)
-        {
-            throw new NotImplementedException();
+		{
+			var result = VisualTreeHelper.HitTest (ListView, new System.Windows.Point (p.X, p.Y)) as PointHitTestResult;
+
+			var element = (result != null) ? result.VisualHit as FrameworkElement : null;
+			while (element != null) {
+				if (element is ExListViewItem)
+					break;
+				if (element is ExListView) // We can't succeed past this point
+					return -1;
+
+				element = VisualTreeHelper.GetParent (element) as FrameworkElement;
+			}
+
+			if (element == null)
+				return -1;
+
+			int index = ListView.ItemContainerGenerator.IndexFromContainer(element);
+			return index;
         }
 
         public Rectangle GetCellBounds(int row, CellView cell, bool includeMargin)
         {
-            throw new NotImplementedException();
+			ExListViewItem item = ListView.ItemContainerGenerator.ContainerFromIndex (row) as ExListViewItem;
+			if (item == null)
+				return Rectangle.Zero;
+
+			// this works only if the wpf layout remains the same
+			try {
+				var stackpanel = VisualTreeHelper.GetChild (item, 0);
+				var border = VisualTreeHelper.GetChild (stackpanel, 0);
+				var grid = VisualTreeHelper.GetChild (border, 0);
+				var rowpresenter = VisualTreeHelper.GetChild (grid, 1) as FrameworkElement;
+
+				if (VisualTreeHelper.GetChildrenCount (rowpresenter) != view.Columns.Count)
+					return Rectangle.Zero;
+
+				var colpresenter =  VisualTreeHelper.GetChild (rowpresenter, cellViews [cell].ColumnIndex) as FrameworkElement;
+				var colchild =  VisualTreeHelper.GetChild (colpresenter, 0) as FrameworkElement;
+
+				if (cellViews [cell].Column.Views.Count > 1 && colchild is System.Windows.Controls.StackPanel) {
+					var childStack = colchild as System.Windows.Controls.StackPanel;
+					if (childStack == null || VisualTreeHelper.GetChildrenCount (childStack) < cellViews [cell].CellIndex)
+						return Rectangle.Zero;
+					var cellpresenter = VisualTreeHelper.GetChild (childStack, cellViews [cell].CellIndex) as FrameworkElement;
+					var position = cellpresenter.TransformToAncestor (ListView).Transform(new System.Windows.Point(-ListView.Padding.Left, 0));
+					var rect = new Rect (position, cellpresenter.RenderSize);
+					return rect.ToXwtRect ();
+				} else {
+					var position = colchild.TransformToAncestor (ListView).Transform(new System.Windows.Point(-ListView.Padding.Left, 0));
+					var rect = new Rect (position, colchild.RenderSize);
+					return rect.ToXwtRect ();
+				}
+			} catch (ArgumentOutOfRangeException) {
+				return Rectangle.Zero;
+			} catch (ArgumentNullException) {
+				return Rectangle.Zero;
+			}
 		}
 
 		public Rectangle GetRowBounds (int row, bool includeMargin)
 		{
-			throw new NotImplementedException ();
+			ExListViewItem item = ListView.ItemContainerGenerator.ContainerFromIndex (row) as ExListViewItem;
+			if (item == null)
+				return Rectangle.Zero;
+
+			// this works only if the wpf layout remains the same
+			try {
+				var stackpanel = VisualTreeHelper.GetChild (item, 0);
+				var border = VisualTreeHelper.GetChild (stackpanel, 0) as FrameworkElement;
+
+				var rect = Rectangle.Zero;
+				if (includeMargin) {
+					var position = border.TransformToAncestor (ListView).Transform (new System.Windows.Point (0, 0));
+					rect = new Rect (position, border.RenderSize).ToXwtRect();
+					rect.X -= ListView.Padding.Left + ListView.BorderThickness.Left;
+				} else {
+					var grid = VisualTreeHelper.GetChild (border, 0);
+					var rowpresenter = VisualTreeHelper.GetChild (grid, 1) as FrameworkElement;
+					for (int i = 0; i < VisualTreeHelper.GetChildrenCount (rowpresenter); i++)
+					{
+						var colpresenter =  VisualTreeHelper.GetChild (rowpresenter, i) as FrameworkElement;
+						var colchild =  VisualTreeHelper.GetChild (colpresenter, 0) as FrameworkElement;
+						var cellcount = VisualTreeHelper.GetChildrenCount (colchild);
+						if (cellcount > 1)
+							for (int j = 0; j < cellcount; j++) {
+								var cell =  VisualTreeHelper.GetChild (colchild, j) as FrameworkElement;
+								var position = cell.TransformToAncestor (ListView).Transform(new System.Windows.Point(-ListView.Padding.Left, 0));
+								var cell_rect = new Rect (position, cell.RenderSize).ToXwtRect();
+								if (rect == Rectangle.Zero)
+									rect = cell_rect;
+								else
+									rect = rect.Union(cell_rect);
+							}
+						else {
+							var position = colchild.TransformToAncestor (ListView).Transform(new System.Windows.Point(-ListView.Padding.Left, 0));
+							var cell_rect = new Rect (position, colchild.RenderSize).ToXwtRect();
+							if (rect == Rectangle.Zero)
+								rect = cell_rect;
+							else
+								rect = rect.Union(cell_rect);
+						}
+					}
+				}
+
+				return rect;
+			} catch (ArgumentOutOfRangeException) {
+				return Rectangle.Zero;
+			} catch (ArgumentNullException) {
+				return Rectangle.Zero;
+			}
 		}
     }
 }

--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -478,5 +478,20 @@ namespace Xwt.WPFBackend
 			new BooleanToValueConverter { TrueValue = Minus, FalseValue = Plus };
 
 		private static readonly Setter HideHeaderSetter = new Setter (UIElement.VisibilityProperty, Visibility.Collapsed);
+
+		public TreePosition GetRowAtPosition (Point p)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Rectangle GetRowBounds (TreePosition pos, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -44,6 +44,14 @@ namespace Xwt.WPFBackend
 	public class TreeViewBackend
 		: WidgetBackend, ITreeViewBackend
 	{
+		Dictionary<CellView,CellInfo> cellViews = new Dictionary<CellView, CellInfo> ();
+
+		class CellInfo {
+			public ListViewColumn Column;
+			public int CellIndex;
+			public int ColumnIndex;
+		}
+
 		private static readonly ResourceDictionary TreeResourceDictionary;
 		static TreeViewBackend()
 		{
@@ -242,6 +250,8 @@ namespace Xwt.WPFBackend
 					col.CellTemplate.VisualTree = dockFactory;
 				}
 
+				MapColumn (column, col);
+
 				break;
 			case ListViewColumnChange.Alignment:
 				var style = new Style(typeof(GridViewColumnHeader));
@@ -254,6 +264,25 @@ namespace Xwt.WPFBackend
 		public void RemoveColumn (ListViewColumn column, object handle)
 		{
 			Tree.View.Columns.Remove ((GridViewColumn) handle);
+			foreach (var k in cellViews.Where (e => e.Value.Column == column).Select (e => e.Key).ToArray ())
+				cellViews.Remove (k);
+		}
+
+		void MapColumn (ListViewColumn col, GridViewColumn handle)
+		{
+			foreach (var k in cellViews.Where (e => e.Value.Column == col).Select (e => e.Key).ToArray ())
+				cellViews.Remove (k);
+
+			var colindex = Tree.View.Columns.IndexOf (handle);
+			for (int i = 0; i < col.Views.Count; i++) {
+				var v = col.Views [i];
+				var cellindex = col.Views.IndexOf (v);
+				cellViews [v] = new CellInfo {
+					Column = col,
+					CellIndex = cellindex,
+					ColumnIndex = colindex
+				};
+			}
 		}
 
 		private RowDropPosition dropPosition;
@@ -481,17 +510,117 @@ namespace Xwt.WPFBackend
 
 		public TreePosition GetRowAtPosition (Point p)
 		{
-			throw new NotImplementedException ();
+			var result = VisualTreeHelper.HitTest (Tree, new System.Windows.Point (p.X, p.Y)) as PointHitTestResult;
+
+			var element = (result != null) ? result.VisualHit as FrameworkElement : null;
+			while (element != null) {
+				if (element is ExTreeViewItem)
+					break;
+				if (element is ExTreeView) // We can't succeed past this point
+					return null;
+
+				element = VisualTreeHelper.GetParent (element) as FrameworkElement;
+			}
+
+			if (element == null)
+				return null;
+
+			return (element.DataContext as TreeStoreNode);
 		}
 
 		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)
 		{
-			throw new NotImplementedException ();
+			ExTreeViewItem item = GetVisibleTreeItem (pos);
+			if (item == null)
+				return Rectangle.Zero;
+
+			// this works only if the wpf layout remains the same
+			try {
+				var stackpanel = VisualTreeHelper.GetChild (item, 0);
+				var border = VisualTreeHelper.GetChild (stackpanel, 0);
+				var rowpresenter = VisualTreeHelper.GetChild (border, 0) as FrameworkElement;
+
+				if (VisualTreeHelper.GetChildrenCount (rowpresenter) < cellViews [cell].ColumnIndex)
+					return Rectangle.Zero;
+
+				var colpresenter =  VisualTreeHelper.GetChild (rowpresenter, cellViews [cell].ColumnIndex) as FrameworkElement;
+				var colchild =  VisualTreeHelper.GetChild (colpresenter, 0) as FrameworkElement;
+
+				if (cellViews [cell].Column.Views.Count > 1 && colchild is System.Windows.Controls.StackPanel) {
+					var childStack = colchild as System.Windows.Controls.StackPanel;
+					if (childStack == null || VisualTreeHelper.GetChildrenCount (childStack) < cellViews [cell].CellIndex)
+						return Rectangle.Zero;
+					var cellpresenter = VisualTreeHelper.GetChild (childStack, cellViews [cell].ColumnIndex == 0 ? cellViews [cell].CellIndex + 1 : cellViews [cell].CellIndex) as FrameworkElement;
+					var position = cellpresenter.TransformToAncestor (Tree).Transform(new System.Windows.Point(-Tree.Padding.Left, 0));
+					var rect = new Rect (position, cellpresenter.RenderSize);
+					return rect.ToXwtRect ();
+				} else {
+					if (cellViews [cell].ColumnIndex == 0)
+						colchild = VisualTreeHelper.GetChild (colchild, 1) as FrameworkElement;
+					var position = colchild.TransformToAncestor (Tree).Transform(new System.Windows.Point(-Tree.Padding.Left, 0));
+					var rect = new Rect (position, colchild.RenderSize);
+					return rect.ToXwtRect ();
+				}
+			} catch (ArgumentOutOfRangeException) {
+				return Rectangle.Zero;
+			} catch (ArgumentNullException) {
+				return Rectangle.Zero;
+			}
 		}
 
 		public Rectangle GetRowBounds (TreePosition pos, bool includeMargin)
 		{
-			throw new NotImplementedException ();
+			ExTreeViewItem item = GetVisibleTreeItem (pos);
+			if (item == null)
+				return Rectangle.Zero;
+
+			// this works only if the wpf layout remains the same
+			try {
+				var stackpanel = VisualTreeHelper.GetChild (item, 0);
+				var border = VisualTreeHelper.GetChild (stackpanel, 0) as FrameworkElement;
+
+				var rect = Rectangle.Zero;
+				if (includeMargin) {
+					var position = border.TransformToAncestor (Tree).Transform (new System.Windows.Point (0, 0));
+					rect = new Rect (position, border.RenderSize).ToXwtRect();
+					rect.X -= Tree.Padding.Left;
+				} else {
+					var rowpresenter = VisualTreeHelper.GetChild (border, 0) as FrameworkElement;
+					for (int i = 0; i < VisualTreeHelper.GetChildrenCount (rowpresenter); i++)
+					{
+						var colpresenter =  VisualTreeHelper.GetChild (rowpresenter, i) as FrameworkElement;
+						var colchild =  VisualTreeHelper.GetChild (colpresenter, 0) as FrameworkElement;
+						var cellcount = VisualTreeHelper.GetChildrenCount (colchild);
+						if (cellcount > 1)
+							for (int j = 0; j < cellcount; j++) {
+								var cell =  VisualTreeHelper.GetChild (colchild, j) as FrameworkElement;
+								var position = cell.TransformToAncestor (Tree).Transform(new System.Windows.Point(-Tree.Padding.Left, 0));
+								var cell_rect = new Rect (position, cell.RenderSize).ToXwtRect();
+								if (rect == Rectangle.Zero)
+									rect = cell_rect;
+								else
+									rect = rect.Union(cell_rect);
+							}
+						else {
+							var position = colchild.TransformToAncestor (Tree).Transform(new System.Windows.Point(-Tree.Padding.Left, 0));
+							var cell_rect = new Rect (position, colchild.RenderSize).ToXwtRect();
+							if (rect == Rectangle.Zero)
+								rect = cell_rect;
+							else
+								rect = rect.Union(cell_rect);
+						}
+					}
+					//var position = rowpresenter.TransformToAncestor (Tree).Transform(new System.Windows.Point(0,0));
+					//rect = new Rect (position, rowpresenter.RenderSize).ToXwtRect();
+					//rect.X -= Tree.Padding.Left + Tree.BorderThickness.Left;
+				}
+
+				return rect;
+			} catch (ArgumentOutOfRangeException) {
+				return Rectangle.Zero;
+			} catch (ArgumentNullException) {
+				return Rectangle.Zero;
+			}
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CellViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CellViewBackend.cs
@@ -56,6 +56,12 @@ namespace Xwt.Mac
 
 		public NSCell CurrentCell { get; set; }
 
+		public int Column {
+			get {
+				return column;
+			}
+		}
+
 		public int CurrentRow { get; set; }
 
 		internal ITablePosition CurrentPosition { get; set; }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -57,6 +57,12 @@ namespace Xwt.Mac
 		ITablePosition tablePosition;
 		ApplicationContext context;
 
+		public List<ICellRenderer> Cells {
+			get {
+				return cells;
+			}
+		}
+
 		static CompositeCell ()
 		{
 			Util.MakeCopiable<CompositeCell> ();
@@ -266,11 +272,9 @@ namespace Xwt.Mac
 
 		public CGRect GetCellRect (CGRect cellFrame, NSCell cell)
 		{
-			if (tablePosition is TableRow) {
-				foreach (var c in GetCells (cellFrame)) {
-					if (c.Cell == cell)
-						return c.Frame;
-				}
+			foreach (var c in GetCells (cellFrame)) {
+				if (c.Cell == cell)
+					return c.Frame;
 			}
 			return CGRect.Empty;
 		}

--- a/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
@@ -169,16 +169,6 @@ namespace Xwt.Mac
 		{
 			return (int) Table.GetRow (new CGPoint ((nfloat)p.X, (nfloat)p.Y));
 		}
-
-		public Rectangle GetCellBounds (int row, CellView cell, bool includeMargin)
-		{
-			return Rectangle.Zero;
-		}
-
-		public Rectangle GetRowBounds (int row, bool includeMargin)
-		{
-			throw new NotImplementedException ();
-		}
 	}
 	
 	class TableRow: NSObject, ITablePosition

--- a/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
@@ -174,6 +174,11 @@ namespace Xwt.Mac
 		{
 			return Rectangle.Zero;
 		}
+
+		public Rectangle GetRowBounds (int row, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
 	}
 	
 	class TableRow: NSObject, ITablePosition

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 using nint = System.Int32;
+using nfloat = System.Single;
 using CGPoint = System.Drawing.PointF;
 #else
 using AppKit;
@@ -208,7 +209,7 @@ namespace Xwt.Mac
 
 		public TreePosition GetRowAtPosition (Point p)
 		{
-			var row = Table.GetRow (new System.Drawing.PointF ((float)p.X, (float)p.Y));
+			var row = Table.GetRow (new CGPoint ((float)p.X, (float)p.Y));
 			return row >= 0 ? ((TreeItem)Tree.ItemAtRow (row)).Position : null;
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -208,17 +208,26 @@ namespace Xwt.Mac
 
 		public TreePosition GetRowAtPosition (Point p)
 		{
-			throw new NotImplementedException ();
+			var row = Table.GetRow (new System.Drawing.PointF ((float)p.X, (float)p.Y));
+			return ((TreeItem)Tree.ItemAtRow (row)).Position;
 		}
 
 		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)
 		{
-			throw new NotImplementedException ();
+			var it = tsource.GetItem (pos);
+			if (it == null)
+				return Rectangle.Zero;
+			var row = Tree.RowForItem (it);
+			return GetCellBounds (row, cell, includeMargin);
 		}
 
 		public Rectangle GetRowBounds (TreePosition pos, bool includeMargin)
 		{
-			throw new NotImplementedException ();
+			var it = tsource.GetItem (pos);
+			if (it == null)
+				return Rectangle.Zero;
+			var row = Tree.RowForItem (it);
+			return GetRowBounds (row, includeMargin);
 		}
 		
 		public bool GetDropTargetRow (double x, double y, out RowDropPosition pos, out TreePosition nodePosition)

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -209,7 +209,7 @@ namespace Xwt.Mac
 		public TreePosition GetRowAtPosition (Point p)
 		{
 			var row = Table.GetRow (new System.Drawing.PointF ((float)p.X, (float)p.Y));
-			return ((TreeItem)Tree.ItemAtRow (row)).Position;
+			return row >= 0 ? ((TreeItem)Tree.ItemAtRow (row)).Position : null;
 		}
 
 		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -205,6 +205,21 @@ namespace Xwt.Mac
 				p = source.GetParent (p);
 			}
 		}
+
+		public TreePosition GetRowAtPosition (Point p)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
+
+		public Rectangle GetRowBounds (TreePosition pos, bool includeMargin)
+		{
+			throw new NotImplementedException ();
+		}
 		
 		public bool GetDropTargetRow (double x, double y, out RowDropPosition pos, out TreePosition nodePosition)
 		{

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -217,7 +217,7 @@ namespace Xwt.Mac
 			var it = tsource.GetItem (pos);
 			if (it == null)
 				return Rectangle.Zero;
-			var row = Tree.RowForItem (it);
+			var row = (int)Tree.RowForItem (it);
 			return GetCellBounds (row, cell, includeMargin);
 		}
 
@@ -226,7 +226,7 @@ namespace Xwt.Mac
 			var it = tsource.GetItem (pos);
 			if (it == null)
 				return Rectangle.Zero;
-			var row = Tree.RowForItem (it);
+			var row = (int)Tree.RowForItem (it);
 			return GetRowBounds (row, includeMargin);
 		}
 		

--- a/Xwt/Xwt.Backends/IListBoxBackend.cs
+++ b/Xwt/Xwt.Backends/IListBoxBackend.cs
@@ -42,6 +42,8 @@ namespace Xwt.Backends
 		void SelectRow (int pos);
 		void UnselectRow (int pos);
 		void ScrollToRow (int row);
+		int GetRowAtPosition (Point p);
+		Rectangle GetRowBounds (int row, bool includeMargin);
 		bool GridLinesVisible { get; set; }
 	}
 

--- a/Xwt/Xwt.Backends/IListViewBackend.cs
+++ b/Xwt/Xwt.Backends/IListViewBackend.cs
@@ -43,6 +43,7 @@ namespace Xwt.Backends
 
 		int GetRowAtPosition (Point p);
 		Rectangle GetCellBounds (int row, CellView cell, bool includeMargin);
+		Rectangle GetRowBounds (int row, bool includeMargin);
 		int CurrentEventRow { get; }
 	}
 	

--- a/Xwt/Xwt.Backends/ITreeViewBackend.cs
+++ b/Xwt/Xwt.Backends/ITreeViewBackend.cs
@@ -49,6 +49,9 @@ namespace Xwt.Backends
 		
 		bool GetDropTargetRow (double x, double y, out RowDropPosition pos, out TreePosition nodePosition);
 
+		TreePosition GetRowAtPosition (Point p);
+		Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin);
+		Rectangle GetRowBounds (TreePosition pos, bool includeMargin);
 		TreePosition CurrentEventRow { get; }
 	}
 	

--- a/Xwt/Xwt/ListBox.cs
+++ b/Xwt/Xwt/ListBox.cs
@@ -293,6 +293,38 @@ namespace Xwt
 		{
 			Backend.ScrollToRow (row);
 		}
+
+		/// <summary>
+		/// Returns the row at the given widget coordinates
+		/// </summary>
+		/// <returns>The row index</returns>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="y">The y coordinate.</param>
+		public int GetRowAtPosition (double x, double y)
+		{
+			return GetRowAtPosition (new Point (x, y));
+		}
+
+		/// <summary>
+		/// Returns the row at the given widget coordinates
+		/// </summary>
+		/// <returns>The row index</returns>
+		/// <param name="p">A position, in widget coordinates</param>
+		public int GetRowAtPosition (Point p)
+		{
+			return Backend.GetRowAtPosition (p);
+		}
+
+		/// <summary>
+		/// Gets the bounds of the given row.
+		/// </summary>
+		/// <returns>The row bounds inside the widget, relative to the widget bounds.</returns>
+		/// <param name="row">The row index.</param>
+		/// <param name="includeMargin">If set to <c>true</c> include margin (the background of the row).</param>
+		public Rectangle GetRowBounds (int row, bool includeMargin)
+		{
+			return Backend.GetRowBounds (row, includeMargin);
+		}
 		
 		void HandleModelChanged (object sender, ListRowEventArgs e)
 		{

--- a/Xwt/Xwt/ListView.cs
+++ b/Xwt/Xwt/ListView.cs
@@ -256,9 +256,27 @@ namespace Xwt
 			return Backend.GetRowAtPosition (p);
 		}
 
+		/// <summary>
+		/// Gets the bounds of a cell inside the given row.
+		/// </summary>
+		/// <returns>The cell bounds inside the widget, relative to the widget bounds.</returns>
+		/// <param name="row">The row index.</param>
+		/// <param name="cell">The cell view.</param>
+		/// <param name="includeMargin">If set to <c>true</c> include margin (the background of the row).</param>
 		public Rectangle GetCellBounds (int row, CellView cell, bool includeMargin)
 		{
 			return Backend.GetCellBounds (row, cell, includeMargin);
+		}
+
+		/// <summary>
+		/// Gets the bounds of the given row.
+		/// </summary>
+		/// <returns>The row bounds inside the widget, relative to the widget bounds.</returns>
+		/// <param name="row">The row index.</param>
+		/// <param name="includeMargin">If set to <c>true</c> include margin (the background of the row).</param>
+		public Rectangle GetRowBounds (int row, bool includeMargin)
+		{
+			return Backend.GetRowBounds (row, includeMargin);
 		}
 
 		void IColumnContainer.NotifyColumnsChanged ()

--- a/Xwt/Xwt/TreeView.cs
+++ b/Xwt/Xwt/TreeView.cs
@@ -425,6 +425,50 @@ namespace Xwt
 		{
 			Backend.ExpandToRow (pos);
 		}
+
+		/// <summary>
+		/// Returns the row at the given widget coordinates
+		/// </summary>
+		/// <returns>The row index</returns>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="y">The y coordinate.</param>
+		public TreePosition GetRowAtPosition (double x, double y)
+		{
+			return GetRowAtPosition (new Point (x, y));
+		}
+
+		/// <summary>
+		/// Returns the row at the given widget coordinates
+		/// </summary>
+		/// <returns>The row index</returns>
+		/// <param name="p">A position, in widget coordinates</param>
+		public TreePosition GetRowAtPosition (Point p)
+		{
+			return Backend.GetRowAtPosition (p);
+		}
+
+		/// <summary>
+		/// Gets the bounds of a cell inside the row at the given position.
+		/// </summary>
+		/// <returns>The cell bounds inside the widget, relative to the widget bounds.</returns>
+		/// <param name="pos">The node position.</param>
+		/// <param name="cell">The cell view.</param>
+		/// <param name="includeMargin">If set to <c>true</c> include margin (the background of the row).</param>
+		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)
+		{
+			return Backend.GetCellBounds (pos, cell, includeMargin);
+		}
+
+		/// <summary>
+		/// Gets the bounds of the row at the given position.
+		/// </summary>
+		/// <returns>The row bounds inside the widget, relative to the widget bounds.</returns>
+		/// <param name="pos">The node position.</param>
+		/// <param name="includeMargin">If set to <c>true</c> include margin (the background of the row).</param>
+		public Rectangle GetRowBounds (TreePosition pos, bool includeMargin)
+		{
+			return Backend.GetRowBounds (pos, includeMargin);
+		}
 		
 		public bool GetDropTargetRow (double x, double y, out RowDropPosition pos, out TreePosition nodePosition)
 		{


### PR DESCRIPTION
This PR adds the already known ListView cell bounds retrieval functions to ListBox and TreeView. Additionally complete row (not only cell) bounds can be retrieved. ListView/TreeView examples included.

Backend implementations/support:
* Gtk: completely rewritten
  * now with real Gtk3 support
  * more native position calculation without static paddings
  * real data is loaded for calculation
  * includes #432 for better ```GetRowAtPosition``` support
* Mac: bounds always include margins (background bounds). Everything else works as expected (tested in VM, needs more testing on a real machine).
* Wpf: ~~still TODO!~~ done in c5b4130
  * static implementation by loading fixed FrameworkElement children
  * the view layout hierarchy may not change

It could be a more consequent solution for #422.