### PR TITLE
Finish WindowState implementation (was #420)

### DIFF
--- a/TestApps/Samples/Samples/Windows.cs
+++ b/TestApps/Samples/Samples/Windows.cs
@@ -37,9 +37,24 @@ namespace Samples
 			bp.Clicked += delegate {
 				Window w = new Window ();
 				w.Decorated = false;
-				Button c = new Button ("This is a window");
+				Button c = new Button ("Close");
 //				c.Margin.SetAll (10);
-				w.Content = c;
+
+				VBox box = new VBox();
+				var biconifiy = new Button ("Iconify");
+				var bmaximize = new Button ("Maximize");
+				var bfullscreen = new Button ("Fullscreen");
+
+				biconifiy.Clicked += (sender, e) => w.Iconified = !w.Iconified;
+				bmaximize.Clicked += (sender, e) => w.Maximized = !w.Maximized;
+				bfullscreen.Clicked += (sender, e) => w.FullScreen = !w.FullScreen;
+
+				box.PackStart (biconifiy);
+				box.PackStart (bmaximize);
+				box.PackStart (bfullscreen);
+				box.PackStart (c);
+
+				w.Content = box;
 				c.Clicked += delegate {
 					w.Dispose ();
 				};

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
@@ -224,44 +224,45 @@ namespace Xwt.GtkBackend
 			}
 		}
 		
-		Xwt.WindowState currentWindowState = Xwt.WindowState.Normal;
-		public Xwt.WindowState WindowState {
+		public WindowState WindowState {
 			get {
-				return this.currentWindowState;
+				var currGdkState = Window.GdkWindow.State;
+				if (currGdkState.HasFlag (Gdk.WindowState.Iconified))
+					return WindowState.Iconified;
+				if (currGdkState.HasFlag (Gdk.WindowState.Fullscreen))
+					return WindowState.FullScreen;
+				if (currGdkState.HasFlag (Gdk.WindowState.Maximized))
+					return WindowState.Maximized;
+				return Xwt.WindowState.Normal;
 			}
 			set {
+				var currGdkState = Window.GdkWindow.State;
 				switch (value) {
 					case Xwt.WindowState.Iconified:
-						if (this.currentWindowState != Xwt.WindowState.Iconified) {
-							this.Window.Iconify();
-							this.currentWindowState = Xwt.WindowState.Iconified;
+						if (!currGdkState.HasFlag (Gdk.WindowState.Iconified))
+							Window.Iconify();
+						break;
+					case Xwt.WindowState.FullScreen:
+						if (!currGdkState.HasFlag (Gdk.WindowState.Fullscreen)) {
+							if (currGdkState.HasFlag (Gdk.WindowState.Maximized)) // unmaximize first
+								Window.Unmaximize();
+							Window.Fullscreen ();
 						}
 						break;
 					case Xwt.WindowState.Maximized:
-						if (this.currentWindowState != Xwt.WindowState.Maximized) {
-							this.Window.Maximize ();
-							this.currentWindowState = Xwt.WindowState.Maximized;
-						}
-						break;
-					case Xwt.WindowState.FullScreen:
-						if (this.currentWindowState != Xwt.WindowState.FullScreen) {
-							this.Window.Fullscreen();
-							this.currentWindowState = Xwt.WindowState.FullScreen;
+						if (!currGdkState.HasFlag (Gdk.WindowState.Maximized)) {
+							if (currGdkState.HasFlag (Gdk.WindowState.Fullscreen)) // unfullscreen first
+								Window.Unfullscreen();
+							Window.Maximize ();
 						}
 						break;
 					default:
-						if (this.currentWindowState == Xwt.WindowState.Iconified) {
-							this.Window.Deiconify();
-							this.currentWindowState = Xwt.WindowState.Normal;
-						}
-						if (this.currentWindowState == Xwt.WindowState.Maximized) {
-							this.Window.Unmaximize();
-							this.currentWindowState = Xwt.WindowState.Normal;
-						}
-						if (this.currentWindowState == Xwt.WindowState.FullScreen) {
-							this.Window.Unfullscreen();
-							this.currentWindowState = Xwt.WindowState.Normal;
-						}
+						if (currGdkState.HasFlag (Gdk.WindowState.Iconified))
+							Window.Deiconify();
+						if (currGdkState.HasFlag (Gdk.WindowState.Fullscreen))
+							Window.Unfullscreen();
+						if (currGdkState.HasFlag (Gdk.WindowState.Maximized))
+							Window.Unmaximize();
 						break;
 				}
 			}

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
@@ -224,18 +224,61 @@ namespace Xwt.GtkBackend
 			}
 		}
 
-		bool fullScreen;
-		bool IWindowFrameBackend.FullScreen {
+		bool IWindowFrameBackend.Iconify {
 			get {
-				return fullScreen;
+				return (WindowState == Xwt.WindowState.Icon);
 			}
 			set {
-				if (value != fullScreen) {
-					fullScreen = value;
-					if (fullScreen)
-						Window.Fullscreen ();
-					else
-						Window.Unfullscreen ();
+				if (value == true) {
+					WindowState = Xwt.WindowState.Icon;
+				} else {
+					WindowState = Xwt.WindowState.Normal;
+				}
+			}
+		}
+		
+		bool IWindowFrameBackend.FullScreen {
+			get {
+				return (WindowState == Xwt.WindowState.FullScreen);
+			}
+			set {
+				if (value == true) {
+					WindowState = Xwt.WindowState.FullScreen;
+				} else {
+					WindowState = Xwt.WindowState.Normal;
+				}
+			}
+		}
+		
+		Xwt.WindowState currentWindowState = Xwt.WindowState.Normal;
+		public Xwt.WindowState WindowState {
+			get {
+				return this.currentWindowState;
+			}
+			set {
+				switch (value) {
+					case Xwt.WindowState.Icon:
+						if (this.currentWindowState != Xwt.WindowState.Icon) {
+							this.Window.Iconify();
+							this.currentWindowState = Xwt.WindowState.Icon;
+						}
+						break;
+					case Xwt.WindowState.FullScreen:
+						if (this.currentWindowState != Xwt.WindowState.FullScreen) {
+							this.Window.Fullscreen();
+							this.currentWindowState = Xwt.WindowState.FullScreen;
+						}
+						break;
+					default:
+						if (this.currentWindowState == Xwt.WindowState.Icon) {
+							this.Window.Deiconify();
+							this.currentWindowState = Xwt.WindowState.Normal;
+						}
+						if (this.currentWindowState == Xwt.WindowState.FullScreen) {
+							this.Window.Unfullscreen();
+							this.currentWindowState = Xwt.WindowState.Normal;
+						}
+						break;
 				}
 			}
 		}

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
@@ -223,32 +223,6 @@ namespace Xwt.GtkBackend
 				Window.Resizable = value;
 			}
 		}
-
-		bool IWindowFrameBackend.Iconify {
-			get {
-				return (WindowState == Xwt.WindowState.Icon);
-			}
-			set {
-				if (value == true) {
-					WindowState = Xwt.WindowState.Icon;
-				} else {
-					WindowState = Xwt.WindowState.Normal;
-				}
-			}
-		}
-		
-		bool IWindowFrameBackend.FullScreen {
-			get {
-				return (WindowState == Xwt.WindowState.FullScreen);
-			}
-			set {
-				if (value == true) {
-					WindowState = Xwt.WindowState.FullScreen;
-				} else {
-					WindowState = Xwt.WindowState.Normal;
-				}
-			}
-		}
 		
 		Xwt.WindowState currentWindowState = Xwt.WindowState.Normal;
 		public Xwt.WindowState WindowState {

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
@@ -237,6 +237,12 @@ namespace Xwt.GtkBackend
 							this.currentWindowState = Xwt.WindowState.Iconified;
 						}
 						break;
+					case Xwt.WindowState.Maximized:
+						if (this.currentWindowState != Xwt.WindowState.Maximized) {
+							this.Window.Maximize ();
+							this.currentWindowState = Xwt.WindowState.Maximized;
+						}
+						break;
 					case Xwt.WindowState.FullScreen:
 						if (this.currentWindowState != Xwt.WindowState.FullScreen) {
 							this.Window.Fullscreen();
@@ -246,6 +252,10 @@ namespace Xwt.GtkBackend
 					default:
 						if (this.currentWindowState == Xwt.WindowState.Iconified) {
 							this.Window.Deiconify();
+							this.currentWindowState = Xwt.WindowState.Normal;
+						}
+						if (this.currentWindowState == Xwt.WindowState.Maximized) {
+							this.Window.Unmaximize();
 							this.currentWindowState = Xwt.WindowState.Normal;
 						}
 						if (this.currentWindowState == Xwt.WindowState.FullScreen) {

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
@@ -231,10 +231,10 @@ namespace Xwt.GtkBackend
 			}
 			set {
 				switch (value) {
-					case Xwt.WindowState.Icon:
-						if (this.currentWindowState != Xwt.WindowState.Icon) {
+					case Xwt.WindowState.Iconified:
+						if (this.currentWindowState != Xwt.WindowState.Iconified) {
 							this.Window.Iconify();
-							this.currentWindowState = Xwt.WindowState.Icon;
+							this.currentWindowState = Xwt.WindowState.Iconified;
 						}
 						break;
 					case Xwt.WindowState.FullScreen:
@@ -244,7 +244,7 @@ namespace Xwt.GtkBackend
 						}
 						break;
 					default:
-						if (this.currentWindowState == Xwt.WindowState.Icon) {
+						if (this.currentWindowState == Xwt.WindowState.Iconified) {
 							this.Window.Deiconify();
 							this.currentWindowState = Xwt.WindowState.Normal;
 						}

--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -183,20 +183,59 @@ namespace Xwt.WPFBackend
 		{
 			window.Activate ();
 		}
+
+		
+		bool IWindowFrameBackend.Iconify {
+			get {
+				return (WindowState == Xwt.WindowState.Icon);
+			}
+			set {
+				if (value == true) {
+					WindowState = Xwt.WindowState.Icon;
+				} else {
+					WindowState = Xwt.WindowState.Normal;
+				}
+			}
+		}
 		
 		bool IWindowFrameBackend.FullScreen {
 			get {
-				return window.WindowState == WindowState.Maximized 
-					&& window.ResizeMode == ResizeMode.NoResize;
+				return (WindowState == Xwt.WindowState.FullScreen);
 			}
 			set {
-				if (value) {
-					window.WindowState = WindowState.Maximized;
-					window.ResizeMode = ResizeMode.NoResize;
+				if (value == true) {
+					WindowState = Xwt.WindowState.FullScreen;
+				} else {
+					WindowState = Xwt.WindowState.Normal;
 				}
-				else {
-					window.WindowState = WindowState.Normal;
-					window.ResizeMode = ResizeMode.CanResize;
+			}
+		}
+		
+		public Xwt.WindowState WindowState {
+			get {
+				switch (this.window.WindowState) {
+					case System.Windows.WindowState.Minimized:
+						return Xwt.WindowState.Icon;
+						break;
+					case System.Windows.WindowState.Maximized:
+						return Xwt.WindowState.FullScreen;
+						break;
+					default:
+						return Xwt.WindowState.Normal;
+						break;
+				}
+			}
+			set {
+				switch (value) {
+					case Xwt.WindowState.Icon:
+						this.window.WindowState = System.Windows.WindowState.Minimized;
+						break;
+					case Xwt.WindowState.FullScreen:
+						this.window.WindowState = System.Windows.WindowState.Maximized;
+						break;
+					default:
+						this.window.WindowState = System.Windows.WindowState.Normal;
+						break;
 				}
 			}
 		}

--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -191,8 +191,9 @@ namespace Xwt.WPFBackend
 						return Xwt.WindowState.Iconified;
 						break;
 					case System.Windows.WindowState.Maximized:
-						return Xwt.WindowState.FullScreen;
-						break;
+						if (window.WindowStyle == WindowStyle.SingleBorderWindow)
+							return Xwt.WindowState.FullScreen;
+						return  Xwt.WindowState.Maximized;
 					default:
 						return Xwt.WindowState.Normal;
 						break;
@@ -202,6 +203,9 @@ namespace Xwt.WPFBackend
 				switch (value) {
 					case Xwt.WindowState.Iconified:
 						this.window.WindowState = System.Windows.WindowState.Minimized;
+						break;
+					case Xwt.WindowState.Maximized:
+							this.window.WindowState = System.Windows.WindowState.Maximized;
 						break;
 					case Xwt.WindowState.FullScreen:
 						this.window.WindowState = System.Windows.WindowState.Maximized;

--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -183,31 +183,35 @@ namespace Xwt.WPFBackend
 		{
 			window.Activate ();
 		}
-		
+
+		bool lastFullScreenDecoratedState;
 		public Xwt.WindowState WindowState {
 			get {
 				switch (this.window.WindowState) {
 					case System.Windows.WindowState.Minimized:
 						return Xwt.WindowState.Iconified;
-						break;
 					case System.Windows.WindowState.Maximized:
-						if (window.WindowStyle == WindowStyle.SingleBorderWindow)
+						if (window.WindowStyle == WindowStyle.None)
 							return Xwt.WindowState.FullScreen;
 						return  Xwt.WindowState.Maximized;
 					default:
 						return Xwt.WindowState.Normal;
-						break;
 				}
 			}
 			set {
+				if (WindowState == WindowState.FullScreen)
+					window.WindowStyle = lastFullScreenDecoratedState ? WindowStyle.SingleBorderWindow : WindowStyle.None;
 				switch (value) {
 					case Xwt.WindowState.Iconified:
 						this.window.WindowState = System.Windows.WindowState.Minimized;
 						break;
 					case Xwt.WindowState.Maximized:
-							this.window.WindowState = System.Windows.WindowState.Maximized;
+						this.window.WindowState = System.Windows.WindowState.Maximized;
 						break;
 					case Xwt.WindowState.FullScreen:
+						lastFullScreenDecoratedState = window.WindowStyle != WindowStyle.None;
+						window.WindowStyle = WindowStyle.None;
+						this.window.WindowState = System.Windows.WindowState.Normal;
 						this.window.WindowState = System.Windows.WindowState.Maximized;
 						break;
 					default:

--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -183,33 +183,6 @@ namespace Xwt.WPFBackend
 		{
 			window.Activate ();
 		}
-
-		
-		bool IWindowFrameBackend.Iconify {
-			get {
-				return (WindowState == Xwt.WindowState.Icon);
-			}
-			set {
-				if (value == true) {
-					WindowState = Xwt.WindowState.Icon;
-				} else {
-					WindowState = Xwt.WindowState.Normal;
-				}
-			}
-		}
-		
-		bool IWindowFrameBackend.FullScreen {
-			get {
-				return (WindowState == Xwt.WindowState.FullScreen);
-			}
-			set {
-				if (value == true) {
-					WindowState = Xwt.WindowState.FullScreen;
-				} else {
-					WindowState = Xwt.WindowState.Normal;
-				}
-			}
-		}
 		
 		public Xwt.WindowState WindowState {
 			get {

--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -188,7 +188,7 @@ namespace Xwt.WPFBackend
 			get {
 				switch (this.window.WindowState) {
 					case System.Windows.WindowState.Minimized:
-						return Xwt.WindowState.Icon;
+						return Xwt.WindowState.Iconified;
 						break;
 					case System.Windows.WindowState.Maximized:
 						return Xwt.WindowState.FullScreen;
@@ -200,7 +200,7 @@ namespace Xwt.WPFBackend
 			}
 			set {
 				switch (value) {
-					case Xwt.WindowState.Icon:
+					case Xwt.WindowState.Iconified:
 						this.window.WindowState = System.Windows.WindowState.Minimized;
 						break;
 					case Xwt.WindowState.FullScreen:

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -155,41 +155,6 @@ namespace Xwt.Mac
 		public void SetFocus ()
 		{
 		}
-
-		bool IWindowFrameBackend.Iconify {
-			get {
-				if (MacSystemInformation.OsVersion < MacSystemInformation.Lion)
-					return false;
-
-				return (WindowState == Xwt.WindowState.Icon);
-			}
-			set {
-				if (value == true) {
-					WindowState = Xwt.WindowState.Icon;
-				} else {
-					WindowState = Xwt.WindowState.Normal;
-				}
-			}
-		}
-		
-		bool IWindowFrameBackend.FullScreen {
-			get {
-				if (MacSystemInformation.OsVersion < MacSystemInformation.Lion)
-					return false;
-
-				return (WindowState == Xwt.WindowState.FullScreen);
-			}
-			set {
-				if (MacSystemInformation.OsVersion < MacSystemInformation.Lion)
-					return;
-
-				if (value == true) {
-					WindowState = Xwt.WindowState.FullScreen;
-				} else {
-					WindowState = Xwt.WindowState.Normal;
-				}
-			}
-		}
 		
 		public Xwt.WindowState WindowState {
 			get {

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -162,7 +162,7 @@ namespace Xwt.Mac
 					return Xwt.WindowState.Normal;
 
 				if ((StyleMask & NSWindowStyle.Miniaturizable) != 0) {
-					return Xwt.WindowState.Icon;
+					return Xwt.WindowState.Iconified;
 				} else if ((StyleMask & NSWindowStyle.FullScreenWindow) != 0) {
 					return Xwt.WindowState.FullScreen;
 				} else {
@@ -173,7 +173,7 @@ namespace Xwt.Mac
 				if (MacSystemInformation.OsVersion < MacSystemInformation.Lion)
 					return;
 
-				if ((value == Xwt.WindowState.Icon) && ((StyleMask & NSWindowStyle.Miniaturizable) == 0)) {
+				if ((value == Xwt.WindowState.Iconified) && ((StyleMask & NSWindowStyle.Miniaturizable) == 0)) {
 					// Currently not iconified.
 					MonoMac.ObjCRuntime.Messaging.void_objc_msgSend_IntPtr (
 						Handle,

--- a/Xwt/Xwt.Backends/IWindowFrameBackend.cs
+++ b/Xwt/Xwt.Backends/IWindowFrameBackend.cs
@@ -80,18 +80,6 @@ namespace Xwt.Backends
 		/// This method doesn't dispose the window. The Dispose method has to be called.
 		/// </remarks>
 		bool Close ();
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this window is iconified (true) or normal (false).
-		/// </summary>
-		/// <value><c>true</c> if the window is iconified; otherwise, <c>false</c>.</value>
-		bool Iconify { get; set; }
-
-		/// <summary>
-		/// Gets or sets a value indicating whether this window is in full screen mode (true) and normal (false).
-		/// </summary>
-		/// <value><c>true</c> if the window is in full screen mode; otherwise, <c>false</c>.</value>
-		bool FullScreen { get; set; }
 		
 		/// <summary>
 		/// Gets or sets the state of the window (iconified, normal or full screen).

--- a/Xwt/Xwt.Backends/IWindowFrameBackend.cs
+++ b/Xwt/Xwt.Backends/IWindowFrameBackend.cs
@@ -82,10 +82,22 @@ namespace Xwt.Backends
 		bool Close ();
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this window is in full screen mode
+		/// Gets or sets a value indicating whether this window is iconified (true) or normal (false).
+		/// </summary>
+		/// <value><c>true</c> if the window is iconified; otherwise, <c>false</c>.</value>
+		bool Iconify { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this window is in full screen mode (true) and normal (false).
 		/// </summary>
 		/// <value><c>true</c> if the window is in full screen mode; otherwise, <c>false</c>.</value>
 		bool FullScreen { get; set; }
+		
+		/// <summary>
+		/// Gets or sets the state of the window (iconified, normal or full screen).
+		/// </summary>
+		/// <value>The state of the window.</value>
+		WindowState WindowState { get; set; }
 
 		/// <summary>
 		/// Gets the screen on which most of the area of this window is placed

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -331,6 +331,7 @@
     <Compile Include="Xwt.Backends\IFontSelectorBackend.cs" />
     <Compile Include="Xwt\SelectFontDialog.cs" />
     <Compile Include="Xwt.Backends\ISelectFontDialogBackend.cs" />
+    <Compile Include="Xwt\WindowState.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt/WindowFrame.cs
+++ b/Xwt/Xwt/WindowFrame.cs
@@ -271,12 +271,30 @@ namespace Xwt
 		}
 		
 		/// <summary>
+		/// Gets or sets a value indicating whether this window is iconified (true) or normal (false).
+		/// </summary>
+		/// <value><c>true</c> if the window is iconified; otherwise, <c>false</c>.</value>
+		public bool Iconify {
+			get { return Backend.Iconify; }
+			set { Backend.Iconify = value; }
+		}
+
+		/// <summary>
 		/// Gets or sets a value indicating whether this window is in full screen mode
 		/// </summary>
 		/// <value><c>true</c> if the window is in full screen mode; otherwise, <c>false</c>.</value>
 		public bool FullScreen {
 			get { return Backend.FullScreen; }
 			set { Backend.FullScreen = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the state of the window (icon, normal, fullscreen).
+		/// </summary>
+		/// <value>The state of the window.</value>
+		public WindowState WindowState {
+			get { return Backend.WindowState; }
+			set { Backend.WindowState = value; }
 		}
 
 		/// <summary>

--- a/Xwt/Xwt/WindowFrame.cs
+++ b/Xwt/Xwt/WindowFrame.cs
@@ -285,6 +285,20 @@ namespace Xwt
 		}
 
 		/// <summary>
+		/// Gets or sets a value indicating whether this window is maximized (true) or normal (false).
+		/// </summary>
+		/// <value><c>true</c> if the window is maximized; otherwise, <c>false</c>.</value>
+		public bool Maximized {
+			get { return WindowState == WindowState.Maximized; }
+			set {
+				if (value)
+					Backend.WindowState = WindowState.Maximized;
+				else
+					Backend.WindowState = WindowState.Normal;
+			}
+		}
+
+		/// <summary>
 		/// Gets or sets a value indicating whether this window is in full screen mode
 		/// </summary>
 		/// <value><c>true</c> if the window is in full screen mode; otherwise, <c>false</c>.</value>

--- a/Xwt/Xwt/WindowFrame.cs
+++ b/Xwt/Xwt/WindowFrame.cs
@@ -274,11 +274,11 @@ namespace Xwt
 		/// Gets or sets a value indicating whether this window is iconified (true) or normal (false).
 		/// </summary>
 		/// <value><c>true</c> if the window is iconified; otherwise, <c>false</c>.</value>
-		public bool Iconify {
-			get { return WindowState == WindowState.Icon; }
+		public bool Iconified {
+			get { return WindowState == WindowState.Iconified; }
 			set {
 				if (value)
-					Backend.WindowState = WindowState.Icon;
+					Backend.WindowState = WindowState.Iconified;
 				else
 					Backend.WindowState = WindowState.Normal;
 			}

--- a/Xwt/Xwt/WindowFrame.cs
+++ b/Xwt/Xwt/WindowFrame.cs
@@ -275,8 +275,13 @@ namespace Xwt
 		/// </summary>
 		/// <value><c>true</c> if the window is iconified; otherwise, <c>false</c>.</value>
 		public bool Iconify {
-			get { return Backend.Iconify; }
-			set { Backend.Iconify = value; }
+			get { return WindowState == WindowState.Icon; }
+			set {
+				if (value)
+					Backend.WindowState = WindowState.Icon;
+				else
+					Backend.WindowState = WindowState.Normal;
+			}
 		}
 
 		/// <summary>
@@ -284,8 +289,13 @@ namespace Xwt
 		/// </summary>
 		/// <value><c>true</c> if the window is in full screen mode; otherwise, <c>false</c>.</value>
 		public bool FullScreen {
-			get { return Backend.FullScreen; }
-			set { Backend.FullScreen = value; }
+			get { return WindowState == WindowState.FullScreen; }
+			set {
+				if (value)
+					Backend.WindowState = WindowState.FullScreen;
+				else
+					Backend.WindowState = WindowState.Normal;
+			}
 		}
 
 		/// <summary>

--- a/Xwt/Xwt/WindowState.cs
+++ b/Xwt/Xwt/WindowState.cs
@@ -13,6 +13,7 @@ namespace Xwt
 	{
 		Normal,
 		Iconified,				// Minimized.
-		FullScreen		// Maximized.
+		Maximized,
+		FullScreen
 	}
 }

--- a/Xwt/Xwt/WindowState.cs
+++ b/Xwt/Xwt/WindowState.cs
@@ -12,7 +12,7 @@ namespace Xwt
 	public enum WindowState
 	{
 		Normal,
-		Icon,				// Minimized.
+		Iconified,				// Minimized.
 		FullScreen		// Maximized.
 	}
 }

--- a/Xwt/Xwt/WindowState.cs
+++ b/Xwt/Xwt/WindowState.cs
@@ -1,0 +1,18 @@
+//
+// WindowState.cs
+//
+// Author:
+//       Jérémie Laval <jeremie.laval@xamarin.com>
+//
+// Copyright (c) 2012 Xamarin, Inc.
+using System;
+
+namespace Xwt
+{
+	public enum WindowState
+	{
+		Normal,
+		Icon,				// Minimized.
+		FullScreen		// Maximized.
+	}
+}


### PR DESCRIPTION
This is a complete version of the WindowState implementation (closes #420) including:
* renamed Window.Iconify to Window.Iconified
* renamed WindowState.Icon to WindowState.Iconified
* new WindowState.Maximized
* completed backend implementations
* rebased

Limitations/Workarounds:
* Wpf: it depends on the window style (decorated) whether a window can be maximized or fullscreened. A workaround for normal windows is included (removes/restores decorations when FullScreen is toggled)
* Mac: When switching from FullScreen to Maximized or Iconified, the new state has to be set after the Unfullscreen action is finished. The workaround connects the ```DidExitFullScreen``` event to delay the state change.