### PR TITLE
Ensure that Toolkit.Type is always set

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
@@ -38,6 +38,15 @@ namespace Xwt.GtkBackend
 	{
 		GtkPlatformBackend platformBackend;
 
+		public override ToolkitType GetToolkitType ()
+		{
+			#if XWT_GTK3
+			return ToolkitType.Gtk3;
+			#else
+			return ToolkitType.Gtk;
+			#endif
+		}
+
 		public override void InitializeApplication ()
 		{
 			Gtk.Application.Init ();

--- a/Xwt.Mac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.Mac/Xwt.Mac/MacEngine.cs
@@ -40,6 +40,11 @@ namespace Xwt.Mac
 	{
 		static AppDelegate appDelegate;
 		static NSAutoreleasePool pool;
+
+		public override ToolkitType GetToolkitType ()
+		{
+			return ToolkitType.Cocoa;
+		}
 		
 		public static AppDelegate App {
 			get { return appDelegate; }

--- a/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
@@ -44,6 +44,11 @@ namespace Xwt.WPFBackend
 	{
 		System.Windows.Application application;
 
+		public override ToolkitType GetToolkitType ()
+		{
+			return ToolkitType.Wpf;
+		}
+
 		public static WPFEngine Instance { get; private set; }
 
 		public WPFEngine ()

--- a/Xwt/Xwt.Backends/ToolkitEngineBackend.cs
+++ b/Xwt/Xwt.Backends/ToolkitEngineBackend.cs
@@ -41,6 +41,11 @@ namespace Xwt.Backends
 		Toolkit toolkit;
 		bool isGuest;
 
+		public virtual ToolkitType GetToolkitType ()
+		{
+			return ToolkitType.Custom;
+		}
+
 		internal void Initialize (Toolkit toolkit, bool isGuest)
 		{
 			this.toolkit = toolkit;

--- a/Xwt/Xwt/Application.cs
+++ b/Xwt/Xwt/Application.cs
@@ -61,7 +61,6 @@ namespace Xwt
 		public static void Initialize (ToolkitType type)
 		{
 			Initialize (Toolkit.GetBackendType (type));
-			toolkit.Type = type;
 		}
 
 		public static void Initialize (string backendType)
@@ -270,6 +269,7 @@ namespace Xwt
 
 	public enum ToolkitType
 	{
+		Custom = 0,
 		Gtk = 1,
 		Cocoa = 2,
 		Wpf = 3,

--- a/Xwt/Xwt/Toolkit.cs
+++ b/Xwt/Xwt/Toolkit.cs
@@ -40,7 +40,6 @@ namespace Xwt
 		ToolkitEngineBackend backend;
 		ApplicationContext context;
 		XwtTaskScheduler scheduler;
-		ToolkitType toolkitType;
 
 		int inUserCode;
 		Queue<Action> exitActions = new Queue<Action> ();
@@ -82,8 +81,7 @@ namespace Xwt
 		}
 
 		public ToolkitType Type {
-			get { return toolkitType; }
-			internal set { toolkitType = value; }
+			get { return Backend.GetToolkitType (); }
 		}
 
 		internal static void DisposeAll ()
@@ -122,12 +120,11 @@ namespace Xwt
 
 		public static Toolkit Load (ToolkitType type)
 		{
-			var et = toolkits.Values.FirstOrDefault (tk => tk.toolkitType == type);
+			var et = toolkits.Values.FirstOrDefault (tk => tk.Type == type);
 			if (et != null)
 				return et;
 
 			Toolkit t = new Toolkit ();
-			t.toolkitType = type;
 			t.LoadBackend (GetBackendType (type), true, true);
 			return t;
 		}
@@ -140,14 +137,13 @@ namespace Xwt
 		/// <param name="toolkit">The loaded toolkit</param>
 		public static bool TryLoad (ToolkitType type, out Toolkit toolkit)
 		{
-			var et = toolkits.Values.FirstOrDefault (tk => tk.toolkitType == type);
+			var et = toolkits.Values.FirstOrDefault (tk => tk.Type == type);
 			if (et != null) {
 				toolkit = et;
 				return true;
 			}
 
 			Toolkit t = new Toolkit ();
-			t.toolkitType = type;
 			if (t.LoadBackend (GetBackendType (type), true, false)) {
 				toolkit = t;
 				return true;


### PR DESCRIPTION
This ensures that the Type of a Toolkit is always set correctly (fixes #260). Additionally every engine can set the own type by overriding ToolkitEngineBackend.GetToolkitType(). The new ToolkitType.Custom indicates that the toolkit is not known to Xwt.

Regression: ToolkitType.XamMac is never assigned (if loaded with ToolkitType.XamMac, Toolkit.Type will still return ToolkitType.Cocoa). To fix this, some additional code would be required in Xwt.XamMac, but as I understand Xwt.XamMac will be removed in favor to a unified version (xammac-unified branch), so this regression is not very problematic.