### PR TITLE
[Gtk3] fix widgets with enabled SupportsCustomScrolling

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk2ViewPort.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk2ViewPort.cs
@@ -29,6 +29,13 @@ namespace Xwt.GtkBackend
 {
 	public class GtkViewPort: Gtk.Bin
 	{
+		public GtkViewPort ()
+		{
+		}
+
+		public GtkViewPort (IntPtr raw) : base (raw)
+		{
+		}
 	}
 }
 

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk3ViewPort.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk3ViewPort.cs
@@ -27,8 +27,46 @@ using System;
 
 namespace Xwt.GtkBackend
 {
-	public class GtkViewPort: Gtk.Viewport
+	public class GtkViewPort: Gtk.Bin, Gtk.IScrollableImplementor
 	{
+		public GtkViewPort ()
+		{
+		}
+
+		public GtkViewPort (IntPtr raw) : base (raw)
+		{
+		}
+
+		Gtk.Adjustment hadjustment;
+		public Gtk.Adjustment Hadjustment {
+			get {
+				return hadjustment;
+			}
+			set {
+				hadjustment = value;
+				if (vadjustment != null) {
+					OnSetScrollAdjustments (value, vadjustment);
+				}
+			}
+		}
+
+		Gtk.Adjustment vadjustment;
+		public Gtk.Adjustment Vadjustment {
+			get {
+				return vadjustment;
+			}
+			set {
+				vadjustment = value;
+				if (hadjustment != null) {
+					OnSetScrollAdjustments (hadjustment, value);
+				}
+			}
+		}
+
+		public Gtk.ScrollablePolicy HscrollPolicy { get; set; }
+
+		public Gtk.ScrollablePolicy VscrollPolicy { get; set; }
+
 		protected override void OnAdded (Gtk.Widget widget)
 		{
 			base.OnAdded (widget);

--- a/Xwt.Gtk/Xwt.GtkBackend/ScrollViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ScrollViewBackend.cs
@@ -181,6 +181,10 @@ namespace Xwt.GtkBackend
 	{
 		Gtk.Widget child;
 		IWidgetEventSink eventSink;
+
+		public CustomViewPort (IntPtr raw) : base (raw)
+		{
+		}
 		
 		public CustomViewPort (IWidgetEventSink eventSink)
 		{
@@ -207,34 +211,6 @@ namespace Xwt.GtkBackend
 			} else {
 				requisition.Width = 0;
 				requisition.Height = 0;
-			}
-		}
-
-		Gtk.Adjustment hadjustment;
-		[GLib.Property ("hadjustment")]
-		public new Gtk.Adjustment Hadjustment {
-			get {
-				return hadjustment;
-			}
-			set {
-				hadjustment = value;
-				if (vadjustment != null) {
-					OnSetScrollAdjustments (value, vadjustment);
-				}
-			}
-		}
-
-		Gtk.Adjustment vadjustment;
-		[GLib.Property ("vadjustment")]
-		public new Gtk.Adjustment Vadjustment {
-			get {
-				return vadjustment;
-			}
-			set {
-				vadjustment = value;
-				if (hadjustment != null) {
-					OnSetScrollAdjustments (hadjustment, value);
-				}
 			}
 		}
 


### PR DESCRIPTION
use a simple Box (like for Gtk2) and implementing IScrollableImplementor
instead of a Viewport (not allowing to override adjustment handling).

(fixes #468)