### PR TITLE
Commands with writable properties

### DIFF
--- a/Xwt/Xwt/Command.cs
+++ b/Xwt/Xwt/Command.cs
@@ -30,10 +30,23 @@ namespace Xwt
 {
 	public class Command
 	{
-		public Command (string id)
+		public Command (string id) : this (id, id)
+		{
+		}
+
+		public Command (string label, Image icon) : this (label, label, icon)
+		{
+		}
+
+		public Command (string id, string label, Image icon) : this (id, label)
+		{
+			Icon = icon;
+		}
+
+		public Command (string id, string label)
 		{
 			Id = id;
-			Label = Id;
+			Label = label;
 		}
 		
 		public string Id { get; private set; }


### PR DESCRIPTION
Even if implemented (e.g. IAlertDialogBackend) the command icons are never assigned, since private. This PR lets the user set custom command icons and labels.

This is connected to #53, where a new Command concept is proposed. Until we have some more sophisticated solution, this is an easy way to allow icons on dialog buttons, or create menu items using commands.