### PR TITLE
[MAC] Respect SelectionMode on row selection

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
@@ -125,7 +125,7 @@ namespace Xwt.Mac
 		
 		public void SelectRow (int pos)
 		{
-			Table.SelectRow (pos, false);
+			Table.SelectRow (pos, Table.AllowsMultipleSelection);
 		}
 		
 		public void UnselectRow (int pos)

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -138,7 +138,7 @@ namespace Xwt.Mac
 		{
 			var it = tsource.GetItem (pos);
 			if (it != null)
-				Table.SelectRow ((int)Tree.RowForItem (it), false);
+				Table.SelectRow ((int)Tree.RowForItem (it), Table.AllowsMultipleSelection);
 		}
 
 		public void UnselectRow (TreePosition pos)


### PR DESCRIPTION
The default behavior when selecting single rows should be extending the selection when SelectionMode is set to ```SelectionMode.Multiple``` (WPF and GTK work this way). The current Mac behavior is to replace the selection (deselect previously selected rows), which is fixed here.