### PR TITLE
Fix default ColorSelectorBackend without window

### DIFF
--- a/Xwt/Xwt/ColorSelector.cs
+++ b/Xwt/Xwt/ColorSelector.cs
@@ -405,7 +405,11 @@ namespace Xwt
 							ib.Context.Fill ();
 						}
 					}
-					colorBox = ib.ToBitmap (this);
+
+					if (ParentWindow != null)
+						colorBox = ib.ToBitmap (this); // take screen scale factor into account
+					else
+						colorBox = ib.ToBitmap ();
 				}
 			}
 			ctx.DrawImage (colorBox, padding, padding);


### PR DESCRIPTION
This fixes the problem when the default ColorSelector is rendered without a parent window (e.g. when initialized with Wpf, or in a foreign host context). In this case the color box is drawn without taking the current screen scale factor into account.