### PR TITLE
[MAC] Extends NSOutlineView for proper handling mouse events

### DIFF
--- a/TestApps/Samples/Samples/TreeViews.cs
+++ b/TestApps/Samples/Samples/TreeViews.cs
@@ -70,7 +70,19 @@ namespace Samples
 			store.AddNode ().SetValue (text, "Three").SetValue (desc, "Third").AddChild ()
 				.SetValue (text, "Sub three").SetValue (desc, "Sub third");
 			PackStart (view, true);
-			
+
+			Menu contextMenu = new Menu ();
+			contextMenu.Items.Add (new MenuItem ("Test menu"));
+			view.ButtonPressed += delegate(object sender, ButtonEventArgs e) {
+				TreePosition tmpTreePos;
+				RowDropPosition tmpRowDrop;
+				if ((e.Button == PointerButton.Right) && view.GetDropTargetRow (e.X, e.Y, out tmpRowDrop, out tmpTreePos)) {
+					// Set actual row to selected
+					view.SelectRow (tmpTreePos);
+					contextMenu.Popup(view, e.X, e.Y);
+				}
+			};
+				
 			view.DataSource = store;
 			
 			Label la = new Label ();

--- a/Xwt.Mac/Xwt.Mac.csproj
+++ b/Xwt.Mac/Xwt.Mac.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Xwt.Mac\NSTableViewBackend.cs" />
     <Compile Include="Xwt.Mac\SaveFileDialogBackend.cs" />
     <Compile Include="Xwt.Mac\ColorPickerBackend.cs" />
+    <Compile Include="Xwt.Mac\OutlineViewBackend.cs" />
   </ItemGroup>
   <Import Project="..\BuildHelpers.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Xwt.Mac/Xwt.Mac/OutlineViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/OutlineViewBackend.cs
@@ -1,0 +1,151 @@
+﻿//
+// OutlineViewBackend.cs
+//
+// Author:
+//       Lluis Sanchez <lluis@xamarin.com>
+//       Hywel Thomas <hywel.w.thomas@gmail.com>
+//       strnadj <jan.strnadek@gmail.com>
+//
+// Copyright (c) 2014 Xamarin Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt.Backends;
+using MonoMac.AppKit;
+using MonoMac.CoreGraphics;
+
+namespace Xwt.Mac
+{
+	public class OutlineViewBackend : NSOutlineView
+	{
+		ITreeViewEventSink eventSink;
+		protected ApplicationContext context;
+		NSTrackingArea trackingArea;
+
+		public OutlineViewBackend (ITreeViewEventSink eventSink, ApplicationContext context)
+		{
+			this.context = context;
+			this.eventSink = eventSink;
+		}
+
+		public NSOutlineView View {
+			get { return this; }
+		}
+
+		public override void UpdateTrackingAreas ()
+		{
+			if (trackingArea != null) {
+				RemoveTrackingArea (trackingArea);
+				trackingArea.Dispose ();
+			}
+			System.Drawing.RectangleF viewBounds = this.Bounds;
+			var options = NSTrackingAreaOptions.MouseMoved | NSTrackingAreaOptions.ActiveInKeyWindow | NSTrackingAreaOptions.MouseEnteredAndExited;
+			trackingArea = new NSTrackingArea (viewBounds, options, this, null);
+			AddTrackingArea (trackingArea);
+		}
+
+		public override void RightMouseDown (NSEvent theEvent)
+		{
+			base.RightMouseUp (theEvent);
+			var p = ConvertPointFromView (theEvent.LocationInWindow, null);
+			ButtonEventArgs args = new ButtonEventArgs ();
+			args.X = p.X;
+			args.Y = p.Y;
+			args.Button = PointerButton.Right;
+			context.InvokeUserCode (delegate {
+				eventSink.OnButtonPressed (args);
+			});
+		}
+
+		public override void RightMouseUp (NSEvent theEvent)
+		{
+			base.RightMouseUp (theEvent);
+			var p = ConvertPointFromView (theEvent.LocationInWindow, null);
+			ButtonEventArgs args = new ButtonEventArgs ();
+			args.X = p.X;
+			args.Y = p.Y;
+			args.Button = PointerButton.Right;
+			context.InvokeUserCode (delegate {
+				eventSink.OnButtonReleased (args);
+			});
+		}
+
+		public override void MouseDown (NSEvent theEvent)
+		{
+			base.MouseDown (theEvent);
+			var p = ConvertPointFromView (theEvent.LocationInWindow, null);
+			ButtonEventArgs args = new ButtonEventArgs ();
+			args.X = p.X;
+			args.Y = p.Y;
+			args.Button = PointerButton.Left;
+			context.InvokeUserCode (delegate {
+				eventSink.OnButtonPressed (args);
+			});
+		}
+
+		public override void MouseUp (NSEvent theEvent)
+		{
+			base.MouseUp (theEvent);
+			var p = ConvertPointFromView (theEvent.LocationInWindow, null);
+			ButtonEventArgs args = new ButtonEventArgs ();
+			args.X = p.X;
+			args.Y = p.Y;
+			args.Button = (PointerButton) theEvent.ButtonNumber + 1;
+			context.InvokeUserCode (delegate {
+				eventSink.OnButtonReleased (args);
+			});
+		}
+
+		public override void MouseEntered (NSEvent theEvent)
+		{
+			base.MouseEntered (theEvent);
+			context.InvokeUserCode (delegate {
+				eventSink.OnMouseEntered ();
+			});
+		}
+
+		public override void MouseExited (NSEvent theEvent)
+		{
+			base.MouseExited (theEvent);
+			context.InvokeUserCode (delegate {
+				eventSink.OnMouseExited ();
+			});
+		}
+
+		public override void MouseMoved (NSEvent theEvent)
+		{
+			base.MouseMoved (theEvent);
+			var p = ConvertPointFromView (theEvent.LocationInWindow, null);
+			MouseMovedEventArgs args = new MouseMovedEventArgs ((long) TimeSpan.FromSeconds (theEvent.Timestamp).TotalMilliseconds, p.X, p.Y);
+			context.InvokeUserCode (delegate {
+				eventSink.OnMouseMoved (args);
+			});
+		}
+
+		public override void MouseDragged (NSEvent theEvent)
+		{
+			base.MouseDragged (theEvent);
+			var p = ConvertPointFromView (theEvent.LocationInWindow, null);
+			MouseMovedEventArgs args = new MouseMovedEventArgs ((long) TimeSpan.FromSeconds (theEvent.Timestamp).TotalMilliseconds, p.X, p.Y);
+			context.InvokeUserCode (delegate {
+				eventSink.OnMouseMoved (args);
+			});
+		}
+	}
+}

--- a/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.Mac/Xwt.Mac/TreeViewBackend.cs
@@ -69,7 +69,7 @@ namespace Xwt.Mac
 		
 		protected override NSTableView CreateView ()
 		{
-			var t = new NSOutlineView ();
+			var t = new OutlineViewBackend (EventSink, ApplicationContext);
 			t.Delegate = new TreeDelegate () { Backend = this };
 			return t;
 		}
@@ -180,9 +180,14 @@ namespace Xwt.Mac
 		
 		public bool GetDropTargetRow (double x, double y, out RowDropPosition pos, out TreePosition nodePosition)
 		{
+			// Get row
+			int row = Tree.GetRow(new System.Drawing.PointF ((float)x, (float)y));
 			pos = RowDropPosition.Into;
 			nodePosition = null;
-			return false;
+			if (row >= 0) {
+				nodePosition = ((TreeItem)Tree.ItemAtRow (row)).Position;
+			}
+			return nodePosition != null;
 		}
 		
 /*		protected override void OnDragOverCheck (NSDraggingInfo di, DragOverCheckEventArgs args)


### PR DESCRIPTION
I've accidentaly deleted my xwt branch, Iam creating this PR again (reference to pull request: 319)

Iam referencing my Issue #315 from thursday, I have to fix this issue, cause I need it ;) It's something like "example solution", Iam new in Mono / Mono Mac / c#, but it works... I try to find mouse handler for List / TreeView but I was no able to find it... I have to extend NSOutlineView, like "Hywel Thomas" does it in "WidgetView".

I'am sorry for this "PR-mess" :-1: 