### PR TITLE
[WPF] ListBox and ListView: add support to RowActivated event

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ListBoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListBoxBackend.cs
@@ -30,6 +30,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Xwt.Backends;
 using Xwt.WPFBackend.Utilities;
+using System.Windows.Input;
 
 namespace Xwt.WPFBackend
 {
@@ -173,6 +174,14 @@ namespace Xwt.WPFBackend
 					break;
 				}
 			}
+
+			if (eventId is ListViewEvent) {
+				switch ((ListViewEvent)eventId) {
+				case ListViewEvent.RowActivated:
+					ListBox.MouseDoubleClick += OnMouseDoubleClick;
+					break;
+				}
+			}
 		}
 
 		public override void DisableEvent (object eventId)
@@ -185,11 +194,25 @@ namespace Xwt.WPFBackend
 					break;
 				}
 			}
+
+			if (eventId is ListViewEvent) {
+				switch ((ListViewEvent)eventId) {
+				case ListViewEvent.RowActivated:
+					ListBox.MouseDoubleClick -= OnMouseDoubleClick;
+					break;
+				}
+			}
 		}
 
 		private void OnSelectionChanged (object sender, SelectionChangedEventArgs e)
 		{
 			ListBoxEventSink.OnSelectionChanged();
+		}
+
+		private void OnMouseDoubleClick (object sender, MouseButtonEventArgs e)
+		{
+			if (e.ChangedButton == MouseButton.Left)
+				ListBoxEventSink.OnRowActivated (ListBox.SelectedIndex);
 		}
 
 		protected ExListBox ListBox {

--- a/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
@@ -33,6 +33,7 @@ using System.Windows.Controls;
 using Xwt.WPFBackend.Utilities;
 using SWC = System.Windows.Controls;
 using Xwt.Backends;
+using System.Windows.Input;
 
 namespace Xwt.WPFBackend
 {
@@ -233,6 +234,14 @@ namespace Xwt.WPFBackend
 					break;
 				}
 			}
+
+			if (eventId is ListViewEvent) {
+				switch ((ListViewEvent)eventId) {
+				case ListViewEvent.RowActivated:
+					ListView.MouseDoubleClick += OnMouseDoubleClick;
+					break;
+				}
+			}
 		}
 
 		public override void DisableEvent (object eventId)
@@ -245,11 +254,25 @@ namespace Xwt.WPFBackend
 					break;
 				}
 			}
+
+			if (eventId is ListViewEvent) {
+				switch ((ListViewEvent)eventId) {
+				case ListViewEvent.RowActivated:
+					ListView.MouseDoubleClick -= OnMouseDoubleClick;
+					break;
+				}
+			}
 		}
 
 		private void OnSelectionChanged (object sender, SelectionChangedEventArgs e)
 		{
 			Context.InvokeUserCode (ListViewEventSink.OnSelectionChanged);
+		}
+
+		private void OnMouseDoubleClick (object sender, MouseButtonEventArgs e)
+		{
+			if (e.ChangedButton == MouseButton.Left)
+				ListViewEventSink.OnRowActivated (ListView.SelectedIndex);
 		}
 
 		private bool headersVisible;


### PR DESCRIPTION
On GTK, the RowActivated event of a ListBox is raised when the user performs a double-click on a row. To mimic this behavior on WPF, I used the MouseDoubleClick event of a System.Windows.Controls.ListBox.

References:

http://en.wikibooks.org/wiki/GTK%2B_By_Example/Tree_View/Events#Double-Clicks_on_a_Row
http://docs.go-mono.com/?link=E%3aGtk.TreeView.RowActivated
https://msdn.microsoft.com/en-us/library/system.windows.controls.control.mousedoubleclick(v=vs.110).aspx


