### PR TITLE
Wpf add textcellviewbackend

### DIFF
--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Xwt.WPFBackend\WpfKeyboardHandler.cs" />
     <Compile Include="Xwt.WPFBackend\WebViewBackend.cs" />
     <Compile Include="Xwt.WPFBackend\ScrollControlBackend.cs" />
+    <Compile Include="Xwt.WPFBackend.CellViews\TextCellViewBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/CellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/CellViewBackend.cs
@@ -11,6 +11,14 @@ namespace Xwt.WPFBackend
     {
         FrameworkElement currentElement;
 
+        public FrameworkElement CurrentElement
+        {
+            get
+            {
+                return currentElement;
+            }
+        }
+
         public CellViewBackend()
         {
         }
@@ -24,6 +32,11 @@ namespace Xwt.WPFBackend
         {
             currentElement = elem;
             CellFrontend.Load(this);
+            OnLoadData();
+        }
+
+        protected virtual void OnLoadData()
+        {
         }
 
         public CellView CellView { get; set; }

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/TextCellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/TextCellViewBackend.cs
@@ -1,0 +1,115 @@
+﻿//
+// TextCellViewBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+using Xwt.Backends;
+using Xwt.WPFBackend;
+
+namespace Xwt.WPFBackend
+{
+	class TextCellViewBackend: CellViewBackend
+	{
+		public TextCellViewBackend ()
+		{
+		}
+
+		public TextBlock TextBlock {
+			get {
+				return base.CurrentElement as TextBlock;
+			}
+		}
+
+		protected override void OnLoadData ()
+		{
+			var view = (ITextCellViewFrontend) CellFrontend;
+
+			if (view.Markup != null && !view.Editable && TextBlock != null) {
+				FormattedText tx = FormattedText.FromMarkup (view.Markup);
+				SetFormattedText (tx);
+			}
+		}
+
+		public void SetFormattedText (FormattedText text)
+		{
+            TextBlock.SetFormattedText(text, this);
+		}
+    }
+
+    class TextCellViewBlock: TextBlock
+    {
+        public TextCellViewBlock ()
+        {
+            DataContextChanged += OnDataChanged;
+        }
+
+        void OnDataChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.OldValue is ValuesContainer)
+                ((ValuesContainer)e.OldValue).PropertyChanged -= TextCellRenderer_PropertyChanged;
+
+            if (e.NewValue is ValuesContainer)
+            {
+                ((ValuesContainer)DataContext).PropertyChanged += TextCellRenderer_PropertyChanged;
+            }
+        }
+
+        void TextCellRenderer_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            CellViewBackend.Load (this);
+        }
+
+        public event DependencyPropertyChangedEventHandler CellViewChanged;
+
+        public static readonly DependencyProperty CellViewBackendProperty =
+            DependencyProperty.Register("CellViewBackend", typeof(CellViewBackend),
+                typeof(TextCellViewBlock), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnCellViewChanged)));
+
+        public CellViewBackend CellViewBackend
+        {
+            get { return (CellViewBackend)GetValue(CellViewBackendProperty); }
+            set { SetValue(CellViewBackendProperty, value); }
+        }
+
+        public static void OnCellViewChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        {
+            var sl = sender as TextCellViewBlock;
+            if (sl != null)
+                sl.RaiseCellViewChangedEvent(e);
+        }
+
+        private void RaiseCellViewChangedEvent(DependencyPropertyChangedEventArgs e)
+        {
+            CellViewBackend.Load (this);
+            if (this.CellViewChanged != null)
+                this.CellViewChanged(this, e);
+        }
+    }
+}
+

--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -60,6 +60,7 @@ namespace Xwt.WPFBackend.Utilities
 				// if it's an editable textcontrol, use a TextBox, if not use a TextBlock. Reason for this is that 
 				// a user usually expects to be able to edit a text if a text cursor is appearing above a field.
 				FrameworkElementFactory factory;
+				var cb = new TextCellViewBackend();
 				if (textView.EditableField == null)
 				{
 					if (textView.Editable)
@@ -74,8 +75,9 @@ namespace Xwt.WPFBackend.Utilities
 					}
 					else
 					{
-						factory = new FrameworkElementFactory(typeof(SWC.TextBlock));
+						factory = new FrameworkElementFactory(typeof(TextCellViewBlock));
 						factory.SetValue(FrameworkElement.MarginProperty, CellMargins);
+						factory.SetValue(TextCellViewBlock.CellViewBackendProperty, cb);
 						if (textView.TextField != null)
 						{
 							factory.SetBinding(SWC.TextBlock.TextProperty, new Binding(dataPath + "[" + textView.TextField.Index + "]"));
@@ -93,7 +95,6 @@ namespace Xwt.WPFBackend.Utilities
 					}
 				}
 
-                var cb = new CellViewBackend();
                 cb.Initialize(view, factory);
                 fr.AttachBackend(parent, cb);
 				return factory;

--- a/Xwt.WPF/Xwt.WPFBackend/LabelBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/LabelBackend.cs
@@ -37,7 +37,7 @@ using Xwt.Backends;
 
 namespace Xwt.WPFBackend
 {
-	public class LabelBackend : WidgetBackend, ILabelBackend
+    public class LabelBackend : WidgetBackend, ILabelBackend, IWpfLinkNavigator
 	{
 		public LabelBackend ()
 		{
@@ -74,95 +74,14 @@ namespace Xwt.WPFBackend
 
 		public void SetFormattedText (FormattedText text)
 		{
-			var atts = new List<Drawing.TextAttribute> (text.Attributes);
-			atts.Sort ((a, b) => {
-				var c = a.StartIndex.CompareTo (b.StartIndex);
-				if (c == 0)
-					c = -(a.Count.CompareTo (b.Count));
-				return c;
-			});
-
-			int i = 0, attrIndex = 0;
-			Label.TextBlock.Inlines.Clear ();
-			GenerateBlocks (Label.TextBlock.Inlines, text.Text, ref i, text.Text.Length, atts, ref attrIndex);
+            Label.TextBlock.SetFormattedText(text, this);
 		}
 
-		void GenerateBlocks (SWD.InlineCollection col, string text, ref int i, int spanEnd, List<Drawing.TextAttribute> attributes, ref int attrIndex)
-		{
-			while (attrIndex < attributes.Count) {
-				var at = attributes[attrIndex];
-				if (at.StartIndex > spanEnd) {
-					FlushText (col, text, ref i, spanEnd);
-					return;
-				}
-
-				FlushText (col, text, ref i, at.StartIndex);
-
-				var s = new SWD.Span ();
-
-				if (at is Drawing.BackgroundTextAttribute) {
-					s.Background = new SWM.SolidColorBrush (((Drawing.BackgroundTextAttribute)at).Color.ToWpfColor ());
-				}
-				else if (at is Drawing.FontWeightTextAttribute) {
-					s.FontWeight = ((Drawing.FontWeightTextAttribute)at).Weight.ToWpfFontWeight ();
-				}
-				else if (at is Drawing.FontStyleTextAttribute) {
-					s.FontStyle = ((Drawing.FontStyleTextAttribute)at).Style.ToWpfFontStyle ();
-				}
-				else if (at is Drawing.UnderlineTextAttribute) {
-					var xa = (Drawing.UnderlineTextAttribute)at;
-					var dec = new TextDecoration (TextDecorationLocation.Underline, null, 0, TextDecorationUnit.FontRecommended, TextDecorationUnit.FontRecommended);
-					s.TextDecorations.Add (dec);
-				}
-				else if (at is Drawing.StrikethroughTextAttribute) {
-					var xa = (Drawing.UnderlineTextAttribute)at;
-					var dec = new TextDecoration (TextDecorationLocation.Strikethrough, null, 0, TextDecorationUnit.FontRecommended, TextDecorationUnit.FontRecommended);
-					s.TextDecorations.Add (dec);
-				}
-				else if (at is Drawing.FontTextAttribute) {
-					var xa = (Drawing.FontTextAttribute)at;
-					s.FontFamily = new SWM.FontFamily (xa.Font.Family);
-					s.FontSize = WpfFontBackendHandler.GetPointsFromDeviceUnits (xa.Font.Size);
-					s.FontStretch = xa.Font.Stretch.ToWpfFontStretch ();
-					s.FontStyle = xa.Font.Style.ToWpfFontStyle ();
-					s.FontWeight = xa.Font.Weight.ToWpfFontWeight ();
-				}
-				else if (at is Drawing.ColorTextAttribute) {
-					s.Foreground = new SWM.SolidColorBrush (((Drawing.ColorTextAttribute)at).Color.ToWpfColor ());
-				}
-				else if (at is Drawing.LinkTextAttribute) {
-					var link = new SWD.Hyperlink () {
-						NavigateUri = ((Drawing.LinkTextAttribute)at).Target
-					};
-					link.RequestNavigate += new System.Windows.Navigation.RequestNavigateEventHandler (link_RequestNavigate);
-					s = link;
-				}
-
-				col.Add (s);
-
-				var max = i + at.Count;
-				if (max > spanEnd)
-					max = spanEnd;
-
-				attrIndex++;
-				GenerateBlocks (s.Inlines, text, ref i, i + at.Count, attributes, ref attrIndex);
-			}
-			FlushText (col, text, ref i, spanEnd);
-		}
-
-		void link_RequestNavigate (object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
+        void IWpfLinkNavigator.LinkRequestNavigate (object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
 		{
 			Context.InvokeUserCode (delegate {
 				EventSink.OnLinkClicked (e.Uri);
 			});
-		}
-
-		void FlushText (SWD.InlineCollection col, string text, ref int i, int pos)
-		{
-			if (pos > i) {
-				col.Add (text.Substring (i, pos - i));
-				i = pos;
-			}
 		}
 
 		public Xwt.Drawing.Color TextColor {

--- a/Xwt.WPF/Xwt.WPFBackend/Util.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/Util.cs
@@ -23,9 +23,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Media;
-using System;
+using SWC = System.Windows.Controls;
+using SWD = System.Windows.Documents;
+using SWM = System.Windows.Media;
 
 namespace Xwt.WPFBackend
 {
@@ -64,5 +68,96 @@ namespace Xwt.WPFBackend
 
 			throw new InvalidOperationException("Invalid alignment value: " + alignment);
         }
+
+        public static void SetFormattedText (this SWC.TextBlock textBlock, FormattedText text, object backend)
+        {
+            var atts = new List<Drawing.TextAttribute> (text.Attributes);
+            atts.Sort ((a, b) => {
+                var c = a.StartIndex.CompareTo (b.StartIndex);
+                if (c == 0)
+                    c = -(a.Count.CompareTo (b.Count));
+                return c;
+            });
+
+            int i = 0, attrIndex = 0;
+            textBlock.Inlines.Clear ();
+            GenerateTextBlocks (backend, textBlock.Inlines, text.Text, ref i, text.Text.Length, atts, ref attrIndex);
+        }
+
+        static void GenerateTextBlocks (object backend, SWD.InlineCollection col, string text, ref int i, int spanEnd, List<Drawing.TextAttribute> attributes, ref int attrIndex)
+        {
+            while (attrIndex < attributes.Count) {
+                var at = attributes[attrIndex];
+                if (at.StartIndex > spanEnd) {
+                    FlushText (col, text, ref i, spanEnd);
+                    return;
+                }
+
+                FlushText (col, text, ref i, at.StartIndex);
+
+                var s = new SWD.Span ();
+
+                if (at is Drawing.BackgroundTextAttribute) {
+                    s.Background = new SolidColorBrush (((Drawing.BackgroundTextAttribute)at).Color.ToWpfColor ());
+                }
+                else if (at is Drawing.FontWeightTextAttribute) {
+                    s.FontWeight = ((Drawing.FontWeightTextAttribute)at).Weight.ToWpfFontWeight ();
+                }
+                else if (at is Drawing.FontStyleTextAttribute) {
+                    s.FontStyle = ((Drawing.FontStyleTextAttribute)at).Style.ToWpfFontStyle ();
+                }
+                else if (at is Drawing.UnderlineTextAttribute) {
+                    var xa = (Drawing.UnderlineTextAttribute)at;
+                    var dec = new TextDecoration (TextDecorationLocation.Underline, null, 0, TextDecorationUnit.FontRecommended, TextDecorationUnit.FontRecommended);
+                    s.TextDecorations.Add (dec);
+                }
+                else if (at is Drawing.StrikethroughTextAttribute) {
+                    var xa = (Drawing.UnderlineTextAttribute)at;
+                    var dec = new TextDecoration (TextDecorationLocation.Strikethrough, null, 0, TextDecorationUnit.FontRecommended, TextDecorationUnit.FontRecommended);
+                    s.TextDecorations.Add (dec);
+                }
+                else if (at is Drawing.FontTextAttribute) {
+                    var xa = (Drawing.FontTextAttribute)at;
+                    s.FontFamily = new FontFamily (xa.Font.Family);
+                    s.FontSize = WpfFontBackendHandler.GetPointsFromDeviceUnits (xa.Font.Size);
+                    s.FontStretch = xa.Font.Stretch.ToWpfFontStretch ();
+                    s.FontStyle = xa.Font.Style.ToWpfFontStyle ();
+                    s.FontWeight = xa.Font.Weight.ToWpfFontWeight ();
+                }
+                else if (at is Drawing.ColorTextAttribute) {
+                    s.Foreground = new SolidColorBrush (((Drawing.ColorTextAttribute)at).Color.ToWpfColor ());
+                }
+                else if (at is Drawing.LinkTextAttribute && backend is IWpfLinkNavigator) {
+                    var link = new SWD.Hyperlink () {
+                        NavigateUri = ((Drawing.LinkTextAttribute)at).Target
+                    };
+                    link.RequestNavigate += ((IWpfLinkNavigator)backend).LinkRequestNavigate;
+                    s = link;
+                }
+
+                col.Add (s);
+
+                var max = i + at.Count;
+                if (max > spanEnd)
+                    max = spanEnd;
+
+                attrIndex++;
+                GenerateTextBlocks (backend, s.Inlines, text, ref i, i + at.Count, attributes, ref attrIndex);
+            }
+            FlushText (col, text, ref i, spanEnd);
+        }
+
+        static void FlushText (SWD.InlineCollection col, string text, ref int i, int pos)
+        {
+            if (pos > i) {
+                col.Add (text.Substring (i, pos - i));
+                i = pos;
+            }
+        }
+    }
+
+    interface IWpfLinkNavigator
+    {
+        void LinkRequestNavigate (object sender, System.Windows.Navigation.RequestNavigateEventArgs e);
     }
 }


### PR DESCRIPTION
Add a TextCellViewBackend for Wpf with Markup support. The Markup handling from LabelBackend is reused (converted to TextBlock extension method) for this purpose.

Limitation: works only for not editable cells. Editable cells ignore the markup.