### PR TITLE
Make stock icons settable.

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
@@ -54,8 +54,9 @@ namespace Xwt.WPFBackend
 
 		public Command Run (WindowFrame transientFor, MessageDescription message)
 		{
-			this.icon = GetIcon (message.Icon);
-			if (ConvertButtons (message.Buttons, out buttons)) {
+			this.icon = GetIcon(message.Icon);
+			bool isCustomIcon = message.Icon != null && this.icon == MessageBoxImage.None;
+			if (ConvertButtons (message.Buttons, out buttons) && !isCustomIcon) {
 				// Use a system message box
 				if (message.SecondaryText == null)
 					message.SecondaryText = String.Empty;

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Xwt.Backends\IPasswordEntryBackend.cs" />
+    <Compile Include="Xwt\IIconSet.cs" />
     <Compile Include="Xwt\PasswordEntry.cs" />
     <Compile Include="Xwt\PreviewTextEventArgs.cs" />
     <Compile Include="Xwt\Widget.cs" />

--- a/Xwt/Xwt/IIconSet.cs
+++ b/Xwt/Xwt/IIconSet.cs
@@ -1,0 +1,35 @@
+﻿//
+// IIconSet.cs
+//
+// Author:
+//       Thomas Mayer <thomas@residuum.org>
+//
+// Copyright (c) 2015 Thomas Mayer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.using Xwt.Drawing;
+
+using Xwt.Drawing;
+
+namespace Xwt
+{
+	public interface IIconSet
+	{
+		Image GetStockIcon(string iconId);
+	}
+}

--- a/Xwt/Xwt/StockIcons.cs
+++ b/Xwt/Xwt/StockIcons.cs
@@ -23,7 +23,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
 using Xwt.Drawing;
 using Xwt.Backends;
 
@@ -32,6 +31,14 @@ namespace Xwt
 	public static class StockIcons
 	{
 		static Image GetIcon (string id)
+		{
+	 		if (IconSet == null) {
+				return GetStockIcon (id);
+			}
+			return IconSet.GetStockIcon (id) ?? GetStockIcon (id);
+		}
+
+		static Image GetStockIcon(string id)
 		{
 			var img = Toolkit.CurrentEngine.GetStockIcon (id);
 			img.SetStockSource (id);
@@ -50,6 +57,7 @@ namespace Xwt
 		public static Image Zoom100 { get { return GetIcon (StockIconId.Zoom100); } }
 		public static Image Add { get { return GetIcon (StockIconId.Add); } }
 		public static Image Remove { get { return GetIcon (StockIconId.Remove); } }
+
+		public static IIconSet IconSet { private get; set; }
 	}
 }
-


### PR DESCRIPTION
Inspired by pull request #477, I have started a simple solution to create icon sets.

This is just adding an interface to implement, and a way to set that class to the StockIcons class. If an icon set returns `null` for an StockImageId, then the stock icon of the toolkit is used.

This will make it simpler to use your own icons in MessageDialog.ShowMessage() et al.
