### PR TITLE
[WPF] Removed empty Run elements in Markdown

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
@@ -139,7 +139,9 @@ namespace Xwt.WPFBackend
 						writer.WriteStartElement ("LineBreak");
 						writer.WriteEndElement ();
 					}
-					writer.WriteElementString ("Run", line);
+					if (!string.IsNullOrEmpty (line)) {
+						writer.WriteElementString ("Run", line);
+					}
 					first = false;
 				}
 			}


### PR DESCRIPTION
Markdown linebreaks add an empty Run element to the FlowDocument, which
adds a leading whitespace to the next line. This fixes that bug.

In the current implementations: `Line 1  \nLine2` leads to:

    <FlowDocument
    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
        <Paragraph>
            <Run>Line 1</Run>
            <LineBreak />
            <Run />
            <Run>Line 2</Run>
        </Paragraph>
    </FlowDocument>

and this renders to: 
![markdown-error](https://cloud.githubusercontent.com/assets/136216/5776460/13a0f90a-9d88-11e4-80c9-c98a2f9d81a8.png)

This commit changes that to:

    <FlowDocument
    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
        <Paragraph>
            <Run>Line 1</Run>
            <LineBreak />
            <Run>Line 2</Run>
        </Paragraph>
    </FlowDocument>

![markdown-fix](https://cloud.githubusercontent.com/assets/136216/5776466/1f7e02a4-9d88-11e4-9222-81adc5e13817.png)

