### PR TITLE
[Mac] fix button sizing and colors

### DIFF
--- a/Xwt.Mac/Xwt.Mac/ButtonBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/ButtonBackend.cs
@@ -135,11 +135,9 @@ namespace Xwt.Mac
 		
 		#endregion
 
-		// Disable ugly bg color support. The default behavior applies the color around the button.
-		// TODO: bg color needs to be drawn above the bezel.
 		public override Color BackgroundColor {
-			get;
-			set;
+			get { return ((MacButton)Widget).BackgroundColor; }
+			set { ((MacButton)Widget).BackgroundColor = value; }
 		}
 	}
 	
@@ -159,6 +157,7 @@ namespace Xwt.Mac
 		
 		public MacButton (IButtonEventSink eventSink, ApplicationContext context)
 		{
+			Cell = new ColoredButtonCell ();
 			BezelStyle = NSBezelStyle.Rounded;
 			Activated += delegate {
 				context.InvokeUserCode (delegate {
@@ -213,6 +212,25 @@ namespace Xwt.Mac
 			base.ResetCursorRects ();
 			if (Backend.Cursor != null)
 				AddCursorRect (Bounds, Backend.Cursor);
+		}
+
+		public Color BackgroundColor {
+			get {
+				return ((ColoredButtonCell)Cell).Color.GetValueOrDefault ();
+			}
+			set {
+				((ColoredButtonCell)Cell).Color = value;
+			}
+		}
+
+		class ColoredButtonCell : NSButtonCell
+		{
+			public Color? Color { get; set; }
+
+			public override void DrawBezelWithFrame (System.Drawing.RectangleF frame, NSView controlView)
+			{
+				controlView.DrawWithColorTransform(Color, delegate { base.DrawBezelWithFrame (frame, controlView); });
+			}
 		}
 	}
 }

--- a/Xwt.Mac/Xwt.Mac/MenuButtonBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/MenuButtonBackend.cs
@@ -28,6 +28,7 @@ using System;
 using MonoMac.Foundation;
 using MonoMac.AppKit;
 using Xwt.Backends;
+using Xwt.Drawing;
 
 
 namespace Xwt.Mac
@@ -46,6 +47,11 @@ namespace Xwt.Mac
 		{
 			ViewObject = new MacMenuButton (EventSink, ApplicationContext);
 		}
+
+		public override Color BackgroundColor {
+			get { return ((MacMenuButton)Widget).BackgroundColor; }
+			set { ((MacMenuButton)Widget).BackgroundColor = value; }
+		}
 	}
 
 	class MacMenuButton: NSPopUpButton, IViewObject
@@ -61,6 +67,8 @@ namespace Xwt.Mac
 		{
 			this.eventSink = eventSink;
 			this.context = context;
+
+			Cell = new ColoredPopUpButtonCell ();
 
 			PullsDown = true;
 			Activated += delegate {
@@ -101,6 +109,26 @@ namespace Xwt.Mac
 		public void DisableEvent (Xwt.Backends.ButtonEvent ev)
 		{
 		}
+
+		public Color BackgroundColor {
+			get {
+				return ((ColoredPopUpButtonCell)Cell).Color.GetValueOrDefault();
+			}
+			set {
+				((ColoredPopUpButtonCell)Cell).Color = value;
+			}
+		}
+
+		class ColoredPopUpButtonCell : NSPopUpButtonCell
+		{
+			public Color? Color { get; set; }
+
+			public override void DrawBezelWithFrame (System.Drawing.RectangleF frame, NSView controlView)
+			{
+				controlView.DrawWithColorTransform(Color, delegate { base.DrawBezelWithFrame (frame, controlView); });
+			}
+		}
+
 
 		protected override void Dispose (bool disposing)
 		{

--- a/Xwt.Mac/Xwt.Mac/ToggleButtonBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/ToggleButtonBackend.cs
@@ -73,23 +73,6 @@ namespace Xwt.Mac
 				});
 			}
 		}
-
-		public override void SetButtonStyle (ButtonStyle style)
-		{
-			switch (style) {
-				case ButtonStyle.Normal:
-					Widget.BezelStyle = NSBezelStyle.Rounded;
-					Messaging.void_objc_msgSend_bool (Widget.Handle, selSetShowsBorderOnlyWhileMouseInside.Handle, false);
-					break;
-				case ButtonStyle.Borderless:
-				case ButtonStyle.Flat:
-					Widget.BezelStyle = NSBezelStyle.ShadowlessSquare;
-					Messaging.void_objc_msgSend_bool (Widget.Handle, selSetShowsBorderOnlyWhileMouseInside.Handle, true);
-					break;
-			}
-		}
-
-		static Selector selSetShowsBorderOnlyWhileMouseInside = new Selector ("setShowsBorderOnlyWhileMouseInside:");
 	}
 }
 

--- a/Xwt.Mac/Xwt.Mac/Util.cs
+++ b/Xwt.Mac/Xwt.Mac/Util.cs
@@ -30,6 +30,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using MonoMac.AppKit;
 using MonoMac.CoreGraphics;
+using MonoMac.CoreImage;
 using MonoMac.Foundation;
 using MonoMac.ObjCRuntime;
 using Xwt.Backends;
@@ -438,6 +439,37 @@ namespace Xwt.Mac
 				return GridLines.Vertical;
 
 			return GridLines.None;
+		}
+
+		public static void DrawWithColorTransform (this NSView view, Color? color, Action drawDelegate)
+		{
+			if (color.HasValue) {
+				if (view.Frame.Size.Width <= 0 || view.Frame.Size.Height <= 0)
+					return;
+
+				// render view to image
+				var image = new NSImage(view.Frame.Size);
+				image.LockFocusFlipped(!view.IsFlipped);
+				drawDelegate ();
+				image.UnlockFocus();
+
+				// create Core image for transformation
+				var rr = new RectangleF(0, 0, view.Frame.Size.Width, view.Frame.Size.Height);
+				var ciImage = CIImage.FromCGImage(image.AsCGImage (ref rr, NSGraphicsContext.CurrentContext, null));
+
+				// apply color matrix
+				var transformColor = new CIColorMatrix();
+				transformColor.SetDefaults();
+				transformColor.Image = ciImage;
+				transformColor.RVector = new CIVector(0, (float)color.Value.Red, 0);
+				transformColor.GVector = new CIVector((float)color.Value.Green, 0, 0);
+				transformColor.BVector = new CIVector(0, 0, (float)color.Value.Blue);
+				ciImage = (CIImage)transformColor.ValueForKey(new NSString("outputImage"));
+
+				var ciCtx = CIContext.FromContext(NSGraphicsContext.CurrentContext.GraphicsPort, null);
+				ciCtx.DrawImage (ciImage, rr, rr);
+			} else
+				drawDelegate();
 		}
 	}
 


### PR DESCRIPTION
*Update: fixes button colors*

**Button sizing:**
The default NSBezelStyle.Rounded style (which is the default for text buttons on Mac)  does not support cusom heights.
When a custom size or image is used, the style should be set to NSBezelStyle.RegularSquare (the default for image or custom buttons on Mac) for the sizing to work as expected.