### PR TITLE
[WPF]Set the name of a control

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -178,6 +178,12 @@ namespace Xwt.WPFBackend
 			set { Widget.Opacity = value; }
 		}
 
+		public string Name
+		{
+			get { return Widget.Name; }
+			set { Widget.Name = value; }
+		}
+
 		FontData GetWidgetFont ()
 		{
 			if (!(Widget is Control)) {

--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -59,6 +59,7 @@ namespace Xwt.WPFBackend
 			Initialize ();
 		}
 
+		public object Tag { get { return window.Tag; } set { window.Tag = value; } }
 		public ApplicationContext Context { get; private set; }
 
 		public virtual void Initialize ()

--- a/Xwt/Xwt.Backends/IWidgetBackend.cs
+++ b/Xwt/Xwt.Backends/IWidgetBackend.cs
@@ -64,6 +64,11 @@ namespace Xwt.Backends
 		bool Sensitive { get; set; }
 
 		/// <summary>
+		/// Gets or sets the name of this widget.
+		/// </summary>
+		string Name { get; set; }
+
+		/// <summary>
 		/// Gets or sets a value indicating whether this widget can get focus.
 		/// </summary>
 		/// <value><c>true</c> if this instance can get focus; otherwise, <c>false</c>.</value>

--- a/Xwt/Xwt.Backends/IWindowFrameBackend.cs
+++ b/Xwt/Xwt.Backends/IWindowFrameBackend.cs
@@ -92,6 +92,8 @@ namespace Xwt.Backends
 		/// </summary>
 		/// <value>The screen.</value>
 		object Screen { get; }
+
+		object Tag { get; set; }
 	}
 	
 	public interface IWindowFrameEventSink

--- a/Xwt/Xwt/Widget.cs
+++ b/Xwt/Xwt/Widget.cs
@@ -590,7 +590,10 @@ namespace Xwt
 		/// <value>The widgets name.</value>
 		/// <remarks>The name can be used to identify this widget by e.g. designers.</remarks>
 		[DefaultValue (null)]
-		public string Name { get; set; }
+		public string Name {
+			get { return Backend.Name; }
+			set { Backend.Name = value; }
+		}
 		
 		/// <summary>
 		/// Gets the parent widget of this <see cref="Xwt.Widget"/>.

--- a/Xwt/Xwt/WindowFrame.cs
+++ b/Xwt/Xwt/WindowFrame.cs
@@ -72,7 +72,7 @@ namespace Xwt
 		bool pendingReallocation;
 		Image icon;
 		WindowFrame transientFor;
-		
+		public override object Tag { get { return Backend.Tag; } set { Backend.Tag = value; } }
 		protected class WindowBackendHost: BackendHost<WindowFrame,IWindowFrameBackend>, IWindowFrameEventSink
 		{
 			protected override void OnBackendCreated ()
@@ -83,7 +83,9 @@ namespace Xwt
 				Parent.size = Backend.Bounds.Size;
 				Backend.EnableEvent (WindowFrameEvent.BoundsChanged);
 			}
+
 			
+
 			public void OnBoundsChanged (Rectangle bounds)
 			{
 				Parent.OnBoundsChanged (new BoundsChangedEventArgs () { Bounds = bounds });

--- a/Xwt/Xwt/XwtComponent.cs
+++ b/Xwt/Xwt/XwtComponent.cs
@@ -76,7 +76,7 @@ namespace Xwt
 		/// <summary>
 		/// A value, that can be used to identify this component
 		/// </summary>
-		public object Tag { get; set; }
+		public virtual object Tag { get; set; }
 
 		/// <summary>
 		/// Maps an event handler of an Xwt component to an event identifier.


### PR DESCRIPTION
 * Implemented extended interface in WPF/WidgetBackend.

This change is important for UI automation/UI testing tools like Microsoft Test Manager. These tools use the name of a control to identify it, without setting a name, at least Microsoft Test Manager will use the first control of that type that it encounters (for example: the minimize button)