### PR TITLE
Add TreeView/ListView FocusedRow property

### DIFF
--- a/TestApps/Samples/Samples/ListBoxSample.cs
+++ b/TestApps/Samples/Samples/ListBoxSample.cs
@@ -42,6 +42,17 @@ namespace Samples
 			
 			for (int n=0; n<100; n++)
 				list.Items.Add ("Value " + n);
+
+
+			list.KeyPressed += (sender, e) => {
+				if (e.Key == Key.Insert) {
+					int r = list.SelectedRow + 1;
+					list.Items.Insert(r, "Value " + list.Items.Count + 1);
+					list.ScrollToRow (r);
+					list.SelectRow (r);
+					list.FocusedRow = r;
+				}
+			};
 			
 			PackStart (list, true);
 			
@@ -61,6 +72,18 @@ namespace Samples
 				store.SetValue (r, icon, png);
 				store.SetValue (r, name, "Value " + n);
 			}
+
+			customList.KeyPressed += (sender, e) => {
+				if (e.Key == Key.Insert) {
+					var r = store.InsertRowAfter(customList.SelectedRow < 0 ? 0 : customList.SelectedRow);
+					store.SetValue (r, icon, png);
+					store.SetValue (r, name, "Value " + (store.RowCount + 1));
+					customList.ScrollToRow (r);
+					customList.SelectRow (r);
+					customList.FocusedRow = r;
+				}
+			};
+
 			PackStart (customList, true);
 
 			var spnValue = new SpinButton ();

--- a/TestApps/Samples/Samples/ListView1.cs
+++ b/TestApps/Samples/Samples/ListView1.cs
@@ -53,6 +53,20 @@ namespace Samples
 				}
 			};
 
+			list.KeyPressed += (sender, e) => {
+				if (e.Key == Key.Insert) {
+					var r = store.InsertRowAfter(list.SelectedRow < 0 ? 0 : list.SelectedRow);
+					store.SetValue (r, icon, png);
+					store.SetValue (r, name, "Value " + (store.RowCount + 1));
+					store.SetValue (r, icon2, png);
+					store.SetValue (r, text, "New Text " + (store.RowCount + 1));
+					store.SetValue (r, progress, new CellData { Value = rand.Next () % 100 });
+					list.ScrollToRow (r);
+					list.SelectRow (r);
+					list.FocusRow = r;
+				}
+			};
+
 			HBox btnBox = new HBox ();
 			Button btnAddItem = new Button ("Add item");
 			btnAddItem.Clicked += delegate {

--- a/TestApps/Samples/Samples/ListView1.cs
+++ b/TestApps/Samples/Samples/ListView1.cs
@@ -63,7 +63,7 @@ namespace Samples
 					store.SetValue (r, progress, new CellData { Value = rand.Next () % 100 });
 					list.ScrollToRow (r);
 					list.SelectRow (r);
-					list.FocusRow = r;
+					list.FocusedRow = r;
 				}
 			};
 

--- a/TestApps/Samples/Samples/TreeViews.cs
+++ b/TestApps/Samples/Samples/TreeViews.cs
@@ -133,6 +133,20 @@ namespace Samples
 			};
 
 			int addCounter = 0;
+			view.KeyPressed += (sender, e) => {
+				if (e.Key == Key.Insert) {
+					TreeNavigator n;
+					if (view.SelectedRow != null)
+						n = store.InsertNodeAfter (view.SelectedRow).SetValue (text, "Inserted").SetValue (desc, "Desc");
+					else
+						n = store.AddNode ().SetValue (text, "Inserted").SetValue (desc, "Desc");
+					view.ExpandToRow (n.CurrentPosition);
+					view.ScrollToRow (n.CurrentPosition);
+					view.UnselectAll ();
+					view.SelectRow (n.CurrentPosition);
+					view.FocusRow = n.CurrentPosition;
+				}
+			};
 			Button addButton = new Button ("Add");
 			addButton.Clicked += delegate(object sender, EventArgs e) {
 				addCounter++;

--- a/TestApps/Samples/Samples/TreeViews.cs
+++ b/TestApps/Samples/Samples/TreeViews.cs
@@ -144,7 +144,7 @@ namespace Samples
 					view.ScrollToRow (n.CurrentPosition);
 					view.UnselectAll ();
 					view.SelectRow (n.CurrentPosition);
-					view.FocusRow = n.CurrentPosition;
+					view.FocusedRow = n.CurrentPosition;
 				}
 			};
 			Button addButton = new Button ("Add");

--- a/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
@@ -106,6 +106,21 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		public int FocusRow {
+			get {
+				Gtk.TreePath path;
+				Gtk.TreeViewColumn column;
+				Widget.GetCursor (out path, out column);
+				if (path == null)
+					return -1;
+				return path.Indices [0];
+			}
+			set {
+				Gtk.TreePath path = new Gtk.TreePath (new [] { value >= 0 ? value : int.MaxValue });
+				Widget.SetCursor (path, null, false);
+			}
+		}
+
 		public int CurrentEventRow {
 			get;
 			internal set;

--- a/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListViewBackend.cs
@@ -106,7 +106,7 @@ namespace Xwt.GtkBackend
 			}
 		}
 
-		public int FocusRow {
+		public int FocusedRow {
 			get {
 				Gtk.TreePath path;
 				Gtk.TreeViewColumn column;

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
@@ -214,6 +214,25 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		public TreePosition FocusRow {
+			get {
+				Gtk.TreePath path;
+				Gtk.TreeViewColumn column;
+				Widget.GetCursor (out path, out column);
+
+				Gtk.TreeIter it;
+				if (path != null && Widget.Model.GetIter (out it, path))
+					return new IterPos (-1, it);
+				return null;
+			}
+			set {
+				Gtk.TreePath path = new Gtk.TreePath(new [] { int.MaxValue }); // set invalid path to unfocus
+				if (value != null)
+					path = Widget.Model.GetPath (((IterPos)value).Iter);
+				Widget.SetCursor (path, null, false);
+			}
+		}
+
 		public TreePosition CurrentEventRow {
 			get;
 			internal set;

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
@@ -214,7 +214,7 @@ namespace Xwt.GtkBackend
 			}
 		}
 
-		public TreePosition FocusRow {
+		public TreePosition FocusedRow {
 			get {
 				Gtk.TreePath path;
 				Gtk.TreeViewColumn column;

--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Xwt.WPFBackend\ExComboBox.cs" />
     <Compile Include="Xwt.WPFBackend\ExGrid.cs" />
     <Compile Include="Xwt.WPFBackend\ExListBox.cs" />
+    <Compile Include="Xwt.WPFBackend\ExListBoxItem.cs" />
     <Compile Include="Xwt.WPFBackend\ExListView.cs" />
     <Compile Include="Xwt.WPFBackend\ExListViewItem.cs" />
     <Compile Include="Xwt.WPFBackend\ExpanderBackend.cs" />

--- a/Xwt.WPF/Xwt.WPFBackend/ExListBox.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExListBox.cs
@@ -42,6 +42,16 @@ namespace Xwt.WPFBackend
 			set;
 		}
 
+		protected override bool IsItemItsOwnContainerOverride(object item)
+		{
+			return item is ExListBoxItem;
+		}
+
+		protected override DependencyObject GetContainerForItemOverride()
+		{
+			return new ExListBoxItem();
+		}
+
 		protected override System.Windows.Size MeasureOverride (System.Windows.Size constraint)
 		{
 			var s = base.MeasureOverride (constraint);
@@ -52,6 +62,25 @@ namespace Xwt.WPFBackend
 				s.Height = SystemParameters.CaptionHeight;
 
 			return Backend.MeasureOverride (constraint, s);
+		}
+
+		private ListBoxItem focusedItem = null;
+		public ListBoxItem FocusedItem {
+			get {
+				return focusedItem;
+			}
+			set {
+				FocusItem (value);
+			}
+		}
+
+		internal void FocusItem(ListBoxItem item)
+		{
+			if (item != null) {
+				focusedItem = item;
+				if (!item.IsFocused)
+					item.Focus ();
+			}
 		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/ExListBoxItem.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExListBoxItem.cs
@@ -1,0 +1,63 @@
+﻿//
+// ExListBoxItem.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Xwt.WPFBackend
+{
+	public class ExListBoxItem : ListBoxItem
+	{
+		private ExListBox view;
+		protected ExListBox ListBox {
+			get {
+				if (this.view == null)
+					this.view = FindListBox ((FrameworkElement) VisualParent);
+
+				return this.view;
+			}
+		}
+
+		private ExListBox FindListBox (FrameworkElement element)
+		{
+			if (element == null)
+				return null;
+
+			ExListBox view = element as ExListBox;
+			if (view != null)
+				return view;
+
+			return FindListBox (element.TemplatedParent as FrameworkElement);
+		} 
+
+		protected override void OnGotFocus (RoutedEventArgs e)
+		{
+			base.OnGotFocus (e);
+			ListBox.FocusItem (this);
+		}
+	}
+}
+

--- a/Xwt.WPF/Xwt.WPFBackend/ExListView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExListView.cs
@@ -56,5 +56,24 @@ namespace Xwt.WPFBackend
 			s = Backend.MeasureOverride (constraint, s);
 			return s;
 		}
+
+		private ListViewItem focusedItem = null;
+		public ListViewItem FocusedItem {
+			get {
+				return focusedItem;
+			}
+			set {
+				FocusItem (value);
+			}
+		}
+
+		internal void FocusItem(ListViewItem item)
+		{
+			if (item != null) {
+				focusedItem = item;
+				if (!item.IsFocused)
+					item.Focus ();
+			}
+		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/ExListViewItem.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExListViewItem.cs
@@ -69,5 +69,11 @@ namespace Xwt.WPFBackend
 
 			return FindListView (element.TemplatedParent as FrameworkElement);
 		}
+
+		protected override void OnGotFocus (RoutedEventArgs e)
+		{
+			base.OnGotFocus (e);
+			ListView.FocusItem (this);
+		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
@@ -379,6 +379,15 @@ namespace Xwt.WPFBackend
 		}
 
 		private ExTreeViewItem focusedTreeViewItem = null;
+		public ExTreeViewItem FocusedItem {
+			get {
+				return focusedTreeViewItem;
+			}
+			set {
+				FocusItem (value);
+			}
+		}
+
 		protected override void OnKeyDown(System.Windows.Input.KeyEventArgs e)
 		{
 			e.Handled = true;

--- a/Xwt.WPF/Xwt.WPFBackend/ListBoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListBoxBackend.cs
@@ -145,6 +145,21 @@ namespace Xwt.WPFBackend
 			get { return ListBox.SelectedItems.Cast<object>().Select (ListBox.Items.IndexOf).ToArray(); }
 		}
 
+		public int FocusedRow {
+			get {
+				if (ListBox.FocusedItem != null)
+					return ListBox.ItemContainerGenerator.IndexFromContainer(ListBox.FocusedItem);
+				return -1;
+			}
+			set {
+				ListBoxItem item = null;
+				if (value >= 0) {
+					item = ListBox.ItemContainerGenerator.ContainerFromIndex(value) as ListBoxItem;
+				}
+				ListBox.FocusItem(item);
+			}
+		}
+
 		public void SelectRow (int pos)
 		{
 			object item = ListBox.Items [pos];

--- a/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
@@ -139,6 +139,21 @@ namespace Xwt.WPFBackend
 			get { return ListView.SelectedItems.Cast<object>().Select (ListView.Items.IndexOf).ToArray (); }
 		}
 
+		public int FocusedRow {
+			get {
+				if (ListView.FocusedItem != null)
+					return ListView.ItemContainerGenerator.IndexFromContainer(ListView.FocusedItem);
+				return -1;
+			}
+			set {
+				ListViewItem item = null;
+				if (value >= 0) {
+					item = ListView.ItemContainerGenerator.ContainerFromIndex(value) as ListViewItem;
+				}
+				ListView.FocusItem(item);
+			}
+		}
+
 		public object AddColumn (ListViewColumn col)
 		{
 			var column = new GridViewColumn ();

--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -95,6 +95,19 @@ namespace Xwt.WPFBackend
 			get { return Tree.SelectedItems.Cast<TreePosition> ().ToArray (); }
 		}
 
+
+		public TreePosition FocusedRow {
+			get {
+				if (Tree.FocusedItem != null)
+					return Tree.FocusedItem.DataContext as TreePosition;
+				return null;
+			}
+			set {
+				ExTreeViewItem item = GetVisibleTreeItem (value);
+				Tree.FocusedItem = item;
+			}
+		}
+
 		private bool headersVisible = true;
 		public bool HeadersVisible {
 			get { return this.headersVisible; }

--- a/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
@@ -122,6 +122,17 @@ namespace Xwt.Mac
 				return sel;
 			}
 		}
+
+		public int FocusedRow {
+			get {
+				if (Table.SelectedRowCount > 0)
+					return (int)Table.SelectedRows.FirstIndex;
+				return -1;
+			}
+			set {
+				SelectRow (value);
+			}
+		}
 		
 		public void SelectRow (int pos)
 		{

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -129,6 +129,17 @@ namespace Xwt.Mac
 			}
 		}
 
+		public TreePosition FocusedRow {
+			get {
+				if (Table.SelectedRowCount > 0)
+					return ((TreeItem)Tree.ItemAtRow ((int)Table.SelectedRows.FirstIndex)).Position;
+				return null;
+			}
+			set {
+				SelectRow (value);
+			}
+		}
+
 		public override void SetCurrentEventRow (object pos)
 		{
 			CurrentEventRow = (TreePosition)pos;

--- a/Xwt/Xwt.Backends/IListBoxBackend.cs
+++ b/Xwt/Xwt.Backends/IListBoxBackend.cs
@@ -38,6 +38,7 @@ namespace Xwt.Backends
 		void SelectAll ();
 		void UnselectAll ();
 		int[] SelectedRows { get; }
+		int FocusedRow { get; set; }
 		void SelectRow (int pos);
 		void UnselectRow (int pos);
 		void ScrollToRow (int row);

--- a/Xwt/Xwt.Backends/IListViewBackend.cs
+++ b/Xwt/Xwt.Backends/IListViewBackend.cs
@@ -32,7 +32,7 @@ namespace Xwt.Backends
 	{
 		void SetSource (IListDataSource source, IBackend sourceBackend);
 		int[] SelectedRows { get; }
-		int FocusRow { get; set; }
+		int FocusedRow { get; set; }
 		void SelectRow (int pos);
 		void UnselectRow (int pos);
 		void ScrollToRow (int row);

--- a/Xwt/Xwt.Backends/IListViewBackend.cs
+++ b/Xwt/Xwt.Backends/IListViewBackend.cs
@@ -32,6 +32,7 @@ namespace Xwt.Backends
 	{
 		void SetSource (IListDataSource source, IBackend sourceBackend);
 		int[] SelectedRows { get; }
+		int FocusRow { get; set; }
 		void SelectRow (int pos);
 		void UnselectRow (int pos);
 		void ScrollToRow (int row);

--- a/Xwt/Xwt.Backends/ITreeViewBackend.cs
+++ b/Xwt/Xwt.Backends/ITreeViewBackend.cs
@@ -35,6 +35,7 @@ namespace Xwt.Backends
 		TreePosition[] SelectedRows { get; }
 		void SelectRow (TreePosition pos);
 		void UnselectRow (TreePosition pos);
+		TreePosition FocusRow { get; set; }
 		
 		bool IsRowSelected (TreePosition pos);
 		bool IsRowExpanded (TreePosition pos);

--- a/Xwt/Xwt.Backends/ITreeViewBackend.cs
+++ b/Xwt/Xwt.Backends/ITreeViewBackend.cs
@@ -35,7 +35,7 @@ namespace Xwt.Backends
 		TreePosition[] SelectedRows { get; }
 		void SelectRow (TreePosition pos);
 		void UnselectRow (TreePosition pos);
-		TreePosition FocusRow { get; set; }
+		TreePosition FocusedRow { get; set; }
 		
 		bool IsRowSelected (TreePosition pos);
 		bool IsRowExpanded (TreePosition pos);

--- a/Xwt/Xwt/ListBox.cs
+++ b/Xwt/Xwt/ListBox.cs
@@ -233,6 +233,19 @@ namespace Xwt
 				return Backend.SelectedRows;
 			}
 		}
+
+		/// <summary>
+		/// Gets or sets the focused row.
+		/// </summary>
+		/// <value>The row with the keyboard focus.</value>
+		public int FocusedRow {
+			get {
+				return Backend.FocusedRow;
+			}
+			set {
+				Backend.FocusedRow = value;
+			}
+		}
 		
 		/// <summary>
 		/// Selects a row.

--- a/Xwt/Xwt/ListView.cs
+++ b/Xwt/Xwt/ListView.cs
@@ -196,6 +196,19 @@ namespace Xwt
 				return Backend.SelectedRows;
 			}
 		}
+
+		/// <summary>
+		/// Gets or sets the focused row.
+		/// </summary>
+		/// <value>The row with the keyboard focus.</value>
+		public int FocusRow {
+			get {
+				return Backend.FocusRow;
+			}
+			set {
+				Backend.FocusRow = value;
+			}
+		}
 		
 		public void SelectRow (int row)
 		{

--- a/Xwt/Xwt/ListView.cs
+++ b/Xwt/Xwt/ListView.cs
@@ -201,12 +201,12 @@ namespace Xwt
 		/// Gets or sets the focused row.
 		/// </summary>
 		/// <value>The row with the keyboard focus.</value>
-		public int FocusRow {
+		public int FocusedRow {
 			get {
-				return Backend.FocusRow;
+				return Backend.FocusedRow;
 			}
 			set {
-				Backend.FocusRow = value;
+				Backend.FocusedRow = value;
 			}
 		}
 		

--- a/Xwt/Xwt/TreeView.cs
+++ b/Xwt/Xwt/TreeView.cs
@@ -262,6 +262,19 @@ namespace Xwt
 				return Backend.SelectedRows;
 			}
 		}
+
+		/// <summary>
+		/// Gets or sets the focused row.
+		/// </summary>
+		/// <value>The row with the keyboard focus.</value>
+		public TreePosition FocusRow {
+			get {
+				return Backend.FocusRow;
+			}
+			set {
+				Backend.FocusRow = value;
+			}
+		}
 		
 		/// <summary>
 		/// Selects a row.

--- a/Xwt/Xwt/TreeView.cs
+++ b/Xwt/Xwt/TreeView.cs
@@ -267,12 +267,12 @@ namespace Xwt
 		/// Gets or sets the focused row.
 		/// </summary>
 		/// <value>The row with the keyboard focus.</value>
-		public TreePosition FocusRow {
+		public TreePosition FocusedRow {
 			get {
-				return Backend.FocusRow;
+				return Backend.FocusedRow;
 			}
 			set {
-				Backend.FocusRow = value;
+				Backend.FocusedRow = value;
 			}
 		}
 		


### PR DESCRIPTION
This adds a FocusedRow property to TreeView, ListView and ListBox to get/set the row with the keyboard focus.

There is a special case on Mac: there is not keyboard focus feature for single rows, but only row selection. So on Mac FocusedRow is always the first selected row (selects a row, when FocusedRow is assigned, or returns the first selected row).

(fixes #376)