### PR TITLE
Handle an invisible TextCellView in WPF

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -76,6 +76,12 @@ namespace Xwt.WPFBackend.Utilities
 					{
 						factory = new FrameworkElementFactory(typeof(SWC.TextBlock));
 						factory.SetValue(FrameworkElement.MarginProperty, CellMargins);
+						if (!view.Visible)
+						{
+							factory.SetValue(FrameworkElement.VisibilityProperty, Visibility.Hidden);
+							factory.SetValue(FrameworkElement.MaxWidthProperty, 0.0);
+						}
+
 						if (textView.TextField != null)
 						{
 							factory.SetBinding(SWC.TextBlock.TextProperty, new Binding(dataPath + "[" + textView.TextField.Index + "]"));

--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -76,11 +76,14 @@ namespace Xwt.WPFBackend.Utilities
 					{
 						factory = new FrameworkElementFactory(typeof(SWC.TextBlock));
 						factory.SetValue(FrameworkElement.MarginProperty, CellMargins);
-						if (!view.Visible)
+						if (textView.VisibleField != null)
 						{
-							factory.SetValue(FrameworkElement.VisibilityProperty, Visibility.Hidden);
-							factory.SetValue(FrameworkElement.MaxWidthProperty, 0.0);
+							var binding = new Binding(dataPath + "[" + textView.VisibleField.Index + "]");
+							binding.Converter = new BooleanToVisibilityConverter();
+							factory.SetBinding(SWC.TextBlock.VisibilityProperty, binding);
 						}
+						else if (!textView.Visible)
+							factory.SetValue(SWC.TextBlock.VisibilityProperty, Visibility.Collapsed);
 
 						if (textView.TextField != null)
 						{


### PR DESCRIPTION
Since there is a 'Visible' Property in TextCellView (and I'm using it so that I can place a hidden GUID on each row that helps me associate a row with an object) the property should be respected.

I'm not sure if this is possible/available in GTK or Cococa, but it does work in WPF.

I'm currently using it by creating a ListViewColumn with a 'normal', visible TextCellView inside. Later I add the invisible TextCellView to the Views collection of the ListViewColumn.

MaxWidth has to be 0 because the column resizes so that both (all?) TextCellViews are accounted for.