### PR TITLE
[Gtk] fix window position

### DIFF
--- a/Testing/Tests/WindowTests.cs
+++ b/Testing/Tests/WindowTests.cs
@@ -256,6 +256,77 @@ namespace Xwt
 				Assert.AreEqual (230, win.Y);
 			}
 		}
+
+		[Test]
+		public void LocationChange ()
+		{
+			using (var win = new Window ()) {
+				win.InitialLocation = WindowLocation.Manual;
+				win.Content = new Label ("Hi there!");
+				win.Location = new Point (210, 230);
+				ShowWindow (win);
+				Assert.AreEqual (210, win.X);
+				Assert.AreEqual (230, win.Y);
+				win.Location = new Point (200, 200);
+				WaitForEvents (100);
+				Assert.AreEqual (200, win.X);
+				Assert.AreEqual (200, win.Y);
+			}
+		}
+
+		[Test]
+		public void LocationChangeWithoutContent ()
+		{
+			using (var win = new Window ()) {
+				win.InitialLocation = WindowLocation.Manual;
+				win.Size = new Size (100, 100);
+				win.Location = new Point (210, 230);
+				ShowWindow (win);
+				Assert.AreEqual (210, win.X);
+				Assert.AreEqual (230, win.Y);
+				Assert.AreEqual (100, win.Width);
+				Assert.AreEqual (100, win.Height);
+				win.Location = new Point (200, 200);
+				WaitForEvents (100);
+				Assert.AreEqual (200, win.X);
+				Assert.AreEqual (200, win.Y);
+				Assert.AreEqual (100, win.Width);
+				Assert.AreEqual (100, win.Height);
+			}
+		}
+
+		[Test]
+		public void LocationChangeWithoutContentAndSize ()
+		{
+			using (var win = new Window ()) {
+				win.InitialLocation = WindowLocation.Manual;
+				win.Location = new Point (210, 230);
+				ShowWindow (win);
+				Assert.AreEqual (210, win.X);
+				Assert.AreEqual (230, win.Y);
+				win.Location = new Point (200, 200);
+				WaitForEvents (100);
+				Assert.AreEqual (200, win.X);
+				Assert.AreEqual (200, win.Y);
+			}
+		}
+
+		[Test]
+		public void LocationPreserve ()
+		{
+			using (var win = new Window ()) {
+				win.InitialLocation = WindowLocation.Manual;
+				win.Content = new Label ("Hi there!");
+				win.Location = new Point (210, 230);
+				ShowWindow (win);
+				Assert.AreEqual (210, win.X);
+				Assert.AreEqual (230, win.Y);
+				win.Location = win.Location;
+				WaitForEvents (100);
+				Assert.AreEqual (210, win.X);
+				Assert.AreEqual (230, win.Y);
+			}
+		}
 	}
 
 	public class SquareBox: Canvas

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
@@ -113,7 +113,10 @@ namespace Xwt.GtkBackend
 
 		public void Move (double x, double y)
 		{
-			Window.Move ((int)x, (int)y);
+			if (Window.Decorated && Window.GdkWindow != null)
+				Window.GdkWindow.Move ((int)x, (int)y);
+			else
+				Window.Move ((int)x, (int)y);
 			ApplicationContext.InvokeUserCode (delegate {
 				EventSink.OnBoundsChanged (Bounds);
 			});
@@ -127,14 +130,18 @@ namespace Xwt.GtkBackend
 			if (height == -1)
 				height = Bounds.Height;
 			requestedSize = new Size (width, height);
-			Window.Resize ((int)width, (int)height);
+			if (Window.Decorated && Window.GdkWindow != null)
+				Window.GdkWindow.Resize ((int)width, (int)height);
+			else
+				Window.Resize ((int)width, (int)height);
 		}
 
 		public Rectangle Bounds {
 			get {
 				int w, h, x, y;
-				if (Window.GdkWindow != null) {
-					Window.GdkWindow.GetOrigin (out x, out y);
+
+				if (Window.Decorated && Window.GdkWindow != null) {
+					Window.GdkWindow.GetRootOrigin (out x, out y);
 					Window.GdkWindow.GetSize (out w, out h);
 				} else {
 					Window.GetPosition (out x, out y);
@@ -144,8 +151,12 @@ namespace Xwt.GtkBackend
 			}
 			set {
 				requestedSize = value.Size;
-				Window.Move ((int)value.X, (int)value.Y);
-				Window.Resize ((int)value.Width, (int)value.Height);
+				if (Window.Decorated && Window.GdkWindow != null) {
+					Window.GdkWindow.MoveResize ((int)value.X, (int)value.Y, (int)value.Width, (int)value.Height);
+				} else {
+					Window.Move ((int)value.X, (int)value.Y);
+					Window.Resize ((int)value.Width, (int)value.Height);
+				}
 				Window.SetDefaultSize ((int)value.Width, (int)value.Height);
 				ApplicationContext.InvokeUserCode (delegate {
 					EventSink.OnBoundsChanged (Bounds);


### PR DESCRIPTION
This is a fix for #257 including tests. The problem was, that the Gtk.Window has been used for setting the location/size and its Gdk.Window to retrieve the Bounds. Since Gtk.Window always includes the Decorations and its Gdk.Window (used for drawing) includes only the client side (without decorations), the decoration size was always added. 

I've included tests for location changes and preserving location (as described in #257). 
* WPF: only does not pass LocationChangeWithoutContent
* MAC: does not pass at all.
* GTK: passes all tests