### PR TITLE
Optimize Font.FromName parser

### DIFF
--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -121,6 +121,8 @@ namespace Xwt.Drawing
 
 		internal static Font FromName (string name, Toolkit toolkit)
 		{
+			if (string.IsNullOrWhiteSpace (name))
+				throw new ArgumentNullException (nameof (name), "Font name cannot be null or empty");
 			var handler = toolkit.FontBackendHandler;
 
 			double size = -1;

--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -181,13 +181,8 @@ namespace Xwt.Drawing
 			string[] names = fontNames.Split (new [] {','}, StringSplitOptions.RemoveEmptyEntries);
 			if (names.Length == 0)
 				throw new ArgumentException ("Font family name not provided");
-
-			foreach (var name in names) {
-				var n = name.Trim ();
-				if (installedFonts.ContainsKey (n))
-					return true;
-			}
-			return false;
+			
+			return names.Any (name => installedFonts.ContainsKey (name.Trim ()));
 		}
 
 		static string GetSupportedFont (string fontNames)

--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -131,13 +131,18 @@ namespace Xwt.Drawing
 			int i = name.LastIndexOf (' ');
 			int lasti = name.Length;
 			do {
+				if (lasti > 0 && IsFontSupported (name.Substring (0, lasti)))
+					break;
+				
 				string token = name.Substring (i + 1, lasti - i - 1);
 				FontStyle st;
 				FontWeight fw;
 				FontStretch fs;
 				double siz;
-				if (double.TryParse (token, NumberStyles.Any, CultureInfo.InvariantCulture, out siz)) // Try parsing the number first, since Enum.TryParse can also parse numbers
-					size = siz;
+				if (double.TryParse (token, NumberStyles.Any, CultureInfo.InvariantCulture, out siz)) { // Try parsing the number first, since Enum.TryParse can also parse numbers
+					if (size == -1) // take only first number
+						size = siz;
+				}
 				else if (Enum.TryParse<FontStyle> (token, true, out st) && st != FontStyle.Normal)
 					style = st;
 				else if (Enum.TryParse<FontWeight> (token, true, out fw) && fw != FontWeight.Normal)
@@ -165,6 +170,22 @@ namespace Xwt.Drawing
 				return new Font (fb, toolkit);
 			else
 				return Font.SystemFont;
+		}
+
+		static bool IsFontSupported (string fontNames)
+		{
+			LoadInstalledFonts ();
+
+			string[] names = fontNames.Split (new [] {','}, StringSplitOptions.RemoveEmptyEntries);
+			if (names.Length == 0)
+				throw new ArgumentException ("Font family name not provided");
+
+			foreach (var name in names) {
+				var n = name.Trim ();
+				if (installedFonts.ContainsKey (n))
+					return true;
+			}
+			return false;
 		}
 
 		static string GetSupportedFont (string fontNames)
@@ -195,7 +216,8 @@ namespace Xwt.Drawing
 
 		static string GetDefaultFont (string unknownFont)
 		{
-			Console.WriteLine ("Font '" + unknownFont + "' not available in the system. Using '" + Font.SystemFont.Family + "' instead");
+			if (unknownFont != Font.SystemFont.Family) // ignore rare case when the default system font is not registered
+				Console.WriteLine ("Font '" + unknownFont + "' not available in the system. Using '" + Font.SystemFont.Family + "' instead");
 			return Font.SystemFont.Family;
 		}
 


### PR DESCRIPTION
For some fonts a valid registered name can include the font settings (weight, size, etc.). In such cases the parser fails to retrieve the font from the backend by stripping the settings from the name.

Fix: the name parser should try to validate the full name including provided settings first.

Examples:
* "Arial Rounded MT Bold", "Bold" is part of the font name and the registered weight is normal (there is only a "Regular" font face registered)
* "Bodoni 72": 72 is not the size but part of the name