### PR TITLE
Implement cellview events + [Gtk][Wpf] support

### DIFF
--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -51,6 +51,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Xwt.WPFBackend.CellViews\CanvasCellViewBackend.cs" />
     <Compile Include="Xwt.WPFBackend.CellViews\CanvasCellViewPanel.cs" />
+    <Compile Include="Xwt.WPFBackend.CellViews\CheckBoxCellViewBackend.cs" />
     <Compile Include="Xwt.WPFBackend.CellViews\CellViewBackend.cs" />
     <Compile Include="Xwt.WPFBackend.Interop\NativeStockIcon.cs" />
     <Compile Include="Xwt.WPFBackend.Utilities\CellUtil.cs" />

--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Xwt.WPFBackend.CellViews\CanvasCellViewPanel.cs" />
     <Compile Include="Xwt.WPFBackend.CellViews\CheckBoxCellViewBackend.cs" />
     <Compile Include="Xwt.WPFBackend.CellViews\CellViewBackend.cs" />
+    <Compile Include="Xwt.WPFBackend.CellViews\TextCellViewBackend.cs" />
     <Compile Include="Xwt.WPFBackend.Interop\NativeStockIcon.cs" />
     <Compile Include="Xwt.WPFBackend.Utilities\CellUtil.cs" />
     <Compile Include="Xwt.WPFBackend.Utilities\ImageToImageSourceConverter.cs" />

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/CanvasCellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/CanvasCellViewBackend.cs
@@ -11,6 +11,7 @@ namespace Xwt.WPFBackend
     {
         public void QueueDraw()
         {
+            CurrentElement.InvalidateVisual ();
         }
     }
 }

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/CellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/CellViewBackend.cs
@@ -61,8 +61,9 @@ namespace Xwt.WPFBackend
 
         public void SetCurrentEventRow ()
         {
-            if (rendererTarget != null)
-                rendererTarget.SetCurrentEventRowForElement (CurrentElement);
+            if (currentElement.DataContext == null)
+                return;
+            rendererTarget?.SetCurrentEventRow (currentElement.DataContext);
         }
 
         public CellView CellView { get; set; }

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/CellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/CellViewBackend.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows;
+using System.Windows.Input;
 using Xwt.Backends;
 
 namespace Xwt.WPFBackend
@@ -10,6 +11,21 @@ namespace Xwt.WPFBackend
     class CellViewBackend : ICellViewBackend, ICellDataSource
     {
         FrameworkElement currentElement;
+		WidgetEvent enabledEvents;
+
+        public WidgetEvent EnabledEvents {
+            get {
+                return enabledEvents;
+            }
+        }
+
+        public FrameworkElement CurrentElement {
+            get {
+                return currentElement;
+            }
+        }
+
+        public ICellViewEventSink EventSink { get; private set; }
 
         public CellViewBackend()
         {
@@ -18,12 +34,26 @@ namespace Xwt.WPFBackend
         public void Initialize(CellView cellView, FrameworkElementFactory factory)
         {
             CellView = cellView;
+
+			factory.AddHandler (UIElement.MouseEnterEvent, new MouseEventHandler (HandleMouseEnter));
+			factory.AddHandler (UIElement.MouseLeaveEvent, new MouseEventHandler (HandleMouseLeave));
+			factory.AddHandler (UIElement.MouseMoveEvent, new MouseEventHandler (HandleMouseMove));
+			factory.AddHandler (UIElement.MouseDownEvent, new MouseButtonEventHandler (HandleMouseDown));
+			factory.AddHandler (UIElement.MouseUpEvent, new MouseButtonEventHandler (HandleMouseUp));
+			factory.AddHandler (UIElement.PreviewKeyDownEvent, new KeyEventHandler (HandlePreviewKeyDown));
+			factory.AddHandler (UIElement.PreviewKeyUpEvent, new KeyEventHandler (HandlePreviewKeyUp));
+
+			OnInitialize (cellView, factory);
         }
+
+		public virtual void OnInitialize(CellView cellView, FrameworkElementFactory factory)
+		{
+		}
 
         public void Load (FrameworkElement elem)
         {
             currentElement = elem;
-            CellFrontend.Load(this);
+            EventSink = CellFrontend.Load(this);
         }
 
         public CellView CellView { get; set; }
@@ -67,10 +97,123 @@ namespace Xwt.WPFBackend
 
         public void EnableEvent(object eventId)
         {
+			if (eventId is WidgetEvent)
+				enabledEvents |= (WidgetEvent)eventId;
         }
 
         public void DisableEvent(object eventId)
         {
+			if (eventId is WidgetEvent)
+				enabledEvents &= ~(WidgetEvent)eventId;
+		}
+
+        void HandleMouseEnter(object sender, MouseEventArgs e)
+        {
+            if (enabledEvents.HasFlag(WidgetEvent.MouseEntered))
+            {
+                Load(sender as FrameworkElement);
+                ApplicationContext.InvokeUserCode(EventSink.OnMouseEntered);
+            }
+        }
+
+        void HandleMouseLeave(object sender, MouseEventArgs e)
+        {
+            if (enabledEvents.HasFlag(WidgetEvent.MouseExited))
+            {
+                Load(sender as FrameworkElement);
+                ApplicationContext.InvokeUserCode(EventSink.OnMouseExited);
+            }
+        }
+
+        void HandleMouseMove(object sender, MouseEventArgs e)
+        {
+            if (enabledEvents.HasFlag(WidgetEvent.MouseMoved))
+            {
+                var p = e.GetPosition(sender as FrameworkElement);
+                Load(sender as FrameworkElement);
+                if (!CellBounds.Contains(p.X, p.Y))
+                    return;
+                var a = new MouseMovedEventArgs(e.Timestamp, p.X, p.Y);
+
+                ApplicationContext.InvokeUserCode(delegate
+                    {
+                        EventSink.OnMouseMoved(a);
+                    });
+                if (a.Handled)
+                    e.Handled = true;
+            }
+        }
+
+        void HandleMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (enabledEvents.HasFlag(WidgetEvent.ButtonPressed))
+            {
+                var a = e.ToXwtButtonArgs(sender as FrameworkElement);
+                Load(sender as FrameworkElement);
+                if (!CellBounds.Contains(a.X, a.Y))
+                    return;
+
+                ApplicationContext.InvokeUserCode(delegate
+                    {
+                        EventSink.OnButtonPressed(a);
+                    });
+                if (a.Handled)
+                    e.Handled = true;
+            }
+        }
+
+        void HandleMouseUp(object sender, MouseButtonEventArgs e)
+        {
+            if (enabledEvents.HasFlag(WidgetEvent.ButtonReleased))
+            {
+                var a = e.ToXwtButtonArgs(sender as FrameworkElement);
+                Load(sender as FrameworkElement);
+                if (!CellBounds.Contains(a.X, a.Y))
+                    return;
+
+                ApplicationContext.InvokeUserCode(delegate
+                    {
+                        EventSink.OnButtonReleased(a);
+                    });
+                if (a.Handled)
+                    e.Handled = true;
+            }
+        }
+
+        void HandlePreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (enabledEvents.HasFlag(WidgetEvent.KeyPressed))
+            {
+                Load(sender as FrameworkElement);
+                KeyEventArgs args;
+                if (e.MapToXwtKeyArgs(out args))
+                {
+                    ApplicationContext.InvokeUserCode(delegate
+                        {
+                            EventSink.OnKeyPressed(args);
+                        });
+                    if (args.Handled)
+                        e.Handled = true;
+                }
+            }
+        }
+
+        void HandlePreviewKeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (enabledEvents.HasFlag(WidgetEvent.KeyReleased))
+            {
+                Load(sender as FrameworkElement);
+                KeyEventArgs args;
+                if (e.MapToXwtKeyArgs(out args))
+                {
+                    ApplicationContext.InvokeUserCode(delegate
+                        {
+                            EventSink.OnKeyReleased(args);
+                        });
+                    if (args.Handled)
+                        e.Handled = true;
+                }
+            }
         }
 
         public object GetValue(IDataField field)

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/CheckBoxCellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/CheckBoxCellViewBackend.cs
@@ -43,6 +43,7 @@ namespace Xwt.WPFBackend
 		{
 			var view = (ICheckBoxCellViewFrontend) CellView;
 			Load(sender as FrameworkElement);
+			SetCurrentEventRow ();
 			view.RaiseToggled ();
 		}
 	}

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/CheckBoxCellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/CheckBoxCellViewBackend.cs
@@ -1,0 +1,50 @@
+﻿//
+// CheckBoxCellViewBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2015 Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using Xwt.Backends;
+using System.Windows;
+using System;
+using SWC = System.Windows.Controls;
+
+namespace Xwt.WPFBackend
+{
+	class CheckBoxCellViewBackend: CellViewBackend
+	{
+		public override void OnInitialize (CellView cellView, FrameworkElementFactory factory)
+		{
+			factory.AddHandler (SWC.Primitives.ToggleButton.CheckedEvent, new RoutedEventHandler (HandleChecked));
+			factory.AddHandler (SWC.Primitives.ToggleButton.UncheckedEvent, new RoutedEventHandler (HandleChecked));
+			base.OnInitialize (cellView, factory);
+		}
+
+		void HandleChecked(object sender, EventArgs e)
+		{
+			var view = (ICheckBoxCellViewFrontend) CellView;
+			Load(sender as FrameworkElement);
+			view.RaiseToggled ();
+		}
+	}
+}
+

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/TextCellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/TextCellViewBackend.cs
@@ -1,0 +1,48 @@
+﻿//
+// TextCellViewBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2017 (c) Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System.Windows;
+using Xwt.Backends;
+using SWC = System.Windows.Controls;
+
+namespace Xwt.WPFBackend
+{
+	class TextCellViewBackend : CellViewBackend
+	{
+		public override void OnInitialize (CellView cellView, FrameworkElementFactory factory)
+		{
+			factory.AddHandler (SWC.Primitives.TextBoxBase.TextChangedEvent, new SWC.TextChangedEventHandler (OnTextChanged));
+			base.OnInitialize (cellView, factory);
+		}
+
+		void OnTextChanged (object sender, SWC.TextChangedEventArgs routedEventArgs)
+		{
+			var view = (ITextCellViewFrontend)CellView;
+			Load (sender as FrameworkElement);
+			SetCurrentEventRow ();
+			routedEventArgs.Handled = view.RaiseTextChanged ();
+		}
+	}
+}

--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -145,7 +145,7 @@ namespace Xwt.WPFBackend.Utilities
 				if (cellView.ActiveField != null)
 					factory.SetBinding (SWC.CheckBox.IsCheckedProperty, new Binding (dataPath + "[" + cellView.ActiveField.Index + "]"));
 
-				var cb = new CellViewBackend ();
+				var cb = new CheckBoxCellViewBackend ();
 				cb.Initialize (view, factory);
 				fr.AttachBackend (parent, cb);
 				return factory;

--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -38,7 +38,7 @@ namespace Xwt.WPFBackend.Utilities
 	{
 		static readonly Thickness CellMargins = new Thickness (2);
 
-		internal static FrameworkElementFactory CreateBoundColumnTemplate (ApplicationContext ctx, Widget parent, CellViewCollection views, string dataPath = ".")
+		internal static FrameworkElementFactory CreateBoundColumnTemplate (ApplicationContext ctx, WidgetBackend parent, CellViewCollection views, string dataPath = ".")
 		{
 			if (views.Count == 1)
                 return CreateBoundCellRenderer(ctx, parent, views[0], dataPath);
@@ -65,7 +65,7 @@ namespace Xwt.WPFBackend.Utilities
 
 			return container;
 		}
-		internal static FrameworkElementFactory CreateBoundCellRenderer (ApplicationContext ctx, Widget parent, CellView view, string dataPath = ".")
+		internal static FrameworkElementFactory CreateBoundCellRenderer (ApplicationContext ctx, WidgetBackend parent, CellView view, string dataPath = ".")
 		{
             ICellViewFrontend fr = view;
 			TextCellView textView = view as TextCellView;
@@ -99,8 +99,8 @@ namespace Xwt.WPFBackend.Utilities
 				}
 
                 var cb = new CellViewBackend();
-                cb.Initialize(view, factory, Toolkit.GetBackend(parent) as ICellRendererTarget);
-                fr.AttachBackend(parent, cb);
+                cb.Initialize(view, factory, parent as ICellRendererTarget);
+				fr.AttachBackend(parent.Frontend, cb);
 				return factory;
 			}
 
@@ -116,8 +116,8 @@ namespace Xwt.WPFBackend.Utilities
 				}
 
                 var cb = new CellViewBackend();
-                cb.Initialize(view, factory, Toolkit.GetBackend(parent) as ICellRendererTarget);
-                fr.AttachBackend(parent, cb);
+                cb.Initialize(view, factory, parent as ICellRendererTarget);
+				fr.AttachBackend(parent.Frontend, cb);
                 return factory;
 			}
 
@@ -128,8 +128,8 @@ namespace Xwt.WPFBackend.Utilities
                 FrameworkElementFactory factory = new FrameworkElementFactory(typeof(CanvasCellViewPanel));
 				factory.SetValue(CanvasCellViewPanel.CellViewBackendProperty, cb);
 
-                cb.Initialize(view, factory, Toolkit.GetBackend(parent) as ICellRendererTarget);
-                fr.AttachBackend(parent, cb);
+                cb.Initialize(view, factory, parent as ICellRendererTarget);
+				fr.AttachBackend(parent.Frontend, cb);
                 return factory;
 			}
 			
@@ -146,8 +146,8 @@ namespace Xwt.WPFBackend.Utilities
 					factory.SetBinding (SWC.CheckBox.IsCheckedProperty, new Binding (dataPath + "[" + cellView.ActiveField.Index + "]"));
 
 				var cb = new CheckBoxCellViewBackend ();
-				cb.Initialize (view, factory, Toolkit.GetBackend(parent) as ICellRendererTarget);
-				fr.AttachBackend (parent, cb);
+				cb.Initialize (view, factory, parent as ICellRendererTarget);
+				fr.AttachBackend (parent.Frontend, cb);
 				return factory;
 			}
 
@@ -157,6 +157,6 @@ namespace Xwt.WPFBackend.Utilities
 
 	public interface ICellRendererTarget
 	{
-		void SetCurrentEventRowForElement (FrameworkElement sender);
+		void SetCurrentEventRow (object dataItem);
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -98,7 +98,7 @@ namespace Xwt.WPFBackend.Utilities
 						factory.SetValue(SWC.TextBlock.TextProperty, textView.Text);
 				}
 
-                var cb = new CellViewBackend();
+                var cb = new TextCellViewBackend();
                 cb.Initialize(view, factory, parent as ICellRendererTarget);
 				fr.AttachBackend(parent.Frontend, cb);
 				return factory;

--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -99,7 +99,7 @@ namespace Xwt.WPFBackend.Utilities
 				}
 
                 var cb = new CellViewBackend();
-                cb.Initialize(view, factory);
+                cb.Initialize(view, factory, Toolkit.GetBackend(parent) as ICellRendererTarget);
                 fr.AttachBackend(parent, cb);
 				return factory;
 			}
@@ -116,7 +116,7 @@ namespace Xwt.WPFBackend.Utilities
 				}
 
                 var cb = new CellViewBackend();
-                cb.Initialize(view, factory);
+                cb.Initialize(view, factory, Toolkit.GetBackend(parent) as ICellRendererTarget);
                 fr.AttachBackend(parent, cb);
                 return factory;
 			}
@@ -128,7 +128,7 @@ namespace Xwt.WPFBackend.Utilities
                 FrameworkElementFactory factory = new FrameworkElementFactory(typeof(CanvasCellViewPanel));
 				factory.SetValue(CanvasCellViewPanel.CellViewBackendProperty, cb);
 
-                cb.Initialize(view, factory);
+                cb.Initialize(view, factory, Toolkit.GetBackend(parent) as ICellRendererTarget);
                 fr.AttachBackend(parent, cb);
                 return factory;
 			}
@@ -146,12 +146,17 @@ namespace Xwt.WPFBackend.Utilities
 					factory.SetBinding (SWC.CheckBox.IsCheckedProperty, new Binding (dataPath + "[" + cellView.ActiveField.Index + "]"));
 
 				var cb = new CheckBoxCellViewBackend ();
-				cb.Initialize (view, factory);
+				cb.Initialize (view, factory, Toolkit.GetBackend(parent) as ICellRendererTarget);
 				fr.AttachBackend (parent, cb);
 				return factory;
 			}
 
 			throw new NotImplementedException ();
 		}
+	}
+
+	public interface ICellRendererTarget
+	{
+		void SetCurrentEventRowForElement (FrameworkElement sender);
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/ComboBoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ComboBoxBackend.cs
@@ -144,12 +144,12 @@ namespace Xwt.WPFBackend
 				spFactory.SetValue (StackPanel.OrientationProperty, WindowsOrientation.Horizontal);
 
 				foreach (var view in views) {
-                    spFactory.AppendChild(CellUtil.CreateBoundCellRenderer(Context, Frontend, view));
+                    spFactory.AppendChild(CellUtil.CreateBoundCellRenderer(Context, this, view));
 				}
 
 				root = spFactory;
 			} else {
-                root = CellUtil.CreateBoundCellRenderer(Context, Frontend, views[0]);
+                root = CellUtil.CreateBoundCellRenderer(Context, this, views[0]);
 			}
 
 			template.VisualTree = root;

--- a/Xwt.WPF/Xwt.WPFBackend/DataConverter.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DataConverter.cs
@@ -372,5 +372,28 @@ namespace Xwt.WPFBackend
 
 			return retval;
 		}
+
+		public static ButtonEventArgs ToXwtButtonArgs (this MouseButtonEventArgs e, FrameworkElement target)
+		{
+			var pos = e.GetPosition (target);
+			return new ButtonEventArgs () {
+				X = pos.X,
+				Y = pos.Y,
+				MultiplePress = e.ClickCount,
+				Button = e.ChangedButton.ToXwtButton ()
+			};
+		}
+
+		public static bool MapToXwtKeyArgs (this System.Windows.Input.KeyEventArgs e, out KeyEventArgs result)
+		{
+			result = null;
+
+			var key = KeyboardUtil.TranslateToXwtKey (e.Key);
+			if ((int)key == 0)
+				return false;
+
+			result = new KeyEventArgs (key, KeyboardUtil.GetModifiers (), e.IsRepeat, e.Timestamp);
+			return true;
+		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/ListBoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListBoxBackend.cs
@@ -104,7 +104,7 @@ namespace Xwt.WPFBackend
 		public void SetViews (CellViewCollection views)
 		{
 			ListBox.DisplayMemberPath = null;
-            ListBox.ItemTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundColumnTemplate(Context, Frontend, views) };
+            ListBox.ItemTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundColumnTemplate(Context, this, views) };
 		}
 
 		public void SetSource (IListDataSource source, IBackend sourceBackend)

--- a/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
@@ -167,9 +167,9 @@ namespace Xwt.WPFBackend
 		public object AddColumn (ListViewColumn col)
 		{
 			var column = new GridViewColumn ();
-			column.CellTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundColumnTemplate (Context, Frontend, col.Views) };
+			column.CellTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundColumnTemplate (Context, this, col.Views) };
 			if (col.HeaderView != null)
-				column.HeaderTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundCellRenderer (Context, Frontend, col.HeaderView) };
+				column.HeaderTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundCellRenderer (Context, this, col.HeaderView) };
 			else
 				column.Header = col.Title;
 
@@ -188,9 +188,9 @@ namespace Xwt.WPFBackend
 		public void UpdateColumn (ListViewColumn col, object handle, ListViewColumnChange change)
 		{
 			var column = (GridViewColumn) handle;
-            column.CellTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundColumnTemplate(Context, Frontend, col.Views) };
+            column.CellTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundColumnTemplate(Context, this, col.Views) };
 			if (col.HeaderView != null)
-                column.HeaderTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundCellRenderer(Context, Frontend, col.HeaderView) };
+                column.HeaderTemplate = new DataTemplate { VisualTree = CellUtil.CreateBoundCellRenderer(Context, this, col.HeaderView) };
 			else
 				column.Header = col.Title;
 
@@ -369,9 +369,11 @@ namespace Xwt.WPFBackend
 			return index;
 		}
 
-		void ICellRendererTarget.SetCurrentEventRowForElement (FrameworkElement sender)
+		void ICellRendererTarget.SetCurrentEventRow (object dataItem)
 		{
-			CurrentEventRow = GetRowForElement (sender);
+			var item = dataItem as ValuesContainer;
+			var container = ListView.ItemContainerGenerator.ContainerFromItem (item);
+			CurrentEventRow = ListView.ItemContainerGenerator.IndexFromContainer (container);
 		}
 
         public Rectangle GetCellBounds(int row, CellView cell, bool includeMargin)

--- a/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ListViewBackend.cs
@@ -39,7 +39,7 @@ using System.Windows.Input;
 namespace Xwt.WPFBackend
 {
 	public class ListViewBackend
-		: WidgetBackend, IListViewBackend
+		: WidgetBackend, IListViewBackend, ICellRendererTarget
 	{
 		Dictionary<CellView,CellInfo> cellViews = new Dictionary<CellView, CellInfo> ();
 
@@ -346,6 +346,13 @@ namespace Xwt.WPFBackend
 			var result = VisualTreeHelper.HitTest (ListView, new System.Windows.Point (p.X, p.Y)) as PointHitTestResult;
 
 			var element = (result != null) ? result.VisualHit as FrameworkElement : null;
+
+			return GetRowForElement (element);
+        }
+
+		int GetRowForElement (FrameworkElement sender)
+		{
+			var element = sender;
 			while (element != null) {
 				if (element is ExListViewItem)
 					break;
@@ -360,7 +367,12 @@ namespace Xwt.WPFBackend
 
 			int index = ListView.ItemContainerGenerator.IndexFromContainer(element);
 			return index;
-        }
+		}
+
+		void ICellRendererTarget.SetCurrentEventRowForElement (FrameworkElement sender)
+		{
+			CurrentEventRow = GetRowForElement (sender);
+		}
 
         public Rectangle GetCellBounds(int row, CellView cell, bool includeMargin)
         {

--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -238,7 +238,7 @@ namespace Xwt.WPFBackend
 				break;
 
 			case ListViewColumnChange.Cells:
-                var cellTemplate = CellUtil.CreateBoundColumnTemplate(Context, Frontend, column.Views);
+                var cellTemplate = CellUtil.CreateBoundColumnTemplate(Context, this, column.Views);
 
 				col.CellTemplate = new DataTemplate { VisualTree = cellTemplate };
 
@@ -556,9 +556,9 @@ namespace Xwt.WPFBackend
 			return (element.DataContext as TreeStoreNode);
 		}
 
-		void ICellRendererTarget.SetCurrentEventRowForElement (FrameworkElement sender)
+		void ICellRendererTarget.SetCurrentEventRow (object dataItem)
 		{
-			CurrentEventRow = GetRowForElement (sender);
+			CurrentEventRow = dataItem as TreePosition;
 		}
 
 		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)

--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -42,7 +42,7 @@ using System.Windows.Controls;
 namespace Xwt.WPFBackend
 {
 	public class TreeViewBackend
-		: WidgetBackend, ITreeViewBackend
+		: WidgetBackend, ITreeViewBackend, ICellRendererTarget
 	{
 		Dictionary<CellView,CellInfo> cellViews = new Dictionary<CellView, CellInfo> ();
 
@@ -535,6 +535,12 @@ namespace Xwt.WPFBackend
 			var result = VisualTreeHelper.HitTest (Tree, new System.Windows.Point (p.X, p.Y)) as PointHitTestResult;
 
 			var element = (result != null) ? result.VisualHit as FrameworkElement : null;
+			return GetRowForElement (element);
+		}
+
+		TreePosition GetRowForElement (FrameworkElement sender)
+		{
+			var element = sender;
 			while (element != null) {
 				if (element is ExTreeViewItem)
 					break;
@@ -548,6 +554,11 @@ namespace Xwt.WPFBackend
 				return null;
 
 			return (element.DataContext as TreeStoreNode);
+		}
+
+		void ICellRendererTarget.SetCurrentEventRowForElement (FrameworkElement sender)
+		{
+			CurrentEventRow = GetRowForElement (sender);
 		}
 
 		public Rectangle GetCellBounds (TreePosition pos, CellView cell, bool includeMargin)

--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -602,7 +602,7 @@ namespace Xwt.WPFBackend
 		void WidgetKeyDownHandler (object sender, System.Windows.Input.KeyEventArgs e)
 		{
 			KeyEventArgs args;
-			if (MapToXwtKeyArgs (e, out args)) {
+			if (e.MapToXwtKeyArgs (out args)) {
 				Context.InvokeUserCode (delegate {
 					eventSink.OnKeyPressed (args);
 				});
@@ -614,7 +614,7 @@ namespace Xwt.WPFBackend
 		void WidgetKeyUpHandler (object sender, System.Windows.Input.KeyEventArgs e)
 		{
 			KeyEventArgs args;
-			if (MapToXwtKeyArgs (e, out args)) {
+			if (e.MapToXwtKeyArgs (out args)) {
 				Context.InvokeUserCode (delegate
 				{
 					eventSink.OnKeyReleased (args);
@@ -622,18 +622,6 @@ namespace Xwt.WPFBackend
 				if (args.Handled)
 					e.Handled = true;
 			}
-		}
-
-		bool MapToXwtKeyArgs (System.Windows.Input.KeyEventArgs e, out KeyEventArgs result)
-		{
-			result = null;
-
-			var key = KeyboardUtil.TranslateToXwtKey (e.Key);
-			if ((int)key == 0)
-				return false;
-
-			result = new KeyEventArgs (key, (int)e.Key, KeyboardUtil.GetModifiers (), e.IsRepeat, e.Timestamp);
-			return true;
 		}
 
 		void WidgetPreviewTextInputHandler (object sender, System.Windows.Input.TextCompositionEventArgs e)
@@ -649,7 +637,7 @@ namespace Xwt.WPFBackend
 
 		void WidgetMouseDownHandler (object o, MouseButtonEventArgs e)
 		{
-			var args = ToXwtButtonArgs (e);
+			var args = e.ToXwtButtonArgs (Widget);
 			Context.InvokeUserCode (delegate () {
 				eventSink.OnButtonPressed (args);
 			});
@@ -659,24 +647,13 @@ namespace Xwt.WPFBackend
 
 		void WidgetMouseUpHandler (object o, MouseButtonEventArgs e)
 		{
-			var args = ToXwtButtonArgs (e);
+			var args = e.ToXwtButtonArgs (Widget);
 			Context.InvokeUserCode (delegate ()
 			{
 				eventSink.OnButtonReleased (args);
 			});
 			if (args.Handled)
 				e.Handled = true;
-		}
-
-		ButtonEventArgs ToXwtButtonArgs (MouseButtonEventArgs e)
-		{
-			var pos = e.GetPosition (Widget);
-			return new ButtonEventArgs () {
-				X = pos.X,
-				Y = pos.Y,
-				MultiplePress = e.ClickCount,
-				Button = e.ChangedButton.ToXwtButton ()
-			};
 		}
 
 		void WidgetGotFocusHandler (object o, RoutedEventArgs e)

--- a/Xwt/Xwt/CellView.cs
+++ b/Xwt/Xwt/CellView.cs
@@ -87,14 +87,16 @@ namespace Xwt
 				if (enabledEvents == null)
 					enabledEvents = new HashSet<object> ();
 				enabledEvents.Add (eventId);
-				base.OnEnableEvent (eventId);
+				if (BackendCreated)
+					base.OnEnableEvent (eventId);
 			}
 
 			protected override void OnDisableEvent (object eventId)
 			{
 				if (enabledEvents != null)
 					enabledEvents.Remove (eventId);
-				base.OnDisableEvent (eventId);
+				if (BackendCreated)
+					base.OnDisableEvent (eventId);
 			}
 
 			public void AttachBackend (ICellViewBackend backend)
@@ -226,54 +228,131 @@ namespace Xwt
 		{
 		}
 
-		public event EventHandler<KeyEventArgs> KeyPressed;
-		public event EventHandler<KeyEventArgs> KeyReleased;
-		public event EventHandler MouseEntered;
-		public event EventHandler MouseExited;
-		public event EventHandler<MouseMovedEventArgs> MouseMoved;
-		public event EventHandler<ButtonEventArgs> ButtonPressed;
-		public event EventHandler<ButtonEventArgs> ButtonReleased;
+		EventHandler<KeyEventArgs> keyPressed;
+		EventHandler<KeyEventArgs> keyReleased;
+		EventHandler mouseEntered;
+		EventHandler mouseExited;
+		EventHandler<MouseMovedEventArgs> mouseMoved;
+		EventHandler<ButtonEventArgs> buttonPressed;
+		EventHandler<ButtonEventArgs> buttonReleased;
+
+		public event EventHandler<KeyEventArgs> KeyPressed {
+			add {
+				BackendHost.OnBeforeEventAdd (WidgetEvent.KeyPressed, keyPressed);
+				keyPressed += value;
+			}
+			remove {
+				keyPressed -= value;
+				BackendHost.OnAfterEventRemove (WidgetEvent.KeyPressed, keyPressed);
+			}
+		}
+
+		public event EventHandler<KeyEventArgs> KeyReleased {
+			add {
+				BackendHost.OnBeforeEventAdd (WidgetEvent.KeyReleased, keyReleased);
+				keyReleased += value;
+			}
+			remove {
+				keyReleased -= value;
+				BackendHost.OnAfterEventRemove (WidgetEvent.KeyReleased, keyReleased);
+			}
+		}
+
+		public event EventHandler MouseEntered {
+			add {
+				BackendHost.OnBeforeEventAdd (WidgetEvent.MouseEntered, mouseEntered);
+				mouseEntered += value;
+			}
+			remove {
+				mouseEntered -= value;
+				BackendHost.OnAfterEventRemove (WidgetEvent.MouseEntered, mouseEntered);
+			}
+		}
+
+		public event EventHandler MouseExited {
+			add {
+				BackendHost.OnBeforeEventAdd (WidgetEvent.MouseExited, mouseExited);
+				mouseExited += value;
+			}
+			remove {
+				mouseExited -= value;
+				BackendHost.OnAfterEventRemove (WidgetEvent.MouseExited, mouseExited);
+			}
+		}
+
+		public event EventHandler<ButtonEventArgs> ButtonPressed {
+			add {
+				BackendHost.OnBeforeEventAdd (WidgetEvent.ButtonPressed, buttonPressed);
+				buttonPressed += value;
+			}
+			remove {
+				buttonPressed -= value;
+				BackendHost.OnAfterEventRemove (WidgetEvent.ButtonPressed, buttonPressed);
+			}
+		}
+
+		public event EventHandler<ButtonEventArgs> ButtonReleased {
+			add {
+				BackendHost.OnBeforeEventAdd (WidgetEvent.ButtonReleased, buttonReleased);
+				buttonReleased += value;
+			}
+			remove {
+				buttonReleased -= value;
+				BackendHost.OnAfterEventRemove (WidgetEvent.ButtonReleased, buttonReleased);
+			}
+		}
+
+		public event EventHandler<MouseMovedEventArgs> MouseMoved {
+			add {
+				BackendHost.OnBeforeEventAdd (WidgetEvent.MouseMoved, mouseMoved);
+				mouseMoved += value;
+			}
+			remove {
+				mouseMoved -= value;
+				BackendHost.OnAfterEventRemove (WidgetEvent.MouseMoved, mouseMoved);
+			}
+		}
 
 		internal protected virtual void OnKeyPressed (KeyEventArgs args)
 		{
-			if (KeyPressed != null)
-				KeyPressed (this, args);
+			if (keyPressed != null)
+				keyPressed (this, args);
 		}
 
 		internal protected virtual void OnKeyReleased (KeyEventArgs args)
 		{
-			if (KeyReleased != null)
-				KeyReleased (this, args);
+			if (keyReleased != null)
+				keyReleased (this, args);
 		}
 
 		internal protected virtual void OnMouseEntered ()
 		{
-			if (MouseEntered != null)
-				MouseEntered (this, EventArgs.Empty);
+			if (mouseEntered != null)
+				mouseEntered (this, EventArgs.Empty);
 		}
 
 		internal protected virtual void OnMouseExited ()
 		{
-			if (MouseExited != null)
-				MouseExited (this, EventArgs.Empty);
+			if (mouseExited != null)
+				mouseExited (this, EventArgs.Empty);
 		}
 
 		internal protected virtual void OnMouseMoved (MouseMovedEventArgs args)
 		{
-			if (MouseMoved != null)
-				MouseMoved (this, args);
+			if (mouseMoved != null)
+				mouseMoved (this, args);
 		}
 
 		internal protected virtual void OnButtonPressed (ButtonEventArgs args)
 		{
-			if (ButtonPressed != null)
-				ButtonPressed (this, args);
+			if (buttonPressed != null)
+				buttonPressed (this, args);
 		}
 
 		internal protected virtual void OnButtonReleased (ButtonEventArgs args)
 		{
-			if (ButtonReleased != null)
-				ButtonReleased (this, args);
+			if (buttonReleased != null)
+				buttonReleased (this, args);
 		}
 	}
 }


### PR DESCRIPTION
This is an optimized approach compared to #435.

Its based on a complete Enable-/DisableEvent implementation in the base CellView which is passed to the backends as intended.

Gtk: I've added the missing events to the backend. The implementation is based on the root TableView events with mouse position checks (CellRenderer has no own events)

Wpf: the events are enabled in the element factory by default and the backend checks whether an event is enabled or not. It is not possible (?) to dynamically enable/disable events for each cell, since the cell generation is handeled by the FrameworkElementFactory which is sealed after initialization. Additionally it includes a little fix for the custom cell (find the working example in the example app).

Mac: still TODO
