### PR TITLE
Fix getting images from clipboard in Gtk

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/ClipboardBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ClipboardBackend.cs
@@ -85,8 +85,8 @@ namespace Xwt.GtkBackend
 		{
 			if (type == TransferDataType.Text)
 				return clipboard.WaitForText ();
-			if (type == TransferDataType.Text)
-				return clipboard.WaitForImage ();
+			if (type == TransferDataType.Image)
+				return new Xwt.Drawing.Image (new GtkImage (clipboard.WaitForImage()), Toolkit.CurrentEngine);
 			
 			TransferDataStore store = new TransferDataStore ();
 			

--- a/Xwt.Gtk/Xwt.GtkBackend/ClipboardBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ClipboardBackend.cs
@@ -86,7 +86,7 @@ namespace Xwt.GtkBackend
 			if (type == TransferDataType.Text)
 				return clipboard.WaitForText ();
 			if (type == TransferDataType.Image)
-				return new Xwt.Drawing.Image (new GtkImage (clipboard.WaitForImage()), Toolkit.CurrentEngine);
+				return ApplicationContext.Toolkit.WrapImage (new GtkImage (clipboard.WaitForImage()));
 			
 			TransferDataStore store = new TransferDataStore ();
 			

--- a/Xwt/AssemblyInfo.cs
+++ b/Xwt/AssemblyInfo.cs
@@ -26,4 +26,3 @@ using System.Runtime.CompilerServices;
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
 
-[assembly: InternalsVisibleTo("Xwt.Gtk, PublicKey=002400000480000094000000060200000024000052534131000400000100010079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d04062447c37e0e68c080536fcf3c3fbe2ff9c979ce998475e506e8ce82dd5b0f350dc10e93bf2eeecf874b24770c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d15069089380284dbdd35f46cdff12a1bd78e4ef0065d016df")]

--- a/Xwt/AssemblyInfo.cs
+++ b/Xwt/AssemblyInfo.cs
@@ -26,3 +26,4 @@ using System.Runtime.CompilerServices;
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
 
+[assembly: InternalsVisibleTo("Xwt.Gtk, PublicKey=002400000480000094000000060200000024000052534131000400000100010079159977d2d03a8e6bea7a2e74e8d1afcc93e8851974952bb480a12c9134474d04062447c37e0e68c080536fcf3c3fbe2ff9c979ce998475e506e8ce82dd5b0f350dc10e93bf2eeecf874b24770c5081dbea7447fddafa277b22de47d6ffea449674a4f9fccf84d15069089380284dbdd35f46cdff12a1bd78e4ef0065d016df")]


### PR DESCRIPTION
This fixes `Clipboard.GetImage()` for the Gtk backend.

I have made visible the internal methods from the Xwt project for Xwt.Gtk. This is a requirement to access to the internal constructor of `Image` that accepts `GtkImage` objects (`clipboard.WaitForImage ()` returns a `Gtk.PixBuf` object). I am not sure if this is the best approach but it's working for me. I have copied the public key from a comment in *Xwt.Gtk/AssemblyInfo.cs*.