### PR TITLE
Fix RadioButtonMenuItem group handling

### DIFF
--- a/TestApps/Samples/Samples/MenuSamples.cs
+++ b/TestApps/Samples/Samples/MenuSamples.cs
@@ -40,7 +40,29 @@ namespace Samples
 			menu.Items.Add (new MenuItem ("Two"));
 			menu.Items.Add (new MenuItem ("Three"));
 			menu.Items.Add (new SeparatorMenuItem ());
-			menu.Items.Add (new MenuItem ("End"));
+
+			var rgroup = new RadioButtonMenuItemGroup ();
+			menu.Items.Add (new RadioButtonMenuItem ("Opt 1") { Group = rgroup, Sensitive = false });
+			menu.Items.Add (new RadioButtonMenuItem ("Opt 2") { Group = rgroup, Checked = true });
+			menu.Items.Add (new RadioButtonMenuItem ("Opt 3") { Group = rgroup });
+
+			menu.Items.Add (new SeparatorMenuItem ());
+
+			menu.Items.Add (new CheckBoxMenuItem ("Check 1"));
+			menu.Items.Add (new CheckBoxMenuItem ("Check 2") { Checked = true });
+
+			menu.Items.Add (new SeparatorMenuItem ());
+
+			var subMenu = new MenuItem ("Submenu");
+			subMenu.SubMenu = new Menu ();
+			var subZoomIn = new MenuItem (new Command ("Zoom+", StockIcons.ZoomIn));
+			var subZoomOut = new MenuItem (new Command ("Zoom-", StockIcons.ZoomOut));
+			subMenu.SubMenu.Items.Add (subZoomIn);
+			subMenu.SubMenu.Items.Add (subZoomOut);
+			menu.Items.Add (subMenu);
+
+			subZoomIn.Clicked += (sender, e) => MessageDialog.ShowMessage ("'Zoom+' item clicked.");
+			subZoomOut.Clicked += (sender, e) => MessageDialog.ShowMessage ("'Zoom-' item clicked.");
 
 			la.ButtonPressed += HandleButtonPressed;
 			PackStart (la);

--- a/Xwt/Xwt/RadioButtonMenuItem.cs
+++ b/Xwt/Xwt/RadioButtonMenuItem.cs
@@ -35,6 +35,20 @@ namespace Xwt
 	public class RadioButtonMenuItem: MenuItem
 	{
 		RadioButtonMenuItemGroup radioGroup;
+
+		protected class RadioButtonMenuItemBackendHost: MenuItemBackendHost
+		{
+			protected override IEnumerable<object> GetDefaultEnabledEvents ()
+			{
+				// always enable clicked event for group logic
+				yield return MenuItemEvent.Clicked;
+			}
+		}
+
+		protected override BackendHost CreateBackendHost ()
+		{
+			return new RadioButtonMenuItemBackendHost ();
+		}
 		
 		public RadioButtonMenuItem ()
 		{


### PR DESCRIPTION
The group handling of RadioButton menu items relies on the Clicked event, which is disabled by default. This patch enables the Clicked event even if it is not subscribed. An extended Menu example is included, too.

@slluis: is this the right way to do it?

(closes #256)