### PR TITLE
Fix build with Xamarin.Mac 2.0

### DIFF
--- a/Xwt.XamMac/Xwt.Mac.CellViews/CanvasTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CanvasTableCell.cs
@@ -76,7 +76,7 @@ namespace Xwt.Mac
 			var size = new CGSize ();
 			Frontend.ApplicationContext.InvokeUserCode (delegate {
 				var s = Frontend.GetRequiredSize ();
-				size = new SizeF ((float)s.Width, (float)s.Height);
+				size = new CGSize ((nfloat)s.Width, (nfloat)s.Height);
 			});
 			if (size.Width > bounds.Width)
 				size.Width = bounds.Width;

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -272,7 +272,7 @@ namespace Xwt.Mac
 						return c.Frame;
 				}
 			}
-			return RectangleF.Empty;
+			return CGRect.Empty;
 		}
 
 		CellPos GetHitCell (NSEvent theEvent, CGRect cellFrame, NSView controlView)

--- a/Xwt.XamMac/Xwt.Mac/BoxBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/BoxBackend.cs
@@ -30,9 +30,11 @@ using Xwt.Backends;
 #if MONOMAC
 using nint = System.Int32;
 using nfloat = System.Single;
+using CGRect = System.Drawing.RectangleF;
 using MonoMac.AppKit;
 #else
 using AppKit;
+using CoreGraphics;
 #endif
 
 namespace Xwt.Mac
@@ -67,7 +69,7 @@ namespace Xwt.Mac
 			for (int n=0; n<widgets.Length; n++) {
 				var w = GetWidget (widgets[n]);
 				var r = rects[n];
-				w.Frame = new System.Drawing.RectangleF ((float)r.Left, (float)r.Top, (float)r.Width, (float)r.Height);
+				w.Frame = new CGRect ((nfloat)r.Left, (nfloat)r.Top, (nfloat)r.Width, (nfloat)r.Height);
 				w.NeedsDisplay = true;
 			}
 		}

--- a/Xwt.XamMac/Xwt.Mac/CanvasBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/CanvasBackend.cs
@@ -34,6 +34,7 @@ using nfloat = System.Single;
 using MonoMac.CoreGraphics;
 using MonoMac.AppKit;
 using CGRect = System.Drawing.RectangleF;
+using CGSize = System.Drawing.SizeF;
 #else
 using CoreGraphics;
 using AppKit;
@@ -58,7 +59,7 @@ namespace Xwt.Mac
 		protected override void OnSizeToFit ()
 		{
 			var s = EventSink.GetPreferredSize ();
-			Widget.SetFrameSize (new System.Drawing.SizeF ((float)s.Width, (float)s.Height)); 
+			Widget.SetFrameSize (new CGSize ((nfloat)s.Width, (nfloat)s.Height)); 
 		}
 
 		public Rectangle Bounds {
@@ -74,7 +75,7 @@ namespace Xwt.Mac
 		
 		public void QueueDraw (Rectangle rect)
 		{
-			view.SetNeedsDisplayInRect (new System.Drawing.RectangleF ((float)rect.X, (float)rect.Y, (float)rect.Width, (float)rect.Height));
+			view.SetNeedsDisplayInRect (new CGRect ((nfloat)rect.X, (nfloat)rect.Y, (nfloat)rect.Width, (nfloat)rect.Height));
 		}
 		
 		public void AddChild (IWidgetBackend widget, Rectangle rect)
@@ -83,7 +84,7 @@ namespace Xwt.Mac
 			view.AddSubview (v);
 			
 			// Not using SetWidgetBounds because the view is flipped
-			v.Frame = new System.Drawing.RectangleF ((float)rect.X, (float)rect.Y, (float)rect.Width, (float)rect.Height);;
+			v.Frame = new CGRect ((nfloat)rect.X, (nfloat)rect.Y, (nfloat)rect.Width, (nfloat)rect.Height);;
 			v.NeedsDisplay = true;
 		}
 		
@@ -98,7 +99,7 @@ namespace Xwt.Mac
 			var w = GetWidget (widget);
 			
 			// Not using SetWidgetBounds because the view is flipped
-			w.Frame = new System.Drawing.RectangleF ((float)rect.X, (float)rect.Y, (float)rect.Width, (float)rect.Height);;
+			w.Frame = new CGRect ((nfloat)rect.X, (nfloat)rect.Y, (nfloat)rect.Width, (nfloat)rect.Height);;
 			w.NeedsDisplay = true;
 		}
 	}

--- a/Xwt.XamMac/Xwt.Mac/ContextBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ContextBackendHandler.cs
@@ -49,7 +49,7 @@ namespace Xwt.Mac
 {
 	class CGContextBackend {
 		public CGContext Context;
-		public SizeF Size;
+		public CGSize Size;
 		public CGAffineTransform? InverseViewTransform;
 		public Stack<ContextStatus> StatusStack = new Stack<ContextStatus> ();
 		public ContextStatus CurrentStatus = new ContextStatus ();
@@ -173,7 +173,7 @@ namespace Xwt.Mac
 
 		public override void Rectangle (object backend, double x, double y, double width, double height)
 		{
-			((CGContextBackend)backend).Context.AddRect (new RectangleF ((float)x, (float)y, (float)width, (float)height));
+			((CGContextBackend)backend).Context.AddRect (new CGRect ((nfloat)x, (nfloat)y, (nfloat)width, (nfloat)height));
 		}
 
 		public override void RelCurveTo (object backend, double dx1, double dy1, double dx2, double dy2, double dx3, double dy3)
@@ -248,7 +248,7 @@ namespace Xwt.Mac
 
 		void SetupPattern (CGContextBackend gc)
 		{
-			gc.Context.SetPatternPhase (new SizeF (0, 0));
+			gc.Context.SetPatternPhase (new CGSize (0, 0));
 
 			if (gc.CurrentStatus.Pattern is GradientInfo)
 				return;
@@ -306,7 +306,7 @@ namespace Xwt.Mac
 
 			double rx = destRect.Width / srcRect.Width;
 			double ry = destRect.Height / srcRect.Height;
-			ctx.AddRect (new RectangleF ((float)destRect.X, (float)destRect.Y, (float)destRect.Width, (float)destRect.Height));
+			ctx.AddRect (new CGRect ((nfloat)destRect.X, (nfloat)destRect.Y, (nfloat)destRect.Width, (nfloat)destRect.Height));
 			ctx.Clip ();
 			ctx.TranslateCTM ((float)(destRect.X - (srcRect.X * rx)), (float)(destRect.Y - (srcRect.Y * ry)));
 			ctx.ScaleCTM ((float)rx, (float)ry);
@@ -377,12 +377,12 @@ namespace Xwt.Mac
 
 		public override bool IsPointInFill (object backend, double x, double y)
 		{
-			return ((CGContextBackend)backend).Context.PathContainsPoint (new PointF ((float)x, (float)y), CGPathDrawingMode.Fill);
+			return ((CGContextBackend)backend).Context.PathContainsPoint (new CGPoint ((nfloat)x, (nfloat)y), CGPathDrawingMode.Fill);
 		}
 
 		public override bool IsPointInStroke (object backend, double x, double y)
 		{
-			return ((CGContextBackend)backend).Context.PathContainsPoint (new PointF ((float)x, (float)y), CGPathDrawingMode.Stroke);
+			return ((CGContextBackend)backend).Context.PathContainsPoint (new CGPoint ((nfloat)x, (nfloat)y), CGPathDrawingMode.Stroke);
 		}
 
 		public override void Dispose (object backend)
@@ -411,7 +411,7 @@ namespace Xwt.Mac
 			// setup pattern drawing to better match the behavior of Cairo
 			var drawPoint = ctx.GetCTM ().TransformPoint (ctx.GetPathBoundingBox ().Location);
 			var patternPhase = new CGSize (drawPoint.X, drawPoint.Y);
-			if (patternPhase != SizeF.Empty)
+			if (patternPhase != CGSize.Empty)
 				ctx.SetPatternPhase (patternPhase);
 		}
 	}

--- a/Xwt.XamMac/Xwt.Mac/FrameBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/FrameBackend.cs
@@ -31,6 +31,7 @@ using Xwt.Drawing;
 using nint = System.Int32;
 using nfloat = System.Single;
 using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
 using MonoMac.AppKit;
 #else
 using CoreGraphics;
@@ -55,11 +56,11 @@ namespace Xwt.Mac
 			switch (type) {
 			case FrameType.WidgetBox:
 				Widget.BoxType = NSBoxType.NSBoxPrimary;
-				Widget.ContentViewMargins = new System.Drawing.SizeF (5,5);
+				Widget.ContentViewMargins = new CGSize (5,5);
 				break;
 			case FrameType.Custom:
 				Widget.BoxType = NSBoxType.NSBoxCustom;
-				Widget.ContentViewMargins = new System.Drawing.SizeF (0,0);
+				Widget.ContentViewMargins = new CGSize (0,0);
 				break;
 			}
 		}
@@ -87,9 +88,9 @@ namespace Xwt.Mac
 			if (currentChild != null) {
 				var s = ((IViewObject)currentChild).Backend.Frontend.Surface.GetPreferredSize ();
 				var frame = (Frame)Frontend;
-				currentChild.Frame = new System.Drawing.RectangleF (0, 0, (float)s.Width, (float)s.Height);
+				currentChild.Frame = new CGRect (0, 0, (nfloat)s.Width, (nfloat)s.Height);
 				Widget.SizeToFit ();
-				Widget.SetFrameSize (new System.Drawing.SizeF ((float)(Widget.Frame.Width + frame.Padding.HorizontalSpacing), (float)(Widget.Frame.Height + frame.Padding.VerticalSpacing)));
+				Widget.SetFrameSize (new CGSize ((nfloat)(Widget.Frame.Width + frame.Padding.HorizontalSpacing), (nfloat)(Widget.Frame.Height + frame.Padding.VerticalSpacing)));
 			}
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/GradientBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/GradientBackendHandler.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 #if MONOMAC
 using nint = System.Int32;
 using nfloat = System.Single;
+using CGPoint = System.Drawing.PointF;
 using MonoMac.CoreGraphics;
 #else
 using CoreGraphics;
@@ -46,8 +47,8 @@ namespace Xwt.Mac
 		{
 			return new GradientInfo () {
 				Linear = true,
-				Start = new PointF ((float)x0, (float)y0),
-				End = new PointF ((float)x1, (float)y1)
+				Start = new CGPoint ((nfloat)x0, (nfloat)y0),
+				End = new CGPoint ((nfloat)x1, (nfloat)y1)
 			};
 		}
 
@@ -59,10 +60,10 @@ namespace Xwt.Mac
 		{
 			return new GradientInfo () {
 				Linear = false,
-				Start = new PointF ((float)cx0, (float)cy0),
-				End = new PointF ((float)cx1, (float)cy1),
-				StartRadius = (float)radius0,
-				EndRadius = (float)radius1
+				Start = new CGPoint ((nfloat)cx0, (nfloat)cy0),
+				End = new CGPoint ((nfloat)cx1, (nfloat)cy1),
+				StartRadius = (nfloat)radius0,
+				EndRadius = (nfloat)radius1
 			};
 		}
 
@@ -90,8 +91,8 @@ namespace Xwt.Mac
 	class GradientInfo
 	{
 		public bool Linear;
-		public PointF Start, End;
-		public float StartRadius, EndRadius;
+		public CGPoint Start, End;
+		public nfloat StartRadius, EndRadius;
 		public List<CGColor> Colors = new List<CGColor> ();
 		public List<nfloat> Stops = new List<nfloat> ();
 	}

--- a/Xwt.XamMac/Xwt.Mac/ImageBuilderBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageBuilderBackendHandler.cs
@@ -31,6 +31,7 @@ using System.Drawing;
 #if MONOMAC
 using nint = System.Int32;
 using nfloat = System.Single;
+using CGSize = System.Drawing.SizeF;
 using MonoMac.CoreGraphics;
 using MonoMac.AppKit;
 #else
@@ -72,7 +73,7 @@ namespace Xwt.Mac
 			bmp.ScaleCTM (1, -1);
 			return new CGContextBackend {
 				Context = bmp,
-				Size = new SizeF (width, height),
+				Size = new CGSize (width, height),
 				InverseViewTransform = bmp.GetCTM ().Invert ()
 			};
 		}

--- a/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
@@ -157,7 +157,7 @@ namespace Xwt.Mac
 
 				var ctx = new CGContextBackend {
 					Context = bmp,
-					Size = new SizeF ((float)width, (float)height),
+					Size = new CGSize ((nfloat)width, (nfloat)height),
 					InverseViewTransform = bmp.GetCTM ().Invert (),
 					ScaleFactor = scaleFactor
 				};
@@ -165,12 +165,12 @@ namespace Xwt.Mac
 				var ci = (CustomImage)handle;
 				ci.DrawInContext (ctx);
 
-				var img = new NSImage (((CGBitmapContext)bmp).ToImage (), new SizeF (pixelWidth, pixelHeight));
+				var img = new NSImage (((CGBitmapContext)bmp).ToImage (), new CGSize (pixelWidth, pixelHeight));
 				var imageData = img.AsTiff ();
 				var imageRep = (NSBitmapImageRep)NSBitmapImageRep.ImageRepFromData (imageData);
 				var im = new NSImage ();
 				im.AddRepresentation (imageRep);
-				im.Size = new SizeF ((float)width, (float)height);
+				im.Size = new CGSize ((nfloat)width, (nfloat)height);
 				bmp.Dispose ();
 				return im;
 			}
@@ -182,7 +182,7 @@ namespace Xwt.Mac
 					var imageRep = (NSBitmapImageRep)NSBitmapImageRep.ImageRepFromData (imageData);
 					var im = new NSImage ();
 					im.AddRepresentation (imageRep);
-					im.Size = new SizeF ((float)width, (float)height);
+					im.Size = new CGSize ((nfloat)width, (nfloat)height);
 					return im;
 				}
 				return handle;
@@ -332,7 +332,7 @@ namespace Xwt.Mac
 
 		internal void DrawInContext (CGContextBackend ctx)
 		{
-			var s = ctx.Size != SizeF.Empty ? ctx.Size : Size;
+			var s = ctx.Size != CGSize.Empty ? ctx.Size : Size;
 			actx.InvokeUserCode (delegate {
 				drawCallback (ctx, new Rectangle (0, 0, s.Width, s.Height));
 			});

--- a/Xwt.XamMac/Xwt.Mac/LinkLabelBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/LinkLabelBackend.cs
@@ -107,8 +107,8 @@ namespace Xwt.Mac
 			var range = new NSRange (0, attrStr.Length);
 
 			var singleUnderlineStyle = NSNumber.FromInt32 ((int)NSUnderlineStyle.Single);
-			attrStr.AddAttribute (NSAttributedString.ForegroundColorAttributeName, NSColor.Blue, range);
-			attrStr.AddAttribute (NSAttributedString.UnderlineStyleAttributeName, singleUnderlineStyle, range);
+			attrStr.AddAttribute (NSStringAttributeKey.ForegroundColor, NSColor.Blue, range);
+			attrStr.AddAttribute (NSStringAttributeKey.UnderlineStyle, singleUnderlineStyle, range);
 
 			return attrStr;
 		}

--- a/Xwt.XamMac/Xwt.Mac/MacDesktopBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacDesktopBackend.cs
@@ -92,12 +92,12 @@ namespace Xwt.Mac
 			return new Rectangle (r.X, r.Y, r.Width, r.Height);
 		}
 
-		public static System.Drawing.RectangleF FromDesktopRect (Rectangle r)
+		public static CGRect FromDesktopRect (Rectangle r)
 		{
 			r.Y = (float)desktopBounds.Height - r.Y - r.Height;
 			if (desktopBounds.Y < 0)
 				r.Y += (float)desktopBounds.Y;
-			return new System.Drawing.RectangleF ((float)r.X, (float)r.Y, (float)r.Width, (float)r.Height);
+			return new CGRect ((nfloat)r.X, (nfloat)r.Y, (nfloat)r.Width, (nfloat)r.Height);
 		}
 		
 		public override Rectangle GetScreenBounds (object backend)

--- a/Xwt.XamMac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacEngine.cs
@@ -32,6 +32,7 @@ using Xwt.Backends;
 #if MONOMAC
 using nint = System.Int32;
 using nfloat = System.Single;
+using CGSize = System.Drawing.SizeF;
 using MonoMac.Foundation;
 using MonoMac.AppKit;
 using MonoMac.ObjCRuntime;
@@ -254,7 +255,7 @@ namespace Xwt.Mac
 			var imageRep = (NSBitmapImageRep)NSBitmapImageRep.ImageRepFromData (imageData);
 			var im = new NSImage ();
 			im.AddRepresentation (imageRep);
-			im.Size = new System.Drawing.SizeF ((float)view.Bounds.Width, (float)view.Bounds.Height);
+			im.Size = new CGSize ((nfloat)view.Bounds.Width, (nfloat)view.Bounds.Height);
 			return im;
 		}
 	}

--- a/Xwt.XamMac/Xwt.Mac/PathBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/PathBackendHandler.cs
@@ -86,7 +86,7 @@ namespace Xwt.Mac
 
 		public override void Rectangle (object backend, double x, double y, double width, double height)
 		{
-			((CGPath)backend).AddRect (new RectangleF ((float)x, (float)y, (float)width, (float)height));
+			((CGPath)backend).AddRect (new CGRect ((nfloat)x, (nfloat)y, (nfloat)width, (nfloat)height));
 		}
 
 		public override void RelCurveTo (object backend, double dx1, double dy1, double dx2, double dy2, double dx3, double dy3)
@@ -135,7 +135,7 @@ namespace Xwt.Mac
 
 		public override bool IsPointInFill (object backend, double x, double y)
 		{
-			return ((CGPath)backend).ContainsPoint (new PointF ((float)x, (float)y), false);
+			return ((CGPath)backend).ContainsPoint (new CGPoint ((nfloat)x, (nfloat)y), false);
 		}
 
 		public override void Dispose (object backend)

--- a/Xwt.XamMac/Xwt.Mac/ScrollViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ScrollViewBackend.cs
@@ -271,7 +271,7 @@ namespace Xwt.Mac
 			var vr = DocumentVisibleRect ();
 			ratioX = hScroll.PageSize != 0 ? (float)vr.Width / (float)hScroll.PageSize : 1;
 			ratioY = vScroll.PageSize != 0 ? (float)vr.Height / (float)vScroll.PageSize : 1;
-			DocumentView.Frame = new System.Drawing.RectangleF (0, 0, (float)(hScroll.UpperValue - hScroll.LowerValue) * ratioX, (float)(vScroll.UpperValue - vScroll.LowerValue) * ratioY);
+			DocumentView.Frame = new CGRect (0, 0, (nfloat)(hScroll.UpperValue - hScroll.LowerValue) * ratioX, (nfloat)(vScroll.UpperValue - vScroll.LowerValue) * ratioY);
 		}
 	}
 

--- a/Xwt.XamMac/Xwt.Mac/SliderBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/SliderBackend.cs
@@ -33,9 +33,11 @@ using System.Collections.Generic;
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 using nint = System.Int32;
+using CGSize = System.Drawing.SizeF;
 #else
 using AppKit;
 using Foundation;
+using CoreGraphics;
 #endif
 
 namespace Xwt.Mac
@@ -54,9 +56,9 @@ namespace Xwt.Mac
 			//((NSSliderCell)Widget.Cell).SetValueForKey (NSObject.FromObject (false), (NSString)"NSVertical");
 			orientation = dir;
 			if (dir == Orientation.Horizontal)
-				Widget.SetFrameSize (new System.Drawing.SizeF (80, 30));
+				Widget.SetFrameSize (new CGSize (80, 30));
 			else
-				Widget.SetFrameSize (new System.Drawing.SizeF (30, 80));
+				Widget.SetFrameSize (new CGSize (30, 80));
 		}
 
 		MacSlider Slider {

--- a/Xwt.XamMac/Xwt.Mac/TextLayoutBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextLayoutBackendHandler.cs
@@ -35,6 +35,9 @@ using MonoMac.Foundation;
 using MonoMac.AppKit;
 using MonoMac.CoreText;
 using MonoMac.CoreGraphics;
+using CGPoint = System.Drawing.PointF;
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
 #else
 using Foundation;
 using AppKit;
@@ -42,9 +45,6 @@ using CoreText;
 using CoreGraphics;
 #endif
 
-using PointF = System.Drawing.PointF;
-using SizeF = System.Drawing.SizeF;
-using RectangleF = System.Drawing.RectangleF;
 using System.Collections.Generic;
 
 namespace Xwt.Mac
@@ -144,7 +144,7 @@ namespace Xwt.Mac
 			using (CTFramesetter framesetter = new CTFramesetter (CreateAttributedString (li))) {
 				CGPath path = new CGPath ();
 				bool ellipsize = li.Width.HasValue && li.TextTrimming == TextTrimming.WordElipsis;
-				path.AddRect (new RectangleF (0, 0, li.Width.HasValue && !ellipsize ? li.Width.Value : float.MaxValue, li.Height ?? float.MaxValue));
+				path.AddRect (new CGRect (0, 0, li.Width.HasValue && !ellipsize ? li.Width.Value : float.MaxValue, li.Height ?? float.MaxValue));
 
 				return framesetter.GetFrame (new NSRange (0, li.Text.Length), path, null);
 			}
@@ -185,7 +185,7 @@ namespace Xwt.Mac
 				ctx.TextMatrix = CGAffineTransform.MakeScale (1f, -1f);
 				ctx.TranslateCTM ((float)x, (float)y + li.Font.Ascender);
 				foreach (var line in frame.GetLines ()) {
-					ctx.TextPosition = PointF.Empty;
+					ctx.TextPosition = CGPoint.Empty;
 					if (ellipsize) // we need to create a new CTLine here because the framesetter already truncated the text for the line
 						new CTLine (CreateAttributedString (li, li.Text.Substring ((int)line.StringRange.Location)))
 							.GetTruncatedLine (li.Width.Value, CTLineTruncation.End, ellipsis).Draw (ctx);

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -32,9 +32,11 @@ using System.Collections.Generic;
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 using nint = System.Int32;
+using CGPoint = System.Drawing.PointF;
 #else
 using AppKit;
 using Foundation;
+using CoreGraphics;
 #endif
 
 namespace Xwt.Mac
@@ -207,7 +209,7 @@ namespace Xwt.Mac
 		public bool GetDropTargetRow (double x, double y, out RowDropPosition pos, out TreePosition nodePosition)
 		{
 			// Get row
-			nint row = Tree.GetRow(new System.Drawing.PointF ((float)x, (float)y));
+			nint row = Tree.GetRow(new CGPoint ((nfloat)x, (nfloat)y));
 			pos = RowDropPosition.Into;
 			nodePosition = null;
 			if (row >= 0) {
@@ -219,7 +221,7 @@ namespace Xwt.Mac
 /*		protected override void OnDragOverCheck (NSDraggingInfo di, DragOverCheckEventArgs args)
 		{
 			base.OnDragOverCheck (di, args);
-			var row = Tree.GetRow (new System.Drawing.PointF (di.DraggingLocation.X, di.DraggingLocation.Y));
+			var row = Tree.GetRow (new CGPoint (di.DraggingLocation.X, di.DraggingLocation.Y));
 			if (row != -1) {
 				var item = Tree.ItemAtRow (row);
 				Tree.SetDropItem (item, row);

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -297,7 +297,7 @@ namespace Xwt.Mac
 			else {
 				img = (NSImage)img.Copy ();
 			}
-			img.Size = new System.Drawing.SizeF ((float)idesc.Size.Width, (float)idesc.Size.Height);
+			img.Size = new CGSize ((nfloat)idesc.Size.Width, (nfloat)idesc.Size.Height);
 			return img;
 		}
 
@@ -317,25 +317,25 @@ namespace Xwt.Mac
 				var r = new NSRange (att.StartIndex, att.Count);
 				if (att is BackgroundTextAttribute) {
 					var xa = (BackgroundTextAttribute)att;
-					ns.AddAttribute (NSAttributedString.BackgroundColorAttributeName, xa.Color.ToNSColor (), r);
+					ns.AddAttribute (NSStringAttributeKey.BackgroundColor, xa.Color.ToNSColor (), r);
 				}
 				else if (att is ColorTextAttribute) {
 					var xa = (ColorTextAttribute)att;
-					ns.AddAttribute (NSAttributedString.ForegroundColorAttributeName, xa.Color.ToNSColor (), r);
+					ns.AddAttribute (NSStringAttributeKey.ForegroundColor, xa.Color.ToNSColor (), r);
 				}
 				else if (att is UnderlineTextAttribute) {
 					var xa = (UnderlineTextAttribute)att;
 					int style = xa.Underline ? 0x01 /*NSUnderlineStyleSingle*/ : 0;
-					ns.AddAttribute (NSAttributedString.UnderlineStyleAttributeName, (NSNumber)style, r);
+					ns.AddAttribute (NSStringAttributeKey.UnderlineStyle, (NSNumber)style, r);
 				}
 				else if (att is FontStyleTextAttribute) {
 					var xa = (FontStyleTextAttribute)att;
 					if (xa.Style == FontStyle.Italic) {
 						Messaging.void_objc_msgSend_int_NSRange (ns.Handle, applyFontTraits.Handle, (IntPtr)(long)NSFontTraitMask.Italic, r);
 					} else if (xa.Style == FontStyle.Oblique) {
-						ns.AddAttribute (NSAttributedString.ObliquenessAttributeName, (NSNumber)0.2f, r);
+						ns.AddAttribute (NSStringAttributeKey.Obliqueness, (NSNumber)0.2f, r);
 					} else {
-						ns.AddAttribute (NSAttributedString.ObliquenessAttributeName, (NSNumber)0.0f, r);
+						ns.AddAttribute (NSStringAttributeKey.Obliqueness, (NSNumber)0.0f, r);
 						Messaging.void_objc_msgSend_int_NSRange (ns.Handle, applyFontTraits.Handle, (IntPtr)(long)NSFontTraitMask.Unitalic, r);
 					}
 				}
@@ -346,19 +346,19 @@ namespace Xwt.Mac
 				}
 				else if (att is LinkTextAttribute) {
 					var xa = (LinkTextAttribute)att;
-					ns.AddAttribute (NSAttributedString.LinkAttributeName, new NSUrl (xa.Target.ToString ()), r);
-					ns.AddAttribute (NSAttributedString.ForegroundColorAttributeName, NSColor.Blue, r);
-					ns.AddAttribute (NSAttributedString.UnderlineStyleAttributeName, NSNumber.FromInt32 ((int)NSUnderlineStyle.Single), r);
+					ns.AddAttribute (NSStringAttributeKey.Link, new NSUrl (xa.Target.ToString ()), r);
+					ns.AddAttribute (NSStringAttributeKey.ForegroundColor, NSColor.Blue, r);
+					ns.AddAttribute (NSStringAttributeKey.UnderlineStyle, NSNumber.FromInt32 ((int)NSUnderlineStyle.Single), r);
 				}
 				else if (att is StrikethroughTextAttribute) {
 					var xa = (StrikethroughTextAttribute)att;
 					int style = xa.Strikethrough ? 0x01 /*NSUnderlineStyleSingle*/ : 0;
-					ns.AddAttribute (NSAttributedString.StrikethroughStyleAttributeName, (NSNumber)style, r);
+					ns.AddAttribute (NSStringAttributeKey.StrikethroughStyle, (NSNumber)style, r);
 				}
 				else if (att is FontTextAttribute) {
 					var xa = (FontTextAttribute)att;
 					var nf = ((FontData)Toolkit.GetBackend (xa.Font)).Font;
-					ns.AddAttribute (NSAttributedString.FontAttributeName, nf, r);
+					ns.AddAttribute (NSStringAttributeKey.Font, nf, r);
 				}
 			}
 			ns.EndEditing ();

--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -416,7 +416,7 @@ namespace Xwt.Mac
 		
 		public Point ConvertToScreenCoordinates (Point widgetCoordinates)
 		{
-			var lo = Widget.ConvertPointToBase (new PointF ((float)widgetCoordinates.X, (float)widgetCoordinates.Y));
+			var lo = Widget.ConvertPointToBase (new CGPoint ((nfloat)widgetCoordinates.X, (nfloat)widgetCoordinates.Y));
 			lo = Widget.Window.ConvertBaseToScreen (lo);
 			return MacDesktopBackend.ToDesktopRect (new CGRect (lo.X, lo.Y, 0, Widget.IsFlipped ? 0 : Widget.Frame.Height)).Location;
 		}
@@ -472,7 +472,7 @@ namespace Xwt.Mac
 			} else {
 				var s = CalcFittingSize ();
 				if (!s.IsZero)
-					Widget.SetFrameSize (new SizeF ((float)s.Width, (float)s.Height));
+					Widget.SetFrameSize (new CGSize ((nfloat)s.Width, (nfloat)s.Height));
 			}
 		}
 		
@@ -489,7 +489,7 @@ namespace Xwt.Mac
 
 		void AutoUpdateSize ()
 		{	var s = Frontend.Surface.GetPreferredSize ();
-			Widget.SetFrameSize (new SizeF ((float)s.Width, (float)s.Height));
+			Widget.SetFrameSize (new CGSize ((nfloat)s.Width, (nfloat)s.Height));
 		}
 
 		NSObject gotFocusObserver;
@@ -567,7 +567,7 @@ namespace Xwt.Mac
 			InitPasteboard (pb, sdata.Data);
 			var img = (NSImage)sdata.ImageBackend;
 			var pos = new CGPoint (ml.X - lo.X - (float)sdata.HotX, lo.Y - ml.Y - (float)sdata.HotY + img.Size.Height);
-			Widget.DragImage (img, pos, new SizeF (0, 0), NSApplication.SharedApplication.CurrentEvent, pb, Widget, true);
+			Widget.DragImage (img, pos, new CGSize (0, 0), NSApplication.SharedApplication.CurrentEvent, pb, Widget, true);
 		}
 		
 		public void SetDragSource (TransferDataType[] types, DragDropAction dragAction)
@@ -855,7 +855,7 @@ namespace Xwt.Mac
 				cy += (cheight - s.Height) * w.VerticalPlacement.GetValue ();
 				cheight = s.Height;
 			}
-			child.Frame = new RectangleF ((float)cx, (float)cy, (float)cwidth, (float)cheight);
+			child.Frame = new CGRect ((nfloat)cx, (nfloat)cy, (nfloat)cwidth, (nfloat)cheight);
 		}
 
 		public override void SizeToFit ()

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -413,7 +413,7 @@ namespace Xwt.Mac
 				width = cr.Width;
 			if (height == -1)
 				height = cr.Height;
-			var r = FrameRectFor (new System.Drawing.RectangleF ((float)cr.X, (float)cr.Y, (float)width, (float)height));
+			var r = FrameRectFor (new CGRect ((nfloat)cr.X, (nfloat)cr.Y, (nfloat)width, (nfloat)height));
 			SetFrame (r, true);
 			LayoutWindow ();
 		}
@@ -480,7 +480,7 @@ namespace Xwt.Mac
 			if (b != ((IWindowBackend)this).Bounds)
 				((IWindowBackend)this).Bounds = b;
 
-		    var r = FrameRectFor (new RectangleF (0, 0, (float)s.Width, (float)s.Height));
+			var r = FrameRectFor (new CGRect (0, 0, (nfloat)s.Width, (nfloat)s.Height));
 			MinSize = r.Size;
 		}
 


### PR DESCRIPTION
* NSAttributedString constants have moved
* `System.Drawing.*F` to `CoreGraphics.CG*` conversions are gone

This will break the build with older versions. The conversions are fine but renamed constants won't work.