### PR TITLE
Wpf combobox with free textentry

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ComboBoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ComboBoxBackend.cs
@@ -67,7 +67,7 @@ namespace Xwt.WPFBackend
 			ComboBox.DisplayMemberPath = ".[0]";
 			//ComboBox.ItemTemplate = DefaultTemplate;
 			ComboBox.ItemContainerStyle = ContainerStyle;
-        }
+		}
 
 		public void SetViews (CellViewCollection views)
 		{

--- a/Xwt.WPF/Xwt.WPFBackend/ComboBoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ComboBoxBackend.cs
@@ -67,7 +67,7 @@ namespace Xwt.WPFBackend
 			ComboBox.DisplayMemberPath = ".[0]";
 			//ComboBox.ItemTemplate = DefaultTemplate;
 			ComboBox.ItemContainerStyle = ContainerStyle;
-		}
+        }
 
 		public void SetViews (CellViewCollection views)
 		{
@@ -75,7 +75,12 @@ namespace Xwt.WPFBackend
 			ComboBox.ItemTemplate = GetDataTemplate (views);
 		}
 
-		public void SetSource (IListDataSource source, IBackend sourceBackend)
+		public void SetIsEditable(bool isEditable)
+		{
+			ComboBox.IsEditable = isEditable;
+		}
+
+		public void SetSource(IListDataSource source, IBackend sourceBackend)
 		{
 			var dataSource = sourceBackend as ListDataSource;
 			if (dataSource != null)
@@ -90,7 +95,12 @@ namespace Xwt.WPFBackend
 			set { ComboBox.SelectedIndex = value; }
 		}
 
-		public override void EnableEvent (object eventId)
+		public string SelectedText
+		{
+			get { return ComboBox.Text; }			
+		}
+
+		public override void EnableEvent(object eventId)
 		{
 			base.EnableEvent (eventId);
 			

--- a/Xwt/Xwt.Backends/IComboBoxBackend.cs
+++ b/Xwt/Xwt.Backends/IComboBoxBackend.cs
@@ -29,9 +29,12 @@ namespace Xwt.Backends
 {
 	public interface IComboBoxBackend: IWidgetBackend
 	{
-		void SetViews (CellViewCollection views);
-		void SetSource (IListDataSource source, IBackend sourceBackend);
+		void SetViews(CellViewCollection views);
+		void SetSource(IListDataSource source, IBackend sourceBackend);
+		void SetIsEditable(bool isEditable);
 		int SelectedRow { get; set; }
+
+		string SelectedText { get; }
 	}
 	
 	public interface IComboBoxEventSink: IWidgetEventSink

--- a/Xwt/Xwt/ComboBox.cs
+++ b/Xwt/Xwt/ComboBox.cs
@@ -73,8 +73,14 @@ namespace Xwt
 		{
 			return new WidgetBackendHost ();
 		}
-		
-		public CellViewCollection Views {
+
+		public void SetIsEditable(bool value)
+		{
+			Backend.SetIsEditable(value);
+		}
+
+		public CellViewCollection Views
+		{
 			get { return views; }
 		}
 		
@@ -144,8 +150,11 @@ namespace Xwt
 		public string SelectedText {
 			get {
 				if (Backend.SelectedRow == -1)
-					return null;
-				return (string)Items.DataSource.GetValue (Backend.SelectedRow, 0);
+				{
+					return Backend.SelectedText;
+				}
+
+				return (string)Items.DataSource.GetValue(Backend.SelectedRow, 0);
 			}
 			set {
 				SelectedIndex = Items.IndexOf (withLabel: value);


### PR DESCRIPTION
With this change it's possible to enter a free text into a WPF combobox. The text can then, by the application using XWT, be added as a new item to the combobox, for example.