### PR TITLE
[Wpf] fix XwtWidgetBackend containers support

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/CustomWidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/CustomWidgetBackend.cs
@@ -43,6 +43,7 @@ namespace Xwt.WPFBackend
 		public void SetContent (IWidgetBackend widget)
 		{
 			if (widget != null) {
+				SetChildPlacement (widget);
 				child = (Widget)((WidgetBackend)widget).Frontend;
 				UserControl.Content = widget.NativeWidget;
 			}
@@ -72,6 +73,13 @@ namespace Xwt.WPFBackend
 		{
 			get;
 			set;
+		}
+
+		protected override SW.Size ArrangeOverride (SW.Size arrangeBounds)
+		{
+			var s = base.ArrangeOverride (arrangeBounds);
+			Backend.Frontend.Surface.Reallocate ();
+			return s;
 		}
 
 		protected override SW.Size MeasureOverride (SW.Size constraint)

--- a/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
@@ -193,8 +193,12 @@ namespace Xwt.WPFBackend
 		
 		public override bool HasNativeParent (Widget w)
 		{
-			var backend = (IWpfWidgetBackend)Toolkit.GetBackend (w);
-			return backend.Widget.Parent != null;
+
+			var b = (IWidgetBackend) Toolkit.GetBackend (w);
+			if (b is XwtWidgetBackend)
+				b = ((XwtWidgetBackend)b).NativeBackend;
+			IWpfWidgetBackend wb = (IWpfWidgetBackend)b;
+			return wb.Widget.Parent != null;
 		}
 
 		public override object GetNativeImage (Image image)


### PR DESCRIPTION
* fix WPFEngine.HasNativeBackend for XwtWidgetBackend
* CustomWidgetBackend should rearrange its child on size changes.

Partial fix for ColorPicker (XwtBackendWidget)