### PR TITLE
Consistent overloads for TreeNavigator.SetValues().

### DIFF
--- a/Xwt/Xwt/TreeNavigator.cs
+++ b/Xwt/Xwt/TreeNavigator.cs
@@ -128,23 +128,11 @@ namespace Xwt
 			return this;
 		}
 
-		[Obsolete ("Use the SetValues (column1, value1, column2, value2) method")]		
-		public TreeNavigator SetValues<T1,T2> (int row, IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2)
-		{
-			return SetValues (column1, value1, column2, value2);
-		}
-
 		public TreeNavigator SetValues<T1,T2> (IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2)
 		{
 			SetValue (column1, value1);
 			SetValue (column2, value2);
 			return this;
-		}
-
-		[Obsolete ("Use the SetValues (column1, value1, column2, value2, column3, value3) method")]
-		public TreeNavigator SetValues<T1,T2,T3> (int row, IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2, IDataField<T3> column3, T3 value3)
-		{
-			return SetValues (column1, value1, column2, value2, column3, value3);
 		}
 
 		public TreeNavigator SetValues<T1,T2,T3> (IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2, IDataField<T3> column3, T3 value3)

--- a/Xwt/Xwt/TreeNavigator.cs
+++ b/Xwt/Xwt/TreeNavigator.cs
@@ -127,16 +127,27 @@ namespace Xwt
 			backend.SetValue (pos, field.Index, data);
 			return this;
 		}
-		
 
+		[Obsolete ("Use the SetValues (column1, value1, column2, value2) method")]		
 		public TreeNavigator SetValues<T1,T2> (int row, IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2)
+		{
+			return SetValues (column1, value1, column2, value2);
+		}
+
+		public TreeNavigator SetValues<T1,T2> (IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2)
 		{
 			SetValue (column1, value1);
 			SetValue (column2, value2);
 			return this;
 		}
 
+		[Obsolete ("Use the SetValues (column1, value1, column2, value2, column3, value3) method")]
 		public TreeNavigator SetValues<T1,T2,T3> (int row, IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2, IDataField<T3> column3, T3 value3)
+		{
+			return SetValues (column1, value1, column2, value2, column3, value3);
+		}
+
+		public TreeNavigator SetValues<T1,T2,T3> (IDataField<T1> column1, T1 value1, IDataField<T2> column2, T2 value2, IDataField<T3> column3, T3 value3)
 		{
 			SetValue (column1, value1);
 			SetValue (column2, value2);


### PR DESCRIPTION
The parameter `int row` is not used in the overloads, and only the overloads for 2 and 3 values use it.

In order not to break existing code, the original signatures are still there, but call the new methods and are marked with `ObsoleteAttribute`.