### PR TITLE
[Mac] fix CustomWidgetBackend / XwtWidgetBackend sizing

### DIFF
--- a/Xwt.Mac/Xwt.Mac/CustomWidgetBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/CustomWidgetBackend.cs
@@ -41,9 +41,7 @@ namespace Xwt.Mac
 
 		public override void Initialize ()
 		{
-			ViewObject = new WidgetView (EventSink, ApplicationContext);
-			if (Frontend is XwtWidgetBackend)
-				SetAutosizeMode (true);
+			ViewObject = new CustomWidgetView (EventSink, ApplicationContext);
 		}
 
 		public void SetContent (IWidgetBackend widget)
@@ -74,5 +72,20 @@ namespace Xwt.Mac
 		}
 	}
 
+	class CustomWidgetView: WidgetView
+	{
+		public CustomWidgetView (IWidgetEventSink eventSink, ApplicationContext context) : base (eventSink, context)
+		{
+		}
+
+		public override void SetFrameSize (System.Drawing.SizeF newSize)
+		{
+			base.SetFrameSize (newSize);
+			if (Subviews.Length == 0)
+				return;
+			Subviews [0].SetFrameSize (newSize);
+			Backend.Frontend.Surface.Reallocate ();
+		}
+	}
 }
 

--- a/Xwt.Mac/Xwt.Mac/CustomWidgetBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/CustomWidgetBackend.cs
@@ -42,6 +42,8 @@ namespace Xwt.Mac
 		public override void Initialize ()
 		{
 			ViewObject = new WidgetView (EventSink, ApplicationContext);
+			if (Frontend is XwtWidgetBackend)
+				SetAutosizeMode (true);
 		}
 
 		public void SetContent (IWidgetBackend widget)

--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -188,20 +188,27 @@ namespace Xwt.Mac
 		
 		public override object GetNativeWidget (Widget w)
 		{
-			ViewBackend wb = (ViewBackend)Toolkit.GetBackend (w);
+			var wb = GetNativeBackend (w);
 			wb.SetAutosizeMode (true);
 			return wb.Widget;
 		}
 
 		public override bool HasNativeParent (Widget w)
 		{
-			var b = (IWidgetBackend) Toolkit.GetBackend (w);
-			if (b is XwtWidgetBackend)
-				b = ((XwtWidgetBackend)b).NativeBackend;
-			ViewBackend wb = (ViewBackend)b;
+			var wb = GetNativeBackend (w);
 			return wb.Widget.Superview != null;
 		}
-		
+
+		public ViewBackend GetNativeBackend (Widget w)
+		{
+			var backend = Toolkit.GetBackend (w);
+			if (backend is ViewBackend)
+				return (ViewBackend)backend;
+			if (backend is XwtWidgetBackend)
+				return GetNativeBackend ((Widget)backend);
+			return null;
+		}
+
 		public override Xwt.Backends.IWindowFrameBackend GetBackendForWindow (object nativeWindow)
 		{
 			throw new NotImplementedException ();

--- a/Xwt.Mac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/ViewBackend.cs
@@ -79,8 +79,10 @@ namespace Xwt.Mac
 			canGetFocus = Widget.AcceptsFirstResponder ();
 		}
 
-		// To be called when the widget is a root and is not inside a Xwt window. For example, when it is in a popover or a tooltip
-		// In that case, the widget has to listen to the change event of the children and resize itself
+		/// <summary>
+		/// To be called when the widget is a root and is not inside a Xwt window. For example, when it is in a popover or a tooltip
+		/// In that case, the widget has to listen to the change event of the children and resize itself
+		/// </summary>
 		public void SetAutosizeMode (bool autosize)
 		{
 			this.autosize = autosize;


### PR DESCRIPTION
CustomWidgetBackend should adjust the size of the child widget to match own bounds directly (without AutoMode). This fixes display and sizing issues for custom widgets with containers.

Includes #226