### PR TITLE
[Window] Fix leak of whole dialog/window content.

### DIFF
--- a/Xwt/Xwt/Window.cs
+++ b/Xwt/Xwt/Window.cs
@@ -130,6 +130,12 @@ namespace Xwt
 					Widget.QueueWindowSizeNegotiation (this);
 			}
 		}
+
+		protected override void Dispose (bool disposing)
+		{
+			Content.Dispose ();
+			base.Dispose (disposing);
+		}
 		
 		protected override void OnReallocate ()
 		{


### PR DESCRIPTION
Basically, this disposes of the Window content in the Xwt hierarchy.

Previously, this was insufficient, while it _did_ remove the Gtk
references, subscribing to an eventhandler and overriding Dispose on a
widget that's placed in a Xwt Window will cause the widget to not be
disposed, thus leak memory.