### PR TITLE
[Wpf] fix Canvas drawing without ParentWindow

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/CanvasBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/CanvasBackend.cs
@@ -39,6 +39,13 @@ namespace Xwt.WPFBackend
 
 		private void Render (System.Windows.Media.DrawingContext dc)
 		{
+			// delay drawing until all parents are registered and we can
+			// get a window which is required for many drawing operations
+			if (Frontend.ParentWindow == null) {
+				QueueDraw ();
+				return;
+			}
+
 			if (BackgroundColorSet) {
 				SolidColorBrush mySolidColorBrush = new SolidColorBrush ();
 				mySolidColorBrush.Color = BackgroundColor.ToWpfColor ();


### PR DESCRIPTION
OnDraw is triggered too early by Wpf when a canvas gets initialized.
Delay drawing until the widget and its parents are registered. Otherwise things like ImageBuilder throw Exceptions because the canvas has no parent window until it is fully initialized.

Partial fix for ColorPicker (XwtBackendWidget)