### PR TITLE
[Wpf] Fix CanvasCellView Events and Redraw

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/CanvasCellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/CanvasCellViewBackend.cs
@@ -10,7 +10,8 @@ namespace Xwt.WPFBackend
     class CanvasCellViewBackend: CellViewBackend, ICanvasCellViewBackend
     {
         public void QueueDraw()
-        {
+		{
+			CurrentElement.InvalidateVisual ();
         }
     }
 }

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/CanvasCellViewPanel.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/CanvasCellViewPanel.cs
@@ -103,6 +103,111 @@ namespace Xwt.WPFBackend
 				size.Height = constraint.Height;
 			return size;
 		}
+
+		protected override void OnMouseEnter (System.Windows.Input.MouseEventArgs e)
+		{
+			if (CellViewBackend.EnabledEvents.HasFlag (WidgetEvent.MouseEntered)) {
+				CellViewBackend.Load(this);
+				CellViewBackend.ApplicationContext.InvokeUserCode (CellViewBackend.EventSink.OnMouseEntered);
+			}
+			base.OnMouseEnter (e);
+		}
+
+		protected override void OnMouseLeave (System.Windows.Input.MouseEventArgs e)
+		{
+			if (CellViewBackend.EnabledEvents.HasFlag(WidgetEvent.MouseEntered)) {
+				CellViewBackend.Load(this);
+				CellViewBackend.ApplicationContext.InvokeUserCode (CellViewBackend.EventSink.OnMouseExited);
+			}
+			base.OnMouseLeave (e);
+		}
+
+		protected override void OnMouseMove (System.Windows.Input.MouseEventArgs e)
+		{
+			if (CellViewBackend.EnabledEvents.HasFlag(WidgetEvent.MouseMoved))
+			{
+				var p = e.GetPosition (this);
+				CellViewBackend.Load(this);
+				if (!CellViewBackend.CellBounds.Contains (p.X, p.Y))
+					return;
+				var a = new MouseMovedEventArgs(e.Timestamp, p.X, p.Y);
+
+				CellViewBackend.ApplicationContext.InvokeUserCode (delegate {
+					CellViewBackend.EventSink.OnMouseMoved (a);
+				});
+				if (a.Handled)
+					e.Handled = true;
+			}
+			base.OnMouseMove (e);
+		}
+
+		protected override void OnMouseDown (System.Windows.Input.MouseButtonEventArgs e)
+		{
+			if (CellViewBackend.EnabledEvents.HasFlag(WidgetEvent.ButtonPressed))
+			{
+				var a = e.ToXwtButtonArgs (this);
+				CellViewBackend.Load(this);
+				if (!CellViewBackend.CellBounds.Contains (a.X, a.Y))
+					return;
+
+				CellViewBackend.ApplicationContext.InvokeUserCode (delegate {
+					CellViewBackend.EventSink.OnButtonPressed (a);
+				});
+				if (a.Handled)
+					e.Handled = true;
+			}
+			base.OnMouseDown (e);
+		}
+
+		protected override void OnMouseUp (System.Windows.Input.MouseButtonEventArgs e)
+		{
+			if (CellViewBackend.EnabledEvents.HasFlag(WidgetEvent.ButtonReleased))
+			{
+				var a = e.ToXwtButtonArgs (this);
+				CellViewBackend.Load(this);
+				if (!CellViewBackend.CellBounds.Contains (a.X, a.Y))
+					return;
+
+				CellViewBackend.ApplicationContext.InvokeUserCode (delegate {
+					CellViewBackend.EventSink.OnButtonReleased (a);
+				});
+				if (a.Handled)
+					e.Handled = true;
+			}
+			base.OnMouseUp (e);
+		}
+
+		protected override void OnPreviewKeyDown (System.Windows.Input.KeyEventArgs e)
+		{
+			if (CellViewBackend.EnabledEvents.HasFlag(WidgetEvent.KeyPressed)) {
+				CellViewBackend.Load(this);
+				KeyEventArgs args;
+				if (e.MapToXwtKeyArgs (out args)) {
+					CellViewBackend.ApplicationContext.InvokeUserCode (delegate {
+						CellViewBackend.EventSink.OnKeyPressed(args);
+					});
+					if (args.Handled)
+						e.Handled = true;
+				}
+			}
+			base.OnKeyDown (e);
+		}
+
+		protected override void OnPreviewKeyUp (System.Windows.Input.KeyEventArgs e)
+		{
+			if (CellViewBackend.EnabledEvents.HasFlag(WidgetEvent.KeyReleased)) {
+				CellViewBackend.Load(this);
+				KeyEventArgs args;
+				if (e.MapToXwtKeyArgs (out args)) {
+					CellViewBackend.ApplicationContext.InvokeUserCode (delegate {
+						CellViewBackend.EventSink.OnKeyReleased(args);
+					});
+					if (args.Handled)
+						e.Handled = true;
+				}
+			}
+			base.OnKeyUp (e);
+		}
 	}
 }
 

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/CellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/CellViewBackend.cs
@@ -9,7 +9,22 @@ namespace Xwt.WPFBackend
 {
     class CellViewBackend : ICellViewBackend, ICellDataSource
     {
-        FrameworkElement currentElement;
+		FrameworkElement currentElement;
+		WidgetEvent enabledEvents;
+
+		public WidgetEvent EnabledEvents {
+			get {
+				return enabledEvents;
+			}
+		}
+
+		public FrameworkElement CurrentElement {
+			get {
+				return currentElement;
+			}
+		}
+
+		public ICellViewEventSink EventSink { get; private set; }
 
         public CellViewBackend()
         {
@@ -23,7 +38,7 @@ namespace Xwt.WPFBackend
         public void Load (FrameworkElement elem)
         {
             currentElement = elem;
-            CellFrontend.Load(this);
+            EventSink = CellFrontend.Load (this);
         }
 
         public CellView CellView { get; set; }
@@ -67,10 +82,14 @@ namespace Xwt.WPFBackend
 
         public void EnableEvent(object eventId)
         {
+            if (eventId is WidgetEvent)
+                enabledEvents |= (WidgetEvent)eventId;
         }
 
         public void DisableEvent(object eventId)
         {
+            if (eventId is WidgetEvent)
+                enabledEvents &= ~ (WidgetEvent)eventId;
         }
 
         public object GetValue(IDataField field)

--- a/Xwt.WPF/Xwt.WPFBackend/DataConverter.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DataConverter.cs
@@ -357,5 +357,28 @@ namespace Xwt.WPFBackend
 
 			return retval;
 		}
+
+		public static ButtonEventArgs ToXwtButtonArgs (this MouseButtonEventArgs e, FrameworkElement target)
+		{
+			var pos = e.GetPosition (target);
+			return new ButtonEventArgs () {
+				X = pos.X,
+				Y = pos.Y,
+				MultiplePress = e.ClickCount,
+				Button = e.ChangedButton.ToXwtButton ()
+			};
+		}
+
+		public static bool MapToXwtKeyArgs (this System.Windows.Input.KeyEventArgs e, out KeyEventArgs result)
+		{
+			result = null;
+
+			var key = KeyboardUtil.TranslateToXwtKey (e.Key);
+			if ((int)key == 0)
+				return false;
+
+			result = new KeyEventArgs (key, KeyboardUtil.GetModifiers (), e.IsRepeat, e.Timestamp);
+			return true;
+		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -572,7 +572,7 @@ namespace Xwt.WPFBackend
 		void WidgetKeyDownHandler (object sender, System.Windows.Input.KeyEventArgs e)
 		{
 			KeyEventArgs args;
-			if (MapToXwtKeyArgs (e, out args)) {
+			if (e.MapToXwtKeyArgs (out args)) {
 				Context.InvokeUserCode (delegate {
 					eventSink.OnKeyPressed (args);
 				});
@@ -584,7 +584,7 @@ namespace Xwt.WPFBackend
 		void WidgetKeyUpHandler (object sender, System.Windows.Input.KeyEventArgs e)
 		{
 			KeyEventArgs args;
-			if (MapToXwtKeyArgs (e, out args)) {
+			if (e.MapToXwtKeyArgs (out args)) {
 				Context.InvokeUserCode (delegate
 				{
 					eventSink.OnKeyReleased (args);
@@ -592,18 +592,6 @@ namespace Xwt.WPFBackend
 				if (args.Handled)
 					e.Handled = true;
 			}
-		}
-
-		bool MapToXwtKeyArgs (System.Windows.Input.KeyEventArgs e, out KeyEventArgs result)
-		{
-			result = null;
-
-			var key = KeyboardUtil.TranslateToXwtKey (e.Key);
-			if ((int)key == 0)
-				return false;
-
-			result = new KeyEventArgs (key, (int)e.Key, KeyboardUtil.GetModifiers (), e.IsRepeat, e.Timestamp);
-			return true;
 		}
 
 		void WidgetPreviewTextInputHandler (object sender, System.Windows.Input.TextCompositionEventArgs e)
@@ -619,7 +607,7 @@ namespace Xwt.WPFBackend
 
 		void WidgetMouseDownHandler (object o, MouseButtonEventArgs e)
 		{
-			var args = ToXwtButtonArgs (e);
+			var args = e.ToXwtButtonArgs (Widget);
 			Context.InvokeUserCode (delegate () {
 				eventSink.OnButtonPressed (args);
 			});
@@ -629,24 +617,13 @@ namespace Xwt.WPFBackend
 
 		void WidgetMouseUpHandler (object o, MouseButtonEventArgs e)
 		{
-			var args = ToXwtButtonArgs (e);
+			var args = e.ToXwtButtonArgs (Widget);
 			Context.InvokeUserCode (delegate ()
 			{
 				eventSink.OnButtonReleased (args);
 			});
 			if (args.Handled)
 				e.Handled = true;
-		}
-
-		ButtonEventArgs ToXwtButtonArgs (MouseButtonEventArgs e)
-		{
-			var pos = e.GetPosition (Widget);
-			return new ButtonEventArgs () {
-				X = pos.X,
-				Y = pos.Y,
-				MultiplePress = e.ClickCount,
-				Button = e.ChangedButton.ToXwtButton ()
-			};
 		}
 
 		void WidgetGotFocusHandler (object o, RoutedEventArgs e)


### PR DESCRIPTION
This PR adds event handling to CellViewBackend and the according implementation for CanvasCellView (other cell view types still need to be implemented). Fixes additionally CanvasCellViewBackend.QueueDraw().

CustomCell Example (ListView1.cs) works now with Wpf :grin: 