### PR TITLE
[Mac] Optimize mac textentry frame, alignment and selection

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/PasswordEntryBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PasswordEntryBackend.cs
@@ -23,7 +23,7 @@ namespace Xwt.Mac
 		{
 			base.Initialize ();
 			var view = new CustomSecureTextField (EventSink, ApplicationContext);
-			ViewObject = new CustomAlignedContainer (EventSink, ApplicationContext, (NSView)view);
+			ViewObject = new CustomAlignedContainer (EventSink, ApplicationContext, (NSView)view) { DrawsBackground = false };
 		}
 
 		protected override void OnSizeToFit ()
@@ -66,6 +66,17 @@ namespace Xwt.Mac
 			}
 			set {
 				((NSTextFieldCell)Widget.Cell).PlaceholderString = value ?? string.Empty;
+			}
+		}
+
+		public override Drawing.Color BackgroundColor {
+			get {
+				return Widget.BackgroundColor.ToXwtColor ();
+			}
+			set {
+				Widget.BackgroundColor = value.ToNSColor ();
+				Widget.Cell.DrawsBackground = true;
+				Widget.Cell.BackgroundColor = value.ToNSColor ();
 			}
 		}
 	}

--- a/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
@@ -151,7 +151,7 @@ namespace Xwt.Mac
 			get {
 				if (Widget is MacComboBox)
 					return false;
-				return Widget.Cell.UsesSingleLineMode;
+				return !Widget.Cell.UsesSingleLineMode;
 			}
 			set {
 				if (Widget is MacComboBox)

--- a/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
@@ -292,12 +292,13 @@ namespace Xwt.Mac
 	{
 		ITextEntryEventSink eventSink;
 		ApplicationContext context;
+		CustomCell cell;
 
 		public CustomTextField (ITextEntryEventSink eventSink, ApplicationContext context)
 		{
 			this.context = context;
 			this.eventSink = eventSink;
-			Cell = new CustomCell {
+			this.Cell = cell = new CustomCell {
 				BezelStyle = NSTextFieldBezelStyle.Square,
 				Bezeled = true,
 				Editable = true,

--- a/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
@@ -384,10 +384,10 @@ namespace Xwt.Mac
 
 				var textHeight = CellSizeForBounds (aRect).Height;
 				var offset = (aRect.Height - textHeight) / 2;
-				if (offset < 0) // do nothing if the frame is too small
+				if (offset <= 0) // do nothing if the frame is too small
 					return aRect;
-				aRect.Inflate (0.0f, -(nfloat)offset);
-				return aRect;
+				var rect = new Rectangle (aRect.X, aRect.Y, aRect.Width, aRect.Height).Inflate (0.0, -offset);
+				return rect.ToCGRect ();
 			}
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
@@ -62,7 +62,8 @@ namespace Xwt.Mac
 				((MacComboBox)ViewObject).SetEntryEventSink (EventSink);
 			} else {
 				var view = new CustomTextField (EventSink, ApplicationContext);
-				ViewObject = view;
+				ViewObject = new CustomAlignedContainer (EventSink, ApplicationContext, (NSView)view) { DrawsBackground = false };
+				Container.ExpandVertically = true;
 				MultiLine = false;
 			}
 			Widget.StringValue = string.Empty;
@@ -83,11 +84,15 @@ namespace Xwt.Mac
 		
 		protected override void OnSizeToFit ()
 		{
-			Widget.SizeToFit ();
+			Container.SizeToFit ();
+		}
+
+		CustomAlignedContainer Container {
+			get { return base.Widget as CustomAlignedContainer; }
 		}
 
 		public new NSTextField Widget {
-			get { return (NSTextField)ViewObject; }
+			get { return (ViewObject is MacComboBox) ? (NSTextField)ViewObject : (NSTextField) Container.Child; }
 		}
 
 		protected override Size GetNaturalSize ()

--- a/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
@@ -284,6 +284,8 @@ namespace Xwt.Mac
 			}
 			set {
 				Widget.BackgroundColor = value.ToNSColor ();
+				Widget.Cell.DrawsBackground = true;
+				Widget.Cell.BackgroundColor = value.ToNSColor ();
 			}
 		}
 	}

--- a/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextEntryBackend.cs
@@ -321,6 +321,7 @@ namespace Xwt.Mac
 		class CustomCell : NSTextFieldCell
 		{
 			CustomEditor editor;
+			NSObject selChangeObserver;
 			public ApplicationContext Context {
 				get; set;
 			}
@@ -343,8 +344,16 @@ namespace Xwt.Mac
 						FieldEditor = true,
 						Editable = true,
 					};
+					selChangeObserver = NSNotificationCenter.DefaultCenter.AddObserver (new NSString ("NSTextViewDidChangeSelectionNotification"), HandleSelectionDidChange, editor);
 				}
 				return editor;
+			}
+
+			void HandleSelectionDidChange (NSNotification notif)
+			{
+				Context.InvokeUserCode (delegate {
+					EventSink.OnSelectionChanged ();
+				});
 			}
 
 			public override void DrawInteriorWithFrame (CGRect cellFrame, NSView inView)

--- a/Xwt.XamMac/Xwt.Mac/WidgetView.cs
+++ b/Xwt.XamMac/Xwt.Mac/WidgetView.cs
@@ -57,6 +57,7 @@ namespace Xwt.Mac
 		{
 			this.context = context;
 			this.eventSink = eventSink;
+			DrawsBackground = true;
 		}
 
 		public ViewBackend Backend { get; set; }
@@ -64,6 +65,8 @@ namespace Xwt.Mac
 		public NSView View {
 			get { return this; }
 		}
+
+		public bool DrawsBackground { get; set; }
 
 		public override bool IsFlipped {
 			get {
@@ -78,11 +81,13 @@ namespace Xwt.Mac
 
 		public override void DrawRect (CGRect dirtyRect)
 		{
-			CGContext ctx = NSGraphicsContext.CurrentContext.GraphicsPort;
+			if (DrawsBackground) {
+				CGContext ctx = NSGraphicsContext.CurrentContext.GraphicsPort;
 
-			//fill BackgroundColor
-			ctx.SetFillColor (Backend.Frontend.BackgroundColor.ToCGColor ());
-			ctx.FillRect (Bounds);
+				//fill BackgroundColor
+				ctx.SetFillColor (Backend.Frontend.BackgroundColor.ToCGColor ());
+				ctx.FillRect (Bounds);
+			}
 		}
 
 		public override void UpdateTrackingAreas ()


### PR DESCRIPTION
* fixes frame drawing and text alignment for custom heights
* removes the 1px white border around the border (appeared sporadically)
* allows to set the background color correctly inside the frame only
* adds TextEntry.SelectionChanged implementation

@alanmcgovern: this fix optimizes some parts of 1e31b7315aa3e528456a586fae56dab7b96103f4, can you review? I hope it doesn't break anything.

Some screenshots:
Before:
<img width="366" alt="bildschirmfoto 2015-12-31 um 18 31 57" src="https://cloud.githubusercontent.com/assets/951587/12066717/d40fb9f2-afec-11e5-9a27-741310ae3850.png">

After:
<img width="365" alt="bildschirmfoto 2015-12-31 um 18 29 02" src="https://cloud.githubusercontent.com/assets/951587/12066706/a802d92a-afec-11e5-9e72-9bcb2d4bb367.png">
