### PR TITLE
Add new Menu.Font property

### DIFF
--- a/TestApps/Samples/Samples/MenuSamples.cs
+++ b/TestApps/Samples/Samples/MenuSamples.cs
@@ -55,6 +55,7 @@ namespace Samples
 
 			var subMenu = new MenuItem ("Submenu");
 			subMenu.SubMenu = new Menu ();
+			subMenu.SubMenu.Font = subMenu.SubMenu.Font.WithSize (20).WithWeight (Xwt.Drawing.FontWeight.Bold);
 			var subZoomIn = new MenuItem (new Command ("Zoom+", StockIcons.ZoomIn));
 			var subZoomOut = new MenuItem (new Command ("Zoom-", StockIcons.ZoomOut));
 			subMenu.SubMenu.Items.Add (subZoomIn);

--- a/Xwt.Gtk/Xwt.GtkBackend/MenuBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/MenuBackend.cs
@@ -70,6 +70,23 @@ namespace Xwt.GtkBackend
 				return bar;
 			}
 		}
+
+		Pango.FontDescription customFont;
+
+		public virtual object Font {
+			get {
+				return customFont ?? menu.Style.FontDescription;
+			}
+			set {
+				customFont = (Pango.FontDescription) value;
+				foreach (var item in menu.AllChildren) {
+					var bin = item as Gtk.Bin;
+					if (bin != null)
+						foreach (Gtk.Widget w in bin.Children)
+							w.ModifyFont (customFont);
+				}
+			}
+		}
 		
 		void TransferProps (Gtk.MenuShell oldMenu, Gtk.MenuShell newMenu)
 		{
@@ -82,6 +99,9 @@ namespace Xwt.GtkBackend
 		public void InsertItem (int index, IMenuItemBackend menuItem)
 		{
 			Gtk.MenuItem item = ((MenuItemBackend)menuItem).MenuItem;
+			if (customFont != null)
+				foreach(Gtk.Widget w in item.AllChildren)
+					w.ModifyFont (customFont);
 			menu.Insert (item, index);
 		}
 

--- a/Xwt.Gtk/Xwt.GtkBackend/MenuBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/MenuBackend.cs
@@ -80,7 +80,7 @@ namespace Xwt.GtkBackend
 			set {
 				customFont = (Pango.FontDescription) value;
 				foreach (var item in menu.AllChildren) {
-					var bin = item as Gtk.Bin;
+					var bin = item as Gtk.Container;
 					if (bin != null)
 						foreach (Gtk.Widget w in bin.Children)
 							w.ModifyFont (customFont);

--- a/Xwt.WPF/Xwt.WPFBackend/MenuBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/MenuBackend.cs
@@ -40,6 +40,7 @@ namespace Xwt.WPFBackend
 	public class MenuBackend : Backend, IMenuBackend
 	{
 		List<MenuItemBackend> items;
+		FontData customFont;
 
 		public override void InitializeBackend (object frontend, ApplicationContext context)
 		{
@@ -63,9 +64,24 @@ namespace Xwt.WPFBackend
 			set;
 		}
 
+		public virtual object Font {
+			get {
+				if (customFont == null)
+					return FontData.FromControl (Items.Count > 0 ? Items[0].MenuItem : new System.Windows.Controls.MenuItem());
+				return customFont;
+			}
+			set {
+				customFont = (FontData)value;
+				foreach (var item in Items)
+					item.SetFont (customFont);
+			}
+		}
+
 		public void InsertItem (int index, IMenuItemBackend item)
 		{
 			var itemBackend = (MenuItemBackend)item;
+			if (customFont != null)
+				itemBackend.SetFont(customFont);
 			items.Insert (index, itemBackend);
 			if (ParentItem != null && ParentItem.MenuItem != null)
 				ParentItem.MenuItem.Items.Insert (index, itemBackend.Item);

--- a/Xwt.WPF/Xwt.WPFBackend/MenuItemBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/MenuItemBackend.cs
@@ -162,6 +162,15 @@ namespace Xwt.WPFBackend
 			this.type = type;
 		}
 
+		internal void SetFont (FontData font)
+		{
+			MenuItem.FontFamily = font.Family;
+			MenuItem.FontSize = font.GetDeviceIndependentPixelSize(MenuItem);
+			MenuItem.FontStyle = font.Style;
+			MenuItem.FontWeight = font.Weight;
+			MenuItem.FontStretch = font.Stretch;
+		}
+
 		public override void EnableEvent (object eventId)
 		{
 			if (menuItem == null)

--- a/Xwt.XamMac/Xwt.Mac/MenuBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/MenuBackend.cs
@@ -74,12 +74,21 @@ namespace Xwt.Mac
 		public void Popup ()
 		{
 			var evt = NSApplication.SharedApplication.CurrentEvent;
-			NSMenu.PopUpContextMenu (this, evt, evt.Window.ContentView, null);
+			NSMenu.PopUpContextMenu (this, evt, evt.Window.ContentView);
 		}
 		
 		public void Popup (IWidgetBackend widget, double x, double y)
 		{
-			NSMenu.PopUpContextMenu (this, NSApplication.SharedApplication.CurrentEvent, ((ViewBackend)widget).Widget, null);
+			NSMenu.PopUpContextMenu (this, NSApplication.SharedApplication.CurrentEvent, ((ViewBackend)widget).Widget);
+		}
+
+		object IMenuBackend.Font {
+			get {
+				return FontData.FromFont (Font);
+			}
+			set {
+				Font = ((FontData)value).Font;
+			}
 		}
 	}
 }

--- a/Xwt/Xwt.Backends/IMenuBackend.cs
+++ b/Xwt/Xwt.Backends/IMenuBackend.cs
@@ -30,6 +30,12 @@ namespace Xwt.Backends
 {
 	public interface IMenuBackend: IBackend
 	{
+
+		/// <summary>
+		/// Gets or sets the native font of this menu.
+		/// </summary>
+		/// <value>The font.</value>
+		object Font { get; set; }
 		void InsertItem (int index, IMenuItemBackend menuItem);
 		void RemoveItem (IMenuItemBackend menuItem);
 		void Popup ();

--- a/Xwt/Xwt/Menu.cs
+++ b/Xwt/Xwt/Menu.cs
@@ -26,7 +26,7 @@
 
 using System;
 using Xwt.Backends;
-
+using Xwt.Drawing;
 
 namespace Xwt
 {
@@ -34,6 +34,21 @@ namespace Xwt
 	public class Menu: XwtComponent
 	{
 		MenuItemCollection items;
+
+		/// <summary>
+		/// Gets or sets the font of the menu.
+		/// </summary>
+		/// <value>
+		/// The font.
+		/// </value>
+		public Font Font {
+			get {
+				return new Font (Backend.Font, BackendHost.ToolkitEngine);
+			}
+			set {
+				Backend.Font = BackendHost.ToolkitEngine.GetSafeBackend (value);
+			}
+		}
 		
 		public Menu ()
 		{


### PR DESCRIPTION
The new `Menu.Font` property allows to modify the font in menus. The font will be applied on all items of a menu, but not on submenus, so each new `Menu` instance will start with the default system font.

Includes WPF/GTK/MAC implementations.
(fixes #569)