### PR TITLE
[Gtk] add RenderWidget coordinates check

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
@@ -316,10 +316,14 @@ namespace Xwt.GtkBackend
 		{
 			var w = ((WidgetBackend)widget.GetBackend ()).Widget;
 			Gdk.Window win = w.GdkWindow;
-			if (win != null && win.IsViewable)
+			if (win != null && win.IsViewable) {
+				int ww, wh;
+				win.GetSize (out ww, out wh);
+				if (ww == w.Allocation.Width && wh == w.Allocation.Height)
+					return new GtkImage (win.ToPixbuf (0, 0, w.Allocation.Width, w.Allocation.Height));
 				return new GtkImage (win.ToPixbuf (w.Allocation.X, w.Allocation.Y, w.Allocation.Width, w.Allocation.Height));
-			else
-				throw new InvalidOperationException ();
+			}
+			throw new InvalidOperationException ();
 		}
 
 		public override void RenderImage (object nativeWidget, object nativeContext, ImageDescription img, double x, double y)


### PR DESCRIPTION
Some Gtk Widgets use an additional Gdk.Window for drawing
and/or their bounds do not match their GdkWindow window. A workaround
is to check if the window and widget allocation sizes are equal.
In that case the widget allocation offset could be relative to a higher level
window and should be ignored.