### PR TITLE
[Mac] add missing AlertDialogBackend features

### DIFF
--- a/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
@@ -72,6 +72,12 @@ namespace Xwt.Mac
 				this.AddButton (message.Buttons [i].Label);
 			}
 
+			if (message.AllowApplyToAll) {
+				ShowsSuppressionButton = true;
+				SuppressionButton.State = NSCellStateValue.Off;
+				SuppressionButton.Activated += (sender, e) => ApplyToAll = SuppressionButton.State == NSCellStateValue.On;
+			}
+
 			var win = (WindowBackend)Toolkit.GetBackend (transientFor);
 			if (win != null)
 				return sortedButtons [this.RunSheetModal (win) - 1000];

--- a/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
@@ -72,6 +72,9 @@ namespace Xwt.Mac
 				this.AddButton (message.Buttons [i].Label);
 			}
 
+			var win = (WindowBackend)Toolkit.GetBackend (transientFor);
+			if (win != null)
+				return sortedButtons [this.RunSheetModal (win) - 1000];
 			return sortedButtons [this.RunModal () - 1000];
 		}
 

--- a/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
@@ -25,10 +25,9 @@
 // THE SOFTWARE.
 
 using System;
+using System.Drawing;
 using MonoMac.AppKit;
-using MonoMac.Foundation;
 using Xwt.Backends;
-using Xwt.Drawing;
 
 namespace Xwt.Mac
 {
@@ -40,7 +39,7 @@ namespace Xwt.Mac
 		{
 		}
 		
-		public AlertDialogBackend (System.IntPtr intptr)
+		public AlertDialogBackend (IntPtr intptr)
 		{
 		}
 
@@ -52,8 +51,8 @@ namespace Xwt.Mac
 		#region IAlertDialogBackend implementation
 		public Command Run (WindowFrame transientFor, MessageDescription message)
 		{
-			this.MessageText = (message.Text != null) ? message.Text : String.Empty;
-			this.InformativeText = (message.SecondaryText != null) ? message.SecondaryText : String.Empty;
+			this.MessageText = message.Text ?? String.Empty;
+			this.InformativeText = message.SecondaryText ?? String.Empty;
 
 			if (message.Icon != null)
 				Icon = message.Icon.ToImageDescription (Context).ToNSImage ();
@@ -80,7 +79,7 @@ namespace Xwt.Mac
 
 			if (message.Options.Count > 0) {
 				AccessoryView = new NSView ();
-				var optionsSize = new System.Drawing.SizeF (0, 3);
+				var optionsSize = new SizeF (0, 3);
 
 				foreach (var op in message.Options) {
 					var chk = new NSButton ();
@@ -90,14 +89,14 @@ namespace Xwt.Mac
 					chk.Activated += (sender, e) => message.SetOptionValue (op.Id, chk.State == NSCellStateValue.On);
 
 					chk.SizeToFit ();
-					chk.Frame = new System.Drawing.RectangleF (new System.Drawing.PointF (0, optionsSize.Height), chk.FittingSize);
+					chk.Frame = new RectangleF (new PointF (0, optionsSize.Height), chk.FittingSize);
 
 					optionsSize.Height += chk.FittingSize.Height + 6;
 					optionsSize.Width = Math.Max (optionsSize.Width, chk.FittingSize.Width);
 
 					AccessoryView.AddSubview (chk);
 					chk.NeedsDisplay = true;
-				} ;
+				}
 
 				AccessoryView.SetFrameSize (optionsSize);
 			}

--- a/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
@@ -78,6 +78,30 @@ namespace Xwt.Mac
 				SuppressionButton.Activated += (sender, e) => ApplyToAll = SuppressionButton.State == NSCellStateValue.On;
 			}
 
+			if (message.Options.Count > 0) {
+				AccessoryView = new NSView ();
+				var optionsSize = new System.Drawing.SizeF (0, 3);
+
+				foreach (var op in message.Options) {
+					var chk = new NSButton ();
+					chk.SetButtonType (NSButtonType.Switch);
+					chk.Title = op.Text;
+					chk.State = op.Value ? NSCellStateValue.On : NSCellStateValue.Off;
+					chk.Activated += (sender, e) => message.SetOptionValue (op.Id, chk.State == NSCellStateValue.On);
+
+					chk.SizeToFit ();
+					chk.Frame = new System.Drawing.RectangleF (new System.Drawing.PointF (0, optionsSize.Height), chk.FittingSize);
+
+					optionsSize.Height += chk.FittingSize.Height + 6;
+					optionsSize.Width = Math.Max (optionsSize.Width, chk.FittingSize.Width);
+
+					AccessoryView.AddSubview (chk);
+					chk.NeedsDisplay = true;
+				} ;
+
+				AccessoryView.SetFrameSize (optionsSize);
+			}
+
 			var win = (WindowBackend)Toolkit.GetBackend (transientFor);
 			if (win != null)
 				return sortedButtons [this.RunSheetModal (win) - 1000];

--- a/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
@@ -34,6 +34,8 @@ namespace Xwt.Mac
 {
 	public class AlertDialogBackend : NSAlert, IAlertDialogBackend
 	{
+		ApplicationContext Context;
+
 		public AlertDialogBackend ()
 		{
 		}
@@ -44,6 +46,7 @@ namespace Xwt.Mac
 
 		public void Initialize (ApplicationContext actx)
 		{
+			Context = actx;
 		}
 
 		#region IAlertDialogBackend implementation
@@ -51,7 +54,9 @@ namespace Xwt.Mac
 		{
 			this.MessageText = (message.Text != null) ? message.Text : String.Empty;
 			this.InformativeText = (message.SecondaryText != null) ? message.SecondaryText : String.Empty;
-			//TODO Set Icon
+
+			if (message.Icon != null)
+				Icon = message.Icon.ToImageDescription (Context).ToNSImage ();
 
 			var sortedButtons = new Command [message.Buttons.Count];
 			var j = 0;

--- a/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
@@ -70,6 +70,12 @@ namespace Xwt.Mac
 				sortedButtons [j++] = message.Buttons [i];
 				this.AddButton (message.Buttons [i].Label);
 			}
+			for (var i = 0; i < sortedButtons.Length; i++) {
+				if (sortedButtons [i].Icon != null) {
+					Buttons [i].Image = sortedButtons [i].Icon.WithSize (IconSize.Small).ToImageDescription (Context).ToNSImage ();
+					Buttons [i].ImagePosition = NSCellImagePosition.ImageLeft;
+				}
+			}
 
 			if (message.AllowApplyToAll) {
 				ShowsSuppressionButton = true;

--- a/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/AlertDialogBackend.cs
@@ -54,9 +54,12 @@ namespace Xwt.Mac
 			//TODO Set Icon
 
 			var sortedButtons = new Command [message.Buttons.Count];
-			sortedButtons [0] = message.Buttons [message.DefaultButton];
-			this.AddButton (message.Buttons [message.DefaultButton].Label);
-			var j = 1;
+			var j = 0;
+			if (message.DefaultButton >= 0) {
+				sortedButtons [0] = message.Buttons [message.DefaultButton];
+				this.AddButton (message.Buttons [message.DefaultButton].Label);
+				j = 1;
+			}
 			for (var i = 0; i < message.Buttons.Count; i++) {
 				if (i == message.DefaultButton)
 					continue;


### PR DESCRIPTION
This PR adds the following fixes and missing features to the AlertDialogBackend on Mac:
* Fix exception thrown when no default button set
* Add Icon support
* Set dialog parent window if requested
* Add ApplyToAll implementation
* Add Message Options