### PR TITLE
Fix mistype in CustomCellRendererImage

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererImage.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererImage.cs
@@ -69,7 +69,7 @@ namespace Xwt.GtkBackend
 				return;
 			var pix = ((GtkImage)image.Backend);
 			int x_offset, y_offset, width, height;
-			GetSize (widget, ref cell_area, out x_offset, out y_offset, out width, out height);
+			OnGetSize (widget, ref cell_area, out x_offset, out y_offset, out width, out height);
 			pix.Draw (Context, cr, Util.GetScaleFactor (widget), cell_area.X + x_offset, cell_area.Y + y_offset, image);
 
 		}


### PR DESCRIPTION
To fix compile error in target `Xwt.Gtk3`, `Xwt.Gtkbackend.ImageRenderer.OnRender`,
change `GetSize` to `OnGetSize`.

The compile error message was:
```
xwt/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererImage.cs(4,4): Error CS0103: The name `GetSize' does not exist in the current context (CS0103) (Xwt.Gtk3)
```