### PR TITLE
Add FontSelector widget and SelectFontDialog

### DIFF
--- a/TestApps/Samples/MainWindow.cs
+++ b/TestApps/Samples/MainWindow.cs
@@ -73,6 +73,7 @@ namespace Samples
 			AddSample (w, "CheckBox", typeof(Checkboxes));
 			AddSample (w, "Clipboard", typeof(ClipboardSample));
 			AddSample (w, "ColorSelector", typeof(ColorSelectorSample));
+			AddSample (w, "FontSelector", typeof(FontSelectorSample));
 			AddSample (w, "ComboBox", typeof(ComboBoxes));
 			AddSample (w, "DatePicker", typeof(DatePickerSample));
 //			AddSample (null, "Designer", typeof(Designer));

--- a/TestApps/Samples/Samples.csproj
+++ b/TestApps/Samples/Samples.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Samples\ListViewCellBounds.cs" />
     <Compile Include="Samples\TreeViewCellBounds.cs" />
     <Compile Include="Samples\CalendarSample.cs" />
+    <Compile Include="Samples\FontSelectorSample.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/TestApps/Samples/Samples/FontSelectorSample.cs
+++ b/TestApps/Samples/Samples/FontSelectorSample.cs
@@ -1,0 +1,48 @@
+﻿//
+// FontSelectorSample.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt;
+
+namespace Samples
+{
+	public class FontSelectorSample: VBox
+	{
+		public FontSelectorSample ()
+		{
+			FontSelector sel = new FontSelector ();
+			sel.PreviewText = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy";
+			Label preview = new Label ("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy");
+			preview.Ellipsize = EllipsizeMode.End;
+
+			sel.FontChanged += (sender, e) => preview.Font = sel.SelectedFont;
+
+			PackStart (sel);
+			PackStart (new HSeparator());
+			PackStart (preview);
+		}
+	}
+}
+

--- a/TestApps/Samples/Samples/Windows.cs
+++ b/TestApps/Samples/Samples/Windows.cs
@@ -141,6 +141,21 @@ namespace Samples
 					MessageDialog.ShowMessage ("A color has been selected!", dlg.Color.ToString ());
 			};
 
+			b = new Button ("Show Select Font dialog");
+			PackStart (b);
+			b.Clicked += delegate {
+				SelectFontDialog dlg = new SelectFontDialog ();
+				if (dlg.Run (ParentWindow)) {
+					Dialog d = new Dialog ();
+					d.Title = "A font has been selected!";
+					d.Content = new Label (dlg.SelectedFont.ToString ());
+					d.Content.Font = dlg.SelectedFont;
+					d.Buttons.Add (new DialogButton (Command.Ok));
+					d.Run (this.ParentWindow);
+					d.Dispose ();
+				}
+			};
+
 			b = new Button("Show window shown event");
 			PackStart(b);
 			b.Clicked += delegate

--- a/Xwt.Gtk/Xwt.Gtk.csproj
+++ b/Xwt.Gtk/Xwt.Gtk.csproj
@@ -151,6 +151,8 @@
     <Compile Include="Xwt.GtkBackend\ColorSelectorBackend.cs" />
     <Compile Include="Xwt.GtkBackend\ColorPickerBackend.cs" />
     <Compile Include="Xwt.GtkBackend\CalendarBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\FontSelectorBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\SelectFontDialogBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Xwt.Gtk/Xwt.Gtk3.csproj
+++ b/Xwt.Gtk/Xwt.Gtk3.csproj
@@ -154,6 +154,9 @@
     <Compile Include="Xwt.GtkBackend\ColorSelectorBackend.cs" />
     <Compile Include="Xwt.GtkBackend\ColorPickerBackend.cs" />
     <Compile Include="Xwt.GtkBackend\CalendarBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\SelectFontDialogBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\Gtk3FontChooserDialog.cs" />
+    <Compile Include="Xwt.GtkBackend\FontSelectorBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Xwt.Gtk/Xwt.GtkBackend/FontSelectorBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/FontSelectorBackend.cs
@@ -1,0 +1,136 @@
+﻿//
+// FontSelectorBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt.Backends;
+using System.Runtime.InteropServices;
+
+namespace Xwt.GtkBackend
+{
+	public class FontSelectorBackend: WidgetBackend, IFontSelectorBackend
+	{
+		public FontSelectorBackend ()
+		{
+		}
+
+		public override void Initialize ()
+		{
+			Widget = new GtkFontSelection ();
+			base.Widget.Show ();
+		}
+
+		protected new GtkFontSelection Widget {
+			get { return (GtkFontSelection)base.Widget; }
+			set { base.Widget = value; }
+		}
+
+		protected new IFontSelectorEventSink EventSink {
+			get { return (IFontSelectorEventSink)base.EventSink; }
+		}
+
+		public override void EnableEvent (object eventId)
+		{
+			base.EnableEvent (eventId);
+			if (eventId is FontSelectorEvent) {
+				switch ((FontSelectorEvent)eventId) {
+					case FontSelectorEvent.FontChanged: Widget.FontChanged += HandleFontChanged; break;
+				}
+			}
+		}
+
+		public override void DisableEvent (object eventId)
+		{
+			base.DisableEvent (eventId);
+			if (eventId is FontSelectorEvent) {
+				switch ((FontSelectorEvent)eventId) {
+					case FontSelectorEvent.FontChanged: Widget.FontChanged -= HandleFontChanged; break;
+				}
+			}
+		}
+
+		void HandleFontChanged (object sender, EventArgs e)
+		{
+			ApplicationContext.InvokeUserCode (delegate {
+				EventSink.OnFontChanged ();
+			});
+		}
+
+		public Xwt.Drawing.Font SelectedFont {
+			get {
+				return Xwt.Drawing.Font.FromName (Widget.FontName);
+			}
+			set {
+				Widget.FontName = value.ToString ();
+			}
+		}
+
+		public string PreviewText {
+			get { return Widget.PreviewText; }
+			set { Widget.PreviewText = value; }
+		}
+	}
+
+	public class GtkFontSelection: Gtk.FontSelection
+	{
+		public event EventHandler FontChanged;
+
+		public GtkFontSelection()
+		{
+			// there is no special font changed event
+			// check whether the font changed on every redraw of the preview entry
+			var entry = GetPreviewEntry();
+			#if XWT_GTK3
+			entry.Drawn += HandleExposeEvent;
+			#else
+			entry.ExposeEvent += HandleExposeEvent;
+			#endif
+		}
+
+		string cachedFontName = String.Empty;
+		void HandleExposeEvent (object o, EventArgs args)
+		{
+			if (cachedFontName !=  FontName) {
+				cachedFontName = FontName;
+				if (FontChanged != null)
+					FontChanged (this, new EventArgs ());
+			}
+		}
+
+		[DllImport (GtkInterop.LIBGTK, CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr gtk_font_selection_get_preview_entry (IntPtr raw);
+
+		Gtk.Entry GetPreviewEntry ()
+		{
+			IntPtr intPtr = gtk_font_selection_get_preview_entry (base.Handle);
+			Gtk.Entry result;
+			if (intPtr == IntPtr.Zero)
+				result = null;
+			else
+				result = (Gtk.Entry)GLib.Object.GetObject (intPtr);
+			return result;
+		}
+	}
+}
+

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk3FontChooserDialog.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk3FontChooserDialog.cs
@@ -1,0 +1,106 @@
+﻿//
+// Gtk3FontChooserDialog.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Runtime.InteropServices;
+
+namespace Xwt.GtkBackend
+{
+	public class Gtk3FontChooserDialog : Gtk.Dialog
+	{
+
+		[DllImport(GtkInterop.LIBGTK, CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gtk_font_chooser_dialog_new(IntPtr title, IntPtr parent);
+
+		[DllImport(GtkInterop.LIBGTK, CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gtk_font_chooser_widget_get_type();
+
+		public Gtk3FontChooserDialog (IntPtr raw) : base(raw)
+		{
+		}
+
+		public Gtk3FontChooserDialog (string title, Gtk.Window parent = null) : base (IntPtr.Zero)
+		{
+			IntPtr ptitle = GLib.Marshaller.StringToPtrGStrdup (title);
+			Raw = gtk_font_chooser_dialog_new(ptitle, parent == null ? IntPtr.Zero : parent.Handle);
+			GLib.Marshaller.Free (ptitle);
+
+			using (GLib.Value val = new GLib.Value (true)) {
+				SetProperty ("show-preview-entry", val);
+			}
+		}
+
+		public static new GLib.GType GType { 
+			get {
+				IntPtr raw_ret = gtk_font_chooser_widget_get_type();
+				GLib.GType ret = new GLib.GType(raw_ret);
+				return ret;
+			}
+		}
+
+		public string FontName {
+			get  {
+				using (GLib.Value property = GetProperty ("font")) {
+					string result = (string)property;
+					return result;
+				}
+			}
+			set  {
+				using (GLib.Value val = new GLib.Value (value)) {
+					SetProperty ("font", val);
+				}
+			}
+		}
+
+		public void SetFontName (string fontname)
+		{
+			FontName = fontname;
+		}
+
+		public string PreviewText {
+			get {
+				using (GLib.Value property = GetProperty ("preview-text")) {
+					string result = (string)property;
+					return result;
+				}
+			}
+			set {
+				using (GLib.Value val = new GLib.Value (value)) {
+					SetProperty ("preview-text", val);
+				}
+			}
+		}
+
+		[GLib.Signal("font-activated")]
+		public event EventHandler FontActivated {
+			add {
+				AddSignalHandler ("font-activated", value, typeof (EventArgs));
+			}
+			remove {
+				RemoveSignalHandler ("font-activated", value);
+			}
+		}
+	}
+}

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
@@ -112,6 +112,8 @@ namespace Xwt.GtkBackend
 			RegisterBackend<IColorSelectorBackend, ColorSelectorBackend> ();
 			RegisterBackend<IColorPickerBackend, ColorPickerBackend> ();
 			RegisterBackend<ICalendarBackend, CalendarBackend> ();
+			RegisterBackend<IFontSelectorBackend, FontSelectorBackend> ();
+			RegisterBackend<ISelectFontDialogBackend, SelectFontDialogBackend> ();
 
 			string typeName = null;
 			string asmName = null;

--- a/Xwt.Gtk/Xwt.GtkBackend/SelectFontDialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/SelectFontDialogBackend.cs
@@ -1,0 +1,97 @@
+﻿//
+// SelectFontDialogBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt.Backends;
+using Xwt.Drawing;
+
+namespace Xwt.GtkBackend
+{
+	#if XWT_GTK3
+	using FontSelectionDialog = Gtk3FontChooserDialog;
+	#else
+	using FontSelectionDialog = Gtk.FontSelectionDialog;
+	#endif
+
+	public class SelectFontDialogBackend: ISelectFontDialogBackend
+	{
+		readonly FontSelectionDialog dlg;
+		string defaultTitle;
+		string defaultPreviewText;
+
+		public Font SelectedFont {
+			get;
+			set;
+		}
+
+		public string Title {
+			get;
+			set;
+		}
+
+		public string PreviewText {
+			get;
+			set;
+		}
+
+		public SelectFontDialogBackend ()
+		{
+			dlg = new FontSelectionDialog (null);
+			defaultTitle = dlg.Title;
+			defaultPreviewText = dlg.PreviewText;
+		}
+
+		public bool Run (IWindowFrameBackend parent)
+		{
+			if (!String.IsNullOrEmpty (Title))
+				dlg.Title = Title;
+			else
+				dlg.Title = defaultTitle;
+
+			if (!String.IsNullOrEmpty (PreviewText))
+				dlg.PreviewText = PreviewText;
+			else
+				dlg.PreviewText = defaultPreviewText;
+
+			if (SelectedFont != null)
+				dlg.SetFontName (SelectedFont.ToString ());
+
+			var p = (WindowFrameBackend)parent;
+			int result = MessageService.RunCustomDialog (dlg, p != null ? p.Window : null);
+
+			if (result == (int)Gtk.ResponseType.Ok) {
+				SelectedFont = Font.FromName (dlg.FontName);
+				return true;
+			}
+			return false;
+		}
+
+		public void Dispose ()
+		{
+			dlg.Destroy ();
+		}
+	}
+}
+

--- a/Xwt.Mac/Xwt.Mac.csproj
+++ b/Xwt.Mac/Xwt.Mac.csproj
@@ -287,6 +287,9 @@
     <Compile Include="..\Xwt.XamMac\Xwt.Mac\CalendarBackend.cs">
       <Link>Xwt.Mac\CalendarBackend.cs</Link>
     </Compile>
+    <Compile Include="..\Xwt.XamMac\Xwt.Mac\SelectFontDialogBackend.cs">
+      <Link>Xwt.Mac\SelectFontDialogBackend.cs</Link>
+    </Compile>
     <Compile Include="Xwt.Mac\NSStringAttributeKey.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
@@ -28,6 +28,8 @@ using System;
 using Xwt.Backends;
 using Xwt.Drawing;
 using System.Collections.Generic;
+using System.Text;
+using System.Globalization;
 
 #if MONOMAC
 using nint = System.Int32;
@@ -337,6 +339,19 @@ namespace Xwt.Mac
 				Weight = Weight,
 				Stretch = Stretch
 			};
+		}
+
+		public override string ToString ()
+		{
+			StringBuilder sb = new StringBuilder (Font.FamilyName);
+			if (Style != FontStyle.Normal)
+				sb.Append (' ').Append (Style);
+			if (Weight != FontWeight.Normal)
+				sb.Append (' ').Append (Weight);
+			if (Stretch != FontStretch.Normal)
+				sb.Append (' ').Append (Stretch);
+			sb.Append (' ').Append (Font.PointSize.ToString (CultureInfo.InvariantCulture));
+			return sb.ToString ();
 		}
 	}
 

--- a/Xwt.XamMac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacEngine.cs
@@ -136,6 +136,7 @@ namespace Xwt.Mac
 			RegisterBackend <Xwt.Backends.ISaveFileDialogBackend, SaveFileDialogBackend> ();
 			RegisterBackend <Xwt.Backends.IColorPickerBackend, ColorPickerBackend> ();
 			RegisterBackend <Xwt.Backends.ICalendarBackend,CalendarBackend> ();
+			RegisterBackend <Xwt.Backends.ISelectFontDialogBackend, SelectFontDialogBackend> ();
 		}
 
 		public override void RunApplication ()

--- a/Xwt.XamMac/Xwt.Mac/SelectFontDialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/SelectFontDialogBackend.cs
@@ -1,0 +1,96 @@
+﻿//
+// SelectFontDialogBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using Xwt.Backends;
+using Xwt.Drawing;
+
+#if MONOMAC
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+#else
+using AppKit;
+using Foundation;
+#endif
+
+namespace Xwt.Mac
+{
+	public class SelectFontDialogBackend : ISelectFontDialogBackend
+	{
+		readonly NSFontPanel fontPanel;
+
+		public SelectFontDialogBackend ()
+		{
+			fontPanel = NSFontPanel.SharedFontPanel;
+		}
+
+		public bool Run (IWindowFrameBackend parent)
+		{
+			fontPanel.Delegate = new FontPanelDelegate ();
+
+			if (SelectedFont != null) {
+				NSFontManager.SharedFontManager.SetSelectedFont (((FontData)Toolkit.GetBackend (SelectedFont)).Font, false);
+			}
+
+			NSApplication.SharedApplication.RunModalForWindow (fontPanel);
+
+			var font = NSFontPanel.SharedFontPanel.PanelConvertFont (NSFont.SystemFontOfSize (0));
+			SelectedFont = Font.FromName (FontData.FromFont (font).ToString ());
+
+			return true;
+		}
+
+		public string Title {
+			get {
+				return fontPanel.Title;
+			}
+			set {
+				fontPanel.Title = value;
+			}
+		}
+
+		public Font SelectedFont { get; set; }
+
+		public string PreviewText { get; set; }
+
+		public void Dispose ()
+		{
+		}
+	}
+
+	class FontPanelDelegate : NSWindowDelegate
+	{
+		[Export ("validModesForFontPanel:")]
+		NSFontPanelMode ValidModesForFontPanel (NSFontPanel panel)
+		{
+			return NSFontPanelMode.CollectionMask | NSFontPanelMode.FaceMask | NSFontPanelMode.SizeMask;
+		}
+
+		public override void WillClose (NSNotification notification)
+		{
+			NSApplication.SharedApplication.StopModal ();
+		}
+	}
+}
+

--- a/Xwt.XamMac/Xwt.XamMac.csproj
+++ b/Xwt.XamMac/Xwt.XamMac.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Xwt.Mac\ColorPickerBackend.cs" />
     <Compile Include="Xwt.Mac\OutlineViewBackend.cs" />
     <Compile Include="Xwt.Mac\CalendarBackend.cs" />
+    <Compile Include="Xwt.Mac\SelectFontDialogBackend.cs" />
   </ItemGroup>
   <Import Project="..\BuildHelpers.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Xwt/Xwt.Backends/IFontSelectorBackend.cs
+++ b/Xwt/Xwt.Backends/IFontSelectorBackend.cs
@@ -1,0 +1,55 @@
+﻿//
+// IFontSelectorBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using Xwt.Drawing;
+
+namespace Xwt.Backends
+{
+	public interface IFontSelectorBackend: IWidgetBackend
+	{
+		/// <summary>
+		/// Gets or sets the selected font.
+		/// </summary>
+		/// <value>The selected font.</value>
+		Font SelectedFont { get; set; }
+
+		/// <summary>
+		/// Gets or sets the text used for the font preview.
+		/// </summary>
+		/// <value>The preview text.</value>
+		string PreviewText { get; set; }
+	}
+
+	public interface IFontSelectorEventSink: IWidgetEventSink
+	{
+		void OnFontChanged ();
+	}
+
+	public enum FontSelectorEvent
+	{
+		FontChanged
+	}
+}
+

--- a/Xwt/Xwt.Backends/ISelectFontDialogBackend.cs
+++ b/Xwt/Xwt.Backends/ISelectFontDialogBackend.cs
@@ -1,0 +1,73 @@
+﻿//
+// ISelectFontDialogBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using Xwt.Drawing;
+
+namespace Xwt.Backends
+{
+	public interface ISelectFontDialogBackend
+	{
+		/// <summary>
+		/// Gets or sets the title of the dialog
+		/// </summary>
+		string Title { get; set; }
+
+		/// <summary>
+		/// Gets or sets the selected font
+		/// </summary>
+		Font SelectedFont { get; set; }
+
+		/// <summary>
+		/// Gets or sets the text used for the font preview.
+		/// </summary>
+		/// <value>The preview text.</value>
+		string PreviewText { get; set; }
+
+		/// <summary>
+		/// Runs the dialog, allowing the user to select a font
+		/// </summary>
+		/// <param name='parent'>
+		/// Parent window (the dialog will be modal to this window). It can be null.
+		/// </param>
+		/// <param name='title'>
+		/// Title of the dialog
+		/// </param>
+		/// <returns>
+		/// <c>true</c> if the user clicked OK, <c>false</c> otherwise
+		/// </returns>
+		/// <remarks>
+		/// The Run method will always be called once (and only once).
+		/// The dialog must be shown in modal mode. The method returns when the user clicks on
+		/// OK or Cancel. The dialog must be already closed when this method returns.
+		/// </remarks>
+		bool Run (IWindowFrameBackend parent);
+
+		/// <summary>
+		/// Frees native resources
+		/// </summary>
+		void Dispose ();	
+	}
+}
+

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -329,6 +329,8 @@
     <Compile Include="Xwt.Backends\ICalendarBackend.cs" />
     <Compile Include="Xwt\FontSelector.cs" />
     <Compile Include="Xwt.Backends\IFontSelectorBackend.cs" />
+    <Compile Include="Xwt\SelectFontDialog.cs" />
+    <Compile Include="Xwt.Backends\ISelectFontDialogBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -327,6 +327,8 @@
     <Compile Include="Xwt\XwtSynchronizationContext.cs" />
     <Compile Include="Xwt\Calendar.cs" />
     <Compile Include="Xwt.Backends\ICalendarBackend.cs" />
+    <Compile Include="Xwt\FontSelector.cs" />
+    <Compile Include="Xwt.Backends\IFontSelectorBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt/FontSelector.cs
+++ b/Xwt/Xwt/FontSelector.cs
@@ -1,0 +1,318 @@
+﻿//
+// FontSelector.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xwt.Backends;
+using Xwt.Drawing;
+
+namespace Xwt
+{
+	/// <summary>
+	/// The <see cref="Xwt.FontSelector"/> widget allows the user to select a font.
+	/// The user can choose from available/installed fonts, styles and sizes.
+	/// </summary>
+	/// <remarks>
+	/// The widget contains a preview text box with the selected font. The preview
+	/// text can be modified.
+	/// The widget raises the <see cref="Xwt.FontSelector.FontChanged"/> event, when
+	/// the selected font changes.
+	/// </remarks>
+	[BackendType (typeof(IFontSelectorBackend))]
+	public class FontSelector: Widget
+	{
+		protected new class WidgetBackendHost: Widget.WidgetBackendHost, IFontSelectorEventSink
+		{
+			protected override IBackend OnCreateBackend ()
+			{
+				var b = base.OnCreateBackend ();
+				if (b == null)
+					b = new DefaultFontSelectorBackend ();
+				return b;
+			}
+
+			public void OnFontChanged ()
+			{
+				((FontSelector)Parent).OnFontChanged (EventArgs.Empty);
+			}
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.FontSelector"/> widget.
+		/// </summary>
+		public FontSelector ()
+		{
+		}
+
+		protected override BackendHost CreateBackendHost ()
+		{
+			return new WidgetBackendHost ();
+		}
+
+		IFontSelectorBackend Backend {
+			get { return (IFontSelectorBackend) BackendHost.Backend; }
+		}
+
+		/// <summary>
+		/// Gets or sets the selected font.
+		/// </summary>
+		/// <value>The selected font.</value>
+		public Font SelectedFont {
+			get { return Backend.SelectedFont; }
+			set { Backend.SelectedFont = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the text used for the font preview.
+		/// </summary>
+		/// <value>The preview text.</value>
+		public string PreviewText {
+			get { return Backend.PreviewText; }
+			set { Backend.PreviewText = value; }
+		}
+
+		protected virtual void OnFontChanged (EventArgs args)
+		{
+			if (fontChanged != null)
+				fontChanged (this, args);
+		}
+
+		EventHandler fontChanged;
+
+		/// <summary>
+		/// Occurs when the font changed.
+		/// </summary>
+		public event EventHandler FontChanged {
+			add {
+				BackendHost.OnBeforeEventAdd (FontSelectorEvent.FontChanged, fontChanged);
+				fontChanged += value;
+			}
+			remove {
+				fontChanged -= value;
+				BackendHost.OnAfterEventRemove (FontSelectorEvent.FontChanged, fontChanged);
+			}
+		}
+	}
+
+	class DefaultFontSelectorBackend: XwtWidgetBackend, IFontSelectorBackend
+	{
+		Font font = Font.SystemFont;
+		TextEntry previewText = new TextEntry ();
+
+		ListView listFonts = new ListView ();
+		ListStore storeFonts;
+		ListView listWeight = new ListView ();
+		ListStore storeWeight;
+		ListView listStyle = new ListView ();
+		ListStore storeStyle;
+		ListBox listSize = new ListBox ();
+		SpinButton spnSize = new SpinButton();
+
+		static readonly double[] DefaultFontSizes = {
+			6.0,     7.0,   8.0,   9.0,   10.0,   11.0,  12.0,  13.0,  14.0,  15.0,  16.0,  17.0,  18.0,
+			20.0,   22.0,  24.0,  26.0,   28.0,   32.0,  36.0,  40.0,  44.0,  48.0,  54.0,  60.0,  66.0,
+			72.0,   80.0,  88.0,  96.0,  104.0,  112.0, 120.0, 128.0, 136.0, 144.0
+		};
+
+		DataField<FontWeight> dweight = new DataField<FontWeight> ();
+		DataField<FontStyle> dstyle = new DataField<FontStyle> ();
+		DataField<string> dfamily = new DataField<string> ();
+		DataField<string> dfamilymarkup = new DataField<string> ();
+
+		List<string> families = new List<string>();
+
+		bool enableFontChangedEvent;
+
+		public DefaultFontSelectorBackend ()
+		{
+			families = Font.AvailableFontFamilies.ToList ();
+			families.Sort ();
+
+			storeFonts = new ListStore (dfamily, dfamilymarkup);
+			listFonts.DataSource = storeFonts;
+			listFonts.HeadersVisible = false;
+			listFonts.Columns.Add ("Font", new TextCellView () { TextField = dfamily, MarkupField = dfamilymarkup });
+
+			foreach (var family in families) {
+				var row = storeFonts.AddRow ();
+				storeFonts.SetValues (row, dfamily, family, dfamilymarkup, "<span font=\"" + family + " " + (listFonts.Font.Size) + "\">" + family + "</span>");
+			}
+
+			storeWeight = new ListStore (dweight);
+			listWeight.DataSource = storeWeight;
+			listWeight.HeadersVisible = false;
+			listWeight.Columns.Add ("Weight", dweight);
+
+			foreach (var weight in Enum.GetValues(typeof(FontWeight))) {
+				var row = storeWeight.AddRow ();
+				storeWeight.SetValue(row, dweight, (FontWeight)weight);
+			}
+
+			storeStyle = new ListStore (dstyle);
+			listStyle.DataSource = storeStyle;
+			listStyle.HeadersVisible = false;
+			listStyle.Columns.Add ("Style", dstyle);
+
+
+			foreach (var style in Enum.GetValues(typeof(FontStyle))) {
+				var row = storeStyle.AddRow ();
+				storeStyle.SetValue(row, dstyle, (FontStyle)style);
+			}
+
+			foreach (var size in DefaultFontSizes)
+				listSize.Items.Add (size);
+
+			spnSize.Digits = 1;
+			spnSize.MinimumValue = 1;
+			spnSize.MaximumValue = 800;
+			spnSize.IncrementValue = 1;
+
+			spnSize.ValueChanged += (sender, e) => {
+				if (DefaultFontSizes.Contains (spnSize.Value)) {
+					var row = Array.IndexOf(DefaultFontSizes, spnSize.Value);
+					listSize.ScrollToRow(row);
+					listSize.SelectRow(row);
+				}
+				else
+					listSize.UnselectAll ();
+				UpdateFont();
+			};
+
+			listWeight.HorizontalScrollPolicy = ScrollPolicy.Never;
+			listStyle.HorizontalScrollPolicy = ScrollPolicy.Never;
+
+			SelectedFont = Font.SystemFont;
+			PreviewText = "The quick brown fox jumps over the lazy dog.";
+
+			listFonts.SelectionChanged += (sender, e) => UpdateFont();
+			listWeight.SelectionChanged += (sender, e) => UpdateFont();
+			listStyle.SelectionChanged += (sender, e) => UpdateFont();
+			listSize.SelectionChanged += (sender, e) => {
+				if (listSize.SelectedRow >= 0 && DefaultFontSizes[listSize.SelectedRow] != spnSize.Value)
+					spnSize.Value = DefaultFontSizes[listSize.SelectedRow];
+			};
+
+			VBox familyBox = new VBox ();
+			familyBox.PackStart (new Label ("Font:"));
+			familyBox.PackStart (listFonts, true);
+
+			VBox propBox = new VBox ();
+			propBox.PackStart (new Label ("Weight:"));
+			propBox.PackStart (listWeight, true);
+			propBox.PackStart (new Label ("Style:"));
+			propBox.PackStart (listStyle, true);
+
+			VBox sizeBox = new VBox ();
+			sizeBox.PackStart (new Label ("Size:"));
+			sizeBox.PackStart (spnSize);
+			sizeBox.PackStart (listSize, true);
+
+			HBox fontBox = new HBox ();
+			fontBox.PackStart (familyBox, true);
+			fontBox.PackStart (propBox);
+			fontBox.PackStart (sizeBox);
+
+			VBox mainBox = new VBox ();
+			mainBox.MinWidth = 350;
+			mainBox.MinHeight = 300;
+			mainBox.PackStart (fontBox, true);
+			mainBox.PackStart (new Label ("Preview:"));
+			mainBox.PackStart (previewText);
+
+			Content = mainBox;
+		}
+
+		void UpdateFont()
+		{
+			SelectedFont = Font.FromName (storeFonts.GetValue(listFonts.SelectedRow, dfamily))
+				.WithWeight (storeWeight.GetValue (listWeight.SelectedRow, dweight))
+				.WithStyle (storeStyle.GetValue (listStyle.SelectedRow, dstyle))
+				.WithSize (spnSize.Value);
+
+			if (enableFontChangedEvent)
+				Application.Invoke (delegate {
+					EventSink.OnFontChanged ();
+				});
+		}
+
+		public Font SelectedFont {
+			get {
+				return font;
+			}
+			set {
+				font = value;
+				previewText.Font = font;
+
+				int rowFamily = families.IndexOf (font.Family);
+				if (listFonts.SelectedRow != rowFamily) {
+					listFonts.ScrollToRow (rowFamily);
+					listFonts.SelectRow (rowFamily);
+				}
+				int rowWeight = Array.IndexOf (Enum.GetValues(typeof(FontWeight)), font.Weight);
+				if (listWeight.SelectedRow != rowWeight) {
+					listWeight.ScrollToRow (rowWeight);
+					listWeight.SelectRow (rowWeight);
+				}
+				int rowStyle = Array.IndexOf (Enum.GetValues(typeof(FontStyle)), font.Style);
+				if (listStyle.SelectedRow != rowStyle) {
+					listStyle.ScrollToRow (rowStyle);
+					listStyle.SelectRow (rowStyle);
+				}
+				spnSize.Value = font.Size;
+			}
+		}
+
+		public string PreviewText {
+			get { return previewText.Text; }
+			set { previewText.Text = value; }
+		}
+
+		protected new IFontSelectorEventSink EventSink {
+			get { return (IFontSelectorEventSink)base.EventSink; }
+		}
+
+		public override void EnableEvent (object eventId)
+		{
+			base.EnableEvent (eventId);
+			if (eventId is FontSelectorEvent) {
+				switch ((FontSelectorEvent)eventId) {
+					case FontSelectorEvent.FontChanged: enableFontChangedEvent = true; break;
+				}
+			}
+		}
+
+		public override void DisableEvent (object eventId)
+		{
+			base.DisableEvent (eventId);
+			if (eventId is FontSelectorEvent) {
+				switch ((FontSelectorEvent)eventId) {
+					case FontSelectorEvent.FontChanged: enableFontChangedEvent = false; break;
+				}
+			}
+		}
+	}
+}
+

--- a/Xwt/Xwt/FontSelector.cs
+++ b/Xwt/Xwt/FontSelector.cs
@@ -137,6 +137,7 @@ namespace Xwt
 
 		DataField<Font> dfaceFont = new DataField<Font> ();
 		DataField<string> dfaceName = new DataField<string> ();
+		DataField<string> dfaceMarkup = new DataField<string> ();
 		DataField<string> dfamily = new DataField<string> ();
 		DataField<string> dfamilymarkup = new DataField<string> ();
 
@@ -160,10 +161,10 @@ namespace Xwt
 				storeFonts.SetValues (row, dfamily, family, dfamilymarkup, "<span font=\"" + family + " " + (listFonts.Font.Size) + "\">" + family + "</span>");
 			}
 
-			storeFace = new ListStore (dfaceName, dfaceFont);
+			storeFace = new ListStore (dfaceName, dfaceMarkup, dfaceFont);
 			listFace.DataSource = storeFace;
 			listFace.HeadersVisible = false;
-			listFace.Columns.Add ("Style", dfaceName);
+			listFace.Columns.Add ("Style", new TextCellView () { TextField = dfaceName, MarkupField = dfaceMarkup });
 			listFace.MinWidth = 60;
 			//listFace.HorizontalScrollPolicy = ScrollPolicy.Never;
 
@@ -257,7 +258,7 @@ namespace Xwt
 			int row = -1;
 			foreach (var face in font.GetAvailableFontFaces ()) {
 				row = storeFace.AddRow ();
-				storeFace.SetValues (row, dfaceName, face.Name, dfaceFont, face.Font);
+				storeFace.SetValues (row, dfaceName, face.Name, dfaceFont, face.Font, dfaceMarkup, "<span font=\"" + face.Font.WithSize (listFace.Font.Size) + "\">" + face.Name + "</span>");
 			}
 			if (row >= 0) {
 				listFace.SelectRow (0);

--- a/Xwt/Xwt/SelectFontDialog.cs
+++ b/Xwt/Xwt/SelectFontDialog.cs
@@ -1,0 +1,169 @@
+﻿//
+// SelectFontDialog.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using Xwt.Drawing;
+using Xwt.Backends;
+using System;
+
+namespace Xwt
+{
+	public sealed class SelectFontDialog
+	{
+		Font font = Font.SystemFont;
+		string title = "Select a font";
+		string previewText = "The quick brown fox jumps over the lazy dog.";
+
+		public SelectFontDialog ()
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Xwt.SelectFontDialog"/> class.
+		/// </summary>
+		/// <param name='title'>
+		/// Title of the dialog
+		/// </param>
+		public SelectFontDialog (string title)
+		{
+			this.title = title;
+		}
+
+		/// <summary>
+		/// Gets or sets the title of the dialog
+		/// </summary>
+		public string Title {
+			get { return title ?? ""; }
+			set { title = value ?? ""; }
+		}
+
+		/// <summary>
+		/// Gets or sets the selected font
+		/// </summary>
+		public Font SelectedFont {
+			get { return font; }
+			set { font = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the text used for the font preview.
+		/// </summary>
+		/// <value>The preview text.</value>
+		public string PreviewText {
+			get { return previewText; }
+			set { previewText = value; }
+		}
+
+		/// <summary>
+		/// Shows the dialog.
+		/// </summary>
+		public bool Run ()
+		{
+			return Run (null);
+		}
+
+		/// <summary>
+		/// Shows the dialog.
+		/// </summary>
+		public bool Run (WindowFrame parentWindow)
+		{
+			var backend = Toolkit.CurrentEngine.Backend.CreateBackend<ISelectFontDialogBackend> ();
+			if (backend == null)
+				backend = new DefaultSelectFontDialogBackend (parentWindow);
+			try {
+				backend.SelectedFont = SelectedFont;
+				backend.Title = Title;
+				backend.PreviewText = PreviewText;
+				return backend.Run ((IWindowFrameBackend)Toolkit.CurrentEngine.GetSafeBackend (parentWindow));
+			} catch (Exception ex) {
+				Console.WriteLine (ex);
+				return false;
+			} finally {
+				font = backend.SelectedFont;
+				backend.Dispose ();
+			}
+		}
+	}
+
+	public class DefaultSelectFontDialogBackend: ISelectFontDialogBackend
+	{
+		readonly Dialog fontDialog;
+		readonly WindowFrame parent;
+		readonly FontSelector fontSelector;
+
+		public DefaultSelectFontDialogBackend (WindowFrame parentWindow)
+		{
+			parent = parentWindow;
+
+			fontDialog = new Dialog ();
+			fontDialog.Width = 500;
+			fontDialog.Height = 300;
+
+			VBox box = new VBox ();
+			fontSelector = new FontSelector ();
+			fontSelector.FontChanged += (sender, e) => SelectedFont = fontSelector.SelectedFont;
+			box.PackStart (fontSelector, true);
+
+			fontDialog.Content = box;
+
+			fontDialog.Buttons.Add (new DialogButton (Command.Cancel));
+			fontDialog.Buttons.Add (new DialogButton (Command.Ok));
+		}
+
+		public Font SelectedFont {
+			get;
+			set;
+		}
+
+		public string PreviewText {
+			get {
+				return fontSelector.PreviewText;
+			}
+			set {
+				fontSelector.PreviewText = value;
+			}
+		}
+
+		public string Title {
+			get {
+				return fontDialog.Title;
+			}
+			set {
+				fontDialog.Title = value;
+			}
+		}
+
+		public bool Run (IWindowFrameBackend parent)
+		{
+			fontSelector.SelectedFont = SelectedFont;
+			return fontDialog.Run (this.parent) == Command.Ok;
+		}
+
+		public void Dispose ()
+		{
+			fontDialog.Dispose ();
+		}
+	}
+}
+


### PR DESCRIPTION
Adds a new FontSelector widget and a SelectFontDialog. Both have their own XwtWidgetBackend based implementations like ColorSelector (native backends are coming).

Backend compatibility:
* WPF: needs ~~#441~~, #442 
* GTK: works out of the box
* MAC: works after ~~#426~~, ~~#446~~ and ~~#447~~

Examples included. This PR includes ~~#450~~ (I've created a separate PR for better overview, since the other contains important fixes, that do not depend on this one.)