### PR TITLE
[Gtk] fix SetFocus

### DIFF
--- a/TestApps/Samples/MainWindow.cs
+++ b/TestApps/Samples/MainWindow.cs
@@ -118,6 +118,7 @@ namespace Samples
 			AddSample (n, "Text Input", typeof (TextInput));
 			var wf = AddSample (null, "Widget Features", null);
 			AddSample (wf, "Drag & Drop", typeof(DragDrop));
+			AddSample (wf, "Focus", typeof(WidgetFocus));
 			AddSample (wf, "Widget Events", typeof(WidgetEvents));
 			AddSample (wf, "Opacity", typeof(OpacitySample));
 			AddSample (wf, "Tooltips", typeof(Tooltips));

--- a/TestApps/Samples/Samples.csproj
+++ b/TestApps/Samples/Samples.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Samples\MouseCursors.cs" />
     <Compile Include="Samples\MessageDialogs.cs" />
     <Compile Include="Samples\MultithreadingSample.cs" />
+    <Compile Include="Samples\WidgetFocus.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/TestApps/Samples/Samples/WidgetFocus.cs
+++ b/TestApps/Samples/Samples/WidgetFocus.cs
@@ -1,0 +1,80 @@
+﻿//
+// FocusWidget.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt;
+
+namespace Samples
+{
+	public class WidgetFocus: VBox
+	{
+		DataField<string> value = new DataField<string> ();
+		public WidgetFocus ()
+		{
+			var text = new TextEntry ();
+			var check = new CheckBox ("CheckBox");
+			var slider = new HSlider ();
+			ListStore store = new ListStore (value);
+			var list = new ListView (store);
+			list.Columns.Add ("Value", value);
+			list.HeadersVisible = false;
+			for (int n=0; n<10; n++) {
+				var r = store.AddRow ();
+				store.SetValue (r, value, "Value " + n);
+			}
+
+			var btn1 = new Button ("TextEnty");
+			var btn2 = new Button ("Checkbox");
+			var btn3 = new Button ("Slider");
+			var btn4 = new Button ("ListBox");
+			var btn5 = new Button ("Button");
+
+			btn1.Clicked += (sender, e) => text.SetFocus ();
+			btn2.Clicked += (sender, e) => check.SetFocus ();
+			btn3.Clicked += (sender, e) => slider.SetFocus ();
+			btn4.Clicked += (sender, e) => list.SetFocus ();
+			btn5.Clicked += (sender, e) => btn1.SetFocus ();
+
+			var btnBox = new HBox ();
+			btnBox.PackStart (btn1);
+			btnBox.PackStart (btn2);
+			btnBox.PackStart (btn3);
+			btnBox.PackStart (btn4);
+			btnBox.PackStart (btn5);
+
+			var focusBox = new HBox ();
+			var vbox = new VBox ();
+			vbox.PackStart (text);
+			vbox.PackStart (check);
+			vbox.PackStart (slider);
+			focusBox.PackStart (vbox);
+			focusBox.PackStart (list, true);
+
+			PackStart (btnBox);
+			PackStart (focusBox, true);
+		}
+	}
+}
+

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -157,17 +157,8 @@ namespace Xwt.GtkBackend
 		
 		public virtual void SetFocus ()
 		{
-			Widget.IsFocus = true;
-//			SetFocus (Widget);
-		}
-
-		void SetFocus (Gtk.Widget w)
-		{
-			if (w.Parent != null)
-				SetFocus (w.Parent);
-			w.GrabFocus ();
-			w.IsFocus = true;
-			w.HasFocus = true;
+			if (CanGetFocus)
+				Widget.GrabFocus ();
 		}
 
 		public string TooltipText {


### PR DESCRIPTION
This is based on #310. As discussed ```Widget.IsFocus = true``` is not always enough. Some Gtk widgets (ListView, maybe others) need sometimes a GrabFocus() to receive keyboard focus and those which don't need it (should) behave as expected/before. Additionally an example is included.

Note: I've removed ```void SetFocus (Gtk.Widget w)``` which is never used.