### PR TITLE
Set TargetFramework to Mono/.Net 4.5

### DIFF
--- a/TestApps/Gtk3Test/Gtk3Test.csproj
+++ b/TestApps/Gtk3Test/Gtk3Test.csproj
@@ -7,6 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Gtk3Test</RootNamespace>
     <AssemblyName>Gtk3Test</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/TestApps/GtkOnMacTest/GtkOnMacTest.csproj
+++ b/TestApps/GtkOnMacTest/GtkOnMacTest.csproj
@@ -7,6 +7,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>GtkOnMacTest</RootNamespace>
     <AssemblyName>GtkOnMacTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TestApps/GtkOnWindowsTest/GtkOnWindowsTest.csproj
+++ b/TestApps/GtkOnWindowsTest/GtkOnWindowsTest.csproj
@@ -7,6 +7,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>GtkOnWindowsTest</RootNamespace>
     <AssemblyName>GtkOnWindowsTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TestApps/GtkTest/GtkTest.csproj
+++ b/TestApps/GtkTest/GtkTest.csproj
@@ -7,6 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>GtkTest</RootNamespace>
     <AssemblyName>GtkTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/TestApps/MixedGtkMacTest/MixedGtkMacTest.csproj
+++ b/TestApps/MixedGtkMacTest/MixedGtkMacTest.csproj
@@ -7,6 +7,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MixedGtkMacTest</RootNamespace>
     <AssemblyName>MixedGtkMacTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/TestApps/Samples/Samples.csproj
+++ b/TestApps/Samples/Samples.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Samples</RootNamespace>
     <AssemblyName>Samples</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/TestApps/WpfTest/WpfTest.csproj
+++ b/TestApps/WpfTest/WpfTest.csproj
@@ -8,8 +8,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WpfTest</RootNamespace>
     <AssemblyName>WpfTest</AssemblyName>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>True</DebugSymbols>

--- a/Testing/GtkTestRunner.csproj
+++ b/Testing/GtkTestRunner.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>GtkTestRunner</RootNamespace>
     <AssemblyName>GtkTestRunner</AssemblyName>
     <TestRunnerCommand>bin\GtkTestRunner.exe</TestRunnerCommand>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Testing/WpfTestRunner.csproj
+++ b/Testing/WpfTestRunner.csproj
@@ -8,9 +8,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WpfTestRunner</RootNamespace>
     <AssemblyName>WpfTestRunner</AssemblyName>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <TestRunnerCommand>bin\WpfTestRunner.exe</TestRunnerCommand>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>

--- a/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
+++ b/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xwt.Gtk.Mac</RootNamespace>
     <AssemblyName>Xwt.Gtk.Mac</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xwt.Gtk.Windows/Xwt.Gtk.Windows.csproj
+++ b/Xwt.Gtk.Windows/Xwt.Gtk.Windows.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Xwt.Gtk.Windows</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -29,13 +30,13 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL" />
-    <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL" />
-    <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
+    <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
+    <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
+    <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GtkWindowsDesktopBackend.cs" />

--- a/Xwt.Gtk/Xwt.Gtk.csproj
+++ b/Xwt.Gtk/Xwt.Gtk.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Xwt.Gtk</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Xwt.Gtk/Xwt.Gtk3.csproj
+++ b/Xwt.Gtk/Xwt.Gtk3.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Xwt.Gtk3</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xwt.WPF</RootNamespace>
     <AssemblyName>Xwt.WPF</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Xwt.XamMac/Xwt.XamMac.csproj
+++ b/Xwt.XamMac/Xwt.XamMac.csproj
@@ -7,6 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xwt.Mac</RootNamespace>
     <AssemblyName>Xwt.XamMac</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Xwt</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
Mono 4 drop support to build old target framework and only support 4.5

Most platforms have or support target 4.5.
I only know that Windows XP not support this target, but If any need build to 4.0 or older target can checkout as submodule and modify the xwt projects for include in the solution.

Signed-off-by: Claudio Rodrigo Pereyra Diaz <claudiorodrigo@pereyradiaz.com.ar>