### PR TITLE
Font optimization

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
@@ -24,12 +24,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
 using Xwt.Backends;
 using Pango;
 using Xwt.Drawing;
 using System.Globalization;
-using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -37,6 +35,20 @@ namespace Xwt.GtkBackend
 {
 	public class GtkFontBackendHandler: FontBackendHandler
 	{
+		static Pango.Context systemContext;
+		static Dictionary<string, Dictionary<string, Pango.FontFace>> familyFontFaces;
+
+		static GtkFontBackendHandler ()
+		{
+			systemContext = Gdk.PangoHelper.ContextGet ();
+			familyFontFaces = new Dictionary<string, Dictionary<string, Pango.FontFace>> ();
+			foreach (var family in systemContext.Families) {
+				familyFontFaces [family.Name] = new Dictionary<string, Pango.FontFace> ();
+				foreach (var face in family.Faces)
+					familyFontFaces [family.Name] [face.FaceName] = face;
+			}
+		}
+
 		public override object GetSystemDefaultFont ()
 		{
 			var la = new Gtk.Label ("");
@@ -45,7 +57,15 @@ namespace Xwt.GtkBackend
 
 		public override IEnumerable<string> GetInstalledFonts ()
 		{
-			return Gdk.PangoHelper.ContextGet ().FontMap.Families.Select (f => f.Name);
+			return systemContext.FontMap.Families.Select (f => f.Name);
+		}
+
+		public override IEnumerable<KeyValuePair<string, object>> GetAvailableFamilyFaces (string family)
+		{
+			if (familyFontFaces.ContainsKey (family))
+				foreach (var fd in familyFontFaces [family].Values)
+					yield return new KeyValuePair<string, object>(fd.FaceName, fd.Describe ());
+			yield break;
 		}
 
 		public override object Create (string fontName, double size, FontStyle style, FontWeight weight, FontStretch stretch)

--- a/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
@@ -36,16 +36,16 @@ namespace Xwt.GtkBackend
 	public class GtkFontBackendHandler: FontBackendHandler
 	{
 		static Pango.Context systemContext;
-		static Dictionary<string, Dictionary<string, Pango.FontFace>> familyFontFaces;
+		static Dictionary<string, Dictionary<string, object>> familyFontFaces;
 
 		static GtkFontBackendHandler ()
 		{
 			systemContext = Gdk.PangoHelper.ContextGet ();
-			familyFontFaces = new Dictionary<string, Dictionary<string, Pango.FontFace>> ();
+			familyFontFaces = new Dictionary<string, Dictionary<string, object>> ();
 			foreach (var family in systemContext.Families) {
-				familyFontFaces [family.Name] = new Dictionary<string, Pango.FontFace> ();
+				familyFontFaces [family.Name] = new Dictionary<string, object> ();
 				foreach (var face in family.Faces)
-					familyFontFaces [family.Name] [face.FaceName] = face;
+					familyFontFaces [family.Name] [face.FaceName] = face.Describe ();
 			}
 		}
 
@@ -62,9 +62,10 @@ namespace Xwt.GtkBackend
 
 		public override IEnumerable<KeyValuePair<string, object>> GetAvailableFamilyFaces (string family)
 		{
-			if (familyFontFaces.ContainsKey (family))
-				foreach (var fd in familyFontFaces [family].Values)
-					yield return new KeyValuePair<string, object>(fd.FaceName, fd.Describe ());
+			Dictionary<string, object> fontFaces;
+			if (familyFontFaces.TryGetValue (family, out fontFaces))
+				foreach (var fd in fontFaces)
+					yield return fd;
 			yield break;
 		}
 

--- a/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
@@ -36,17 +36,10 @@ namespace Xwt.GtkBackend
 	public class GtkFontBackendHandler: FontBackendHandler
 	{
 		static Pango.Context systemContext;
-		static Dictionary<string, Dictionary<string, object>> familyFontFaces;
 
 		static GtkFontBackendHandler ()
 		{
 			systemContext = Gdk.PangoHelper.ContextGet ();
-			familyFontFaces = new Dictionary<string, Dictionary<string, object>> ();
-			foreach (var family in systemContext.Families) {
-				familyFontFaces [family.Name] = new Dictionary<string, object> ();
-				foreach (var face in family.Faces)
-					familyFontFaces [family.Name] [face.FaceName] = face.Describe ();
-			}
 		}
 
 		public override object GetSystemDefaultFont ()
@@ -62,10 +55,11 @@ namespace Xwt.GtkBackend
 
 		public override IEnumerable<KeyValuePair<string, object>> GetAvailableFamilyFaces (string family)
 		{
-			Dictionary<string, object> fontFaces;
-			if (familyFontFaces.TryGetValue (family, out fontFaces))
-				foreach (var fd in fontFaces)
-					yield return fd;
+			FontFamily pangoFamily = systemContext.FontMap.Families.FirstOrDefault (f => f.Name == family);
+			if (pangoFamily != null) {
+				foreach (var face in pangoFamily.Faces)
+					yield return new KeyValuePair<string, object>(face.FaceName, face.Describe ());
+			}
 			yield break;
 		}
 

--- a/Xwt.Mac/Xwt.Mac/FontBackendHandler.cs
+++ b/Xwt.Mac/Xwt.Mac/FontBackendHandler.cs
@@ -103,18 +103,28 @@ namespace Xwt.Mac
 		static int GetWeightValue (FontWeight weight)
 		{
 			switch (weight) {
+			case FontWeight.Thin:
+				return 1;
 			case FontWeight.Ultralight:
 				return 2;
 			case FontWeight.Light:
+				return 3;
+			case FontWeight.Book:
 				return 4;
 			case FontWeight.Normal:
 				return 5;
+			case FontWeight.Medium:
+				return 6;
 			case FontWeight.Semibold:
-				return 7;
+				return 8;
 			case FontWeight.Bold:
 				return 9;
 			case FontWeight.Ultrabold:
+				return 10;
+			case FontWeight.Heavy:
 				return 11;
+			case FontWeight.Ultraheavy:
+				return 12;
 			default:
 				return 13;
 			}
@@ -122,19 +132,27 @@ namespace Xwt.Mac
 
 		internal static FontWeight GetWeightFromValue (int w)
 		{
-			if (w <= 2)
+			if (w <= 1)
+				return FontWeight.Thin;
+			if (w == 2)
 				return FontWeight.Ultralight;
-			if (w <= 4)
+			if (w == 3)
 				return FontWeight.Light;
-			if (w <= 6)
+			if (w == 4)
+				return FontWeight.Book;
+			if (w == 5)
 				return FontWeight.Normal;
+			if (w == 6)
+				return FontWeight.Medium;
 			if (w <= 8)
 				return FontWeight.Semibold;
 			if (w == 9)
 				return FontWeight.Bold;
-			if (w <= 12)
+			if (w == 10)
 				return FontWeight.Ultrabold;
-			return FontWeight.Heavy;
+			if (w == 11)
+				return FontWeight.Heavy;
+			return FontWeight.Ultraheavy;
 		}
 
 		NSFontTraitMask GetStretchTrait (FontStretch stretch)

--- a/Xwt.Mac/Xwt.Mac/FontBackendHandler.cs
+++ b/Xwt.Mac/Xwt.Mac/FontBackendHandler.cs
@@ -185,7 +185,10 @@ namespace Xwt.Mac
 			FontData f = (FontData) handle;
 			f = f.Copy ();
 			int w = GetWeightValue (weight);
-			f.Font = NSFontManager.SharedFontManager.FontWithFamily (f.Font.FamilyName, NSFontManager.SharedFontManager.TraitsOfFont (f.Font), w, f.Font.PointSize);
+			var traits = NSFontManager.SharedFontManager.TraitsOfFont (f.Font);
+			traits |= weight >= FontWeight.Bold ? NSFontTraitMask.Bold : NSFontTraitMask.Unbold;
+			traits &= weight >= FontWeight.Bold ? ~NSFontTraitMask.Unbold : ~NSFontTraitMask.Bold;
+			f.Font = NSFontManager.SharedFontManager.FontWithFamily (f.Font.FamilyName, traits, w, f.Font.PointSize);
 			f.Weight = weight;
 			return f;
 		}

--- a/Xwt.WPF/Xwt.WPFBackend/DataConverter.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DataConverter.cs
@@ -189,24 +189,39 @@ namespace Xwt.WPFBackend
 		public static FontWeight ToXwtFontWeight (this SW.FontWeight value)
 		{
 			// No, SW.FontWeights is not an enum
+			// Extra/Ultra and Demi/Semi are equal
+			// see: http://msdn.microsoft.com/en-us/library/system.windows.fontweights
+			if (value == SW.FontWeights.Thin) return FontWeight.Thin;
+			if (value == SW.FontWeights.ExtraLight) return FontWeight.Ultralight;
 			if (value == SW.FontWeights.UltraLight) return FontWeight.Ultralight;
 			if (value == SW.FontWeights.Light) return FontWeight.Light;
+			if (value == SW.FontWeights.Medium) return FontWeight.Medium;
+			if (value == SW.FontWeights.DemiBold) return FontWeight.Semibold;
 			if (value == SW.FontWeights.SemiBold) return FontWeight.Semibold;
 			if (value == SW.FontWeights.Bold) return FontWeight.Bold;
+			if (value == SW.FontWeights.ExtraBold) return FontWeight.Ultrabold;
 			if (value == SW.FontWeights.UltraBold) return FontWeight.Ultrabold;
 			if (value == SW.FontWeights.Black) return FontWeight.Heavy;
+			if (value == SW.FontWeights.Heavy) return FontWeight.Heavy;
+			if (value == SW.FontWeights.ExtraBlack) return FontWeight.Ultraheavy;
+			if (value == SW.FontWeights.UltraBlack) return FontWeight.Ultraheavy;
 
 			return FontWeight.Normal;
 		}
 
 		public static SW.FontWeight ToWpfFontWeight (this FontWeight value)
 		{
+			if (value == FontWeight.Thin) return SW.FontWeights.Thin;
 			if (value == FontWeight.Ultralight) return SW.FontWeights.UltraLight;
 			if (value == FontWeight.Light) return SW.FontWeights.Light;
+			if (value == FontWeight.Semilight) return SW.FontWeights.Light;
+			if (value == FontWeight.Book) return SW.FontWeights.Normal;
+			if (value == FontWeight.Medium) return SW.FontWeights.Medium;
 			if (value == FontWeight.Semibold) return SW.FontWeights.SemiBold;
 			if (value == FontWeight.Bold) return SW.FontWeights.Bold;
 			if (value == FontWeight.Ultrabold) return SW.FontWeights.UltraBold;
 			if (value == FontWeight.Heavy) return SW.FontWeights.Black;
+			if (value == FontWeight.Ultraheavy) return SW.FontWeights.UltraBlack;
 			
 			return SW.FontWeights.Normal;
 		}

--- a/Xwt.WPF/Xwt.WPFBackend/FontBackendHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/FontBackendHandler.cs
@@ -26,13 +26,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using SW = System.Windows;
 
 using Xwt.Backends;
 using Xwt.Drawing;
 
 using FontFamily = System.Windows.Media.FontFamily;
+using SW = System.Windows;
 
 namespace Xwt.WPFBackend
 {
@@ -48,9 +50,28 @@ namespace Xwt.WPFBackend
 			};
 		}
 
-		public override System.Collections.Generic.IEnumerable<string> GetInstalledFonts ()
+		public override IEnumerable<string> GetInstalledFonts ()
 		{
 			return System.Windows.Media.Fonts.SystemFontFamilies.Select (f => f.Source);
+		}
+
+		public override IEnumerable<KeyValuePair<string, object>> GetAvailableFamilyFaces (string family)
+		{
+			var wpfFamily = new FontFamily (family);
+			foreach (var face in wpfFamily.GetTypefaces ()) {
+				var langCurrent = SW.Markup.XmlLanguage.GetLanguage (CultureInfo.CurrentCulture.IetfLanguageTag);
+				var langInvariant = SW.Markup.XmlLanguage.GetLanguage ("en-us");;
+				string name;
+				if (face.FaceNames.TryGetValue (langCurrent, out name) || face.FaceNames.TryGetValue (langInvariant, out name)) {
+					var fontData = new FontData (wpfFamily, 0) {
+						Style = face.Style,
+						Weight = face.Weight,
+						Stretch = face.Stretch
+					};
+					yield return new KeyValuePair<string, object> (name, fontData);
+				}
+			}
+			yield break;
 		}
 
 		public override object Create (string fontName, double size, FontStyle style, FontWeight weight, FontStretch stretch)

--- a/Xwt/Xwt.Backends/FontBackendHandler.cs
+++ b/Xwt/Xwt.Backends/FontBackendHandler.cs
@@ -112,6 +112,8 @@ namespace Xwt.Backends
 
 		public abstract IEnumerable<string> GetInstalledFonts ();
 
+		public abstract IEnumerable<KeyValuePair<string, object>> GetAvailableFamilyFaces (string family);
+
 		/// <summary>
 		/// Creates a new font. Returns null if the font family is not available in the system
 		/// </summary>

--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -200,6 +200,38 @@ namespace Xwt.Drawing
 		}
 
 		/// <summary>
+		/// Gets the available family/font variants with varying weight, style and stretch.
+		/// </summary>
+		/// <returns>All available font variants for a specific family/font.</returns>
+		/// <param name="fontFamily">A comma separated list of families</param>
+		/// <remarks>
+		/// Not all weights, styles or strech variants and combinations are available
+		/// for every font or family. In case of an invalid combination, most toolkits
+		/// fallback to a system default variant. GetAvailableFontFaces helps to retrieve
+		/// only valid combinations for a specific font family.
+		/// </remarks>
+		public static ReadOnlyCollection<FontFace> GetAvailableFontFaces (string fontFamily)
+		{
+			fontFamily = GetSupportedFont (fontFamily);
+			return new ReadOnlyCollection<FontFace>(Toolkit.CurrentEngine.FontBackendHandler.GetAvailableFamilyFaces(fontFamily).Select (f => new FontFace(f.Key, f.Value)).ToList ());
+		}
+
+		/// <summary>
+		/// Gets the available variants of the font with varying weight, style and stretch.
+		/// </summary>
+		/// <returns>All available font variants for a specific family/font.</returns>
+		/// <remarks>
+		/// Not all weights, styles or strech variants and combinations are available
+		/// for every font or family. In case of an invalid combination, most toolkits
+		/// fallback to a system default variant. GetAvailableFontFaces helps to retrieve
+		/// only valid combinations for a specific font family.
+		/// </remarks>
+		public ReadOnlyCollection<FontFace> GetAvailableFontFaces ()
+		{
+			return GetAvailableFontFaces (Family);
+		}
+
+		/// <summary>
 		/// Returns a copy of the font using the provided font family
 		/// </summary>
 		/// <returns>The new font</returns>
@@ -293,6 +325,42 @@ namespace Xwt.Drawing
 		public override int GetHashCode ()
 		{
 			return ToString().GetHashCode ();
+		}
+	}
+
+	/// <summary>
+	/// The FontFace class describes a variant of a specific font family with a name and its Xwt representation.
+	/// </summary>
+	public class FontFace
+	{
+		/// <summary>
+		/// The specific font variant/face name, unique for the font family on the local system.
+		/// </summary>
+		/// <value>The variant/face name.</value>
+		/// <remarks>
+		/// On most systems the name is a combination of the written weight, style and stretch
+		/// of the font variant without the default values.
+		/// The name is only valid for the specific font, backend and system. On some systems
+		/// the names can be (partially) localized.
+		/// Examples: "Regular", "Bold", "Bold Italic", "Condensed"</remarks>
+		public string Name { get; private set; }
+
+		/// <summary>
+		/// The font with the family face/variant specific settings (weight, style, stretch).
+		/// </summary>
+		/// <value>The <see cref="Xwt.Drawing.Font"/> representation of the font variant/face .</value>
+		public Font Font { get; private set; }
+
+		internal FontFace (string name, Font font)
+		{
+			Name = name;
+			Font = font;
+		}
+
+		internal FontFace (string name, object backend)
+		{
+			Name = name;
+			Font = new Font (backend);
 		}
 	}
 

--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -305,12 +305,20 @@ namespace Xwt.Drawing
 	
 	public enum FontWeight
 	{
-		/// The ultralight weight (200)
+		/// The thin weight (100)
+		Thin = 100,
+		/// The ultra light weight (200)
 		Ultralight = 200,
 		/// The light weight (300)
 		Light = 300,
+		/// The semi light weight (350)
+		Semilight = 350,
+		/// The book weight (380)
+		Book = 350,
 		/// The default weight (400)
 		Normal = 400,
+		/// The medium weight (500)
+		Medium = 500,
 		/// The semi bold weight (600)
 		Semibold = 600,
 		/// The bold weight (700)
@@ -318,7 +326,9 @@ namespace Xwt.Drawing
 		/// The ultrabold weight (800)
 		Ultrabold = 800,
 		/// The heavy weight (900)
-		Heavy = 900
+		Heavy = 900,
+		/// The ultra heavy weight (1000)
+		Ultraheavy = 1000
 	}
 	
 	public enum FontStretch


### PR DESCRIPTION
While working on the FontSelector widget I've found some issues with the current font implementation. 

1. missing weight values (a84e9ff): according to [Pango API](https://developer.gnome.org/pango/stable/pango-Fonts.html#PangoWeight) there are some additional predefined weight values and they have backend specific (Wpf/Mac) pendants. So I have added them and optimized the backend mappings for better fitting.
2. little Mac issue (016c67a): the trait mask has to be updated, when changing the font weight (NSFontTraitMask.Bold, NSFontTraitMask.Unbold)
3. A new function to retrieve available font family variants (c3000f6): since the Font object allows to apply any weight, style and stretch combination (even invalid), I was missing a function to get really available/valid combinations (font/system specific, of course). ```GetAvailableFontFaces``` returns a collection of face specific names and their Font representations.