### PR TITLE
[Gtk] Fix FocusInEvent keeping Popover in memory after it is disposed.

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
@@ -304,6 +304,9 @@ namespace Xwt.GtkBackend
 		
 		public void Dispose ()
 		{
+			if (popover.TransientFor != null)
+				popover.TransientFor.FocusInEvent -= HandleParentFocusInEvent;
+
 			popover.Destroy ();
 			popover.Dispose ();
 		}


### PR DESCRIPTION
Showing a Popover window and then disposing it when it is closed would leave the Popover window in memory if its TransientFor window was not closed. This was because the event handler added to the TransientFor window's FocusInEvent was not removed when the Popover was disposed.