### PR TITLE
[GTK] fix resize artifacts, reuse popover window

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
@@ -105,6 +105,13 @@ namespace Xwt.GtkBackend
 				OnScreenChanged (null);
 			}
 
+			protected override void OnSizeAllocated (Gdk.Rectangle allocation)
+			{
+				base.OnSizeAllocated (allocation);
+				QueueDraw ();
+			}
+
+
 			protected override bool OnDrawn (Context cr)
 			{
 				int w, h;


### PR DESCRIPTION
The Gtk PopoverBackend can reuse the popover window and destroy it on Dispose, instead of creating a new window each time the Popover is shown.