### PR TITLE
[WPF] Calling TreeStore.Clear() raises exception in ExTreeViewItem

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
@@ -65,7 +65,10 @@ namespace Xwt.WPFBackend
 
 		protected override void OnCollapsed(RoutedEventArgs e)
 		{
-			var node = (TreeStoreNode)DataContext;
+			var node = DataContext as TreeStoreNode;
+			if (node == null) {
+				return;
+			}
 			if (!IsExpanded)
 				UnselectChildren((object o, ExTreeViewItem i) =>
 				{


### PR DESCRIPTION
When one or more top nodes in TreeView are expanded, calling `Clear()` on the ITreeDataSource raises an exception.

This is due to `OnCollapsed (RoutedEventArgs e)` being called in ExTreeViewItem, and this cast fails:

    var node = (TreeStoreNode)DataContext;

Specifically: `DataContext` is `DisconnectedItem` of type `MS.Internal.NamedObject`