### PR TITLE
[Gtk] invert Mixed state logic for Gtk3 compatibility

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/CheckBoxBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CheckBoxBackend.cs
@@ -70,7 +70,7 @@ namespace Xwt.GtkBackend
 			set {
 				Widget.Inconsistent = value == CheckBoxState.Mixed;
 				internalActiveUpdate = true;
-				Widget.Active = value != CheckBoxState.Off;
+				Widget.Active = value == CheckBoxState.On;
 				internalActiveUpdate = false;
 			}
 		}
@@ -137,19 +137,19 @@ namespace Xwt.GtkBackend
 				return;
 			
 			if (allowMixed) {
-				if (!Widget.Active) {
+				if (Widget.Active) {
 					if (Widget.Inconsistent)
 						Widget.Inconsistent = false;
 					else {
 						Widget.Inconsistent = true;
 						internalActiveUpdate = true;
-						Widget.Active = true;
+						Widget.Active = false;
 						internalActiveUpdate = false;
 					}
 				}
 			} else if (Widget.Inconsistent) {
 				Widget.Inconsistent = false;
-				Widget.Active = false;
+				Widget.Active = true;
 			}
 
 			if (toggleEventEnabled) {


### PR DESCRIPTION
Gtk3 does not show the Inconsistent state, while the CheckButton is active (Active == true).

The simplest solution is to invert the Activated handling logic, from *Off->On->Mixed* to *Off->Mixed->On* (only visual impact) without a special Gtk3 implementation.

Keeping the original switch order in Gtk3 would require a much more complex logic and two different implementations (Gtk2/Gtk3). 