### PR TITLE
Fix font toolkit validation

### DIFF
--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -343,6 +343,20 @@ namespace Xwt.Drawing
 			return new Font (handler.SetStretch (Backend, stretch), ToolkitEngine);
 		}
 
+		public Font WithSettings (Font fromFont)
+		{
+			return WithSettings (fromFont.Size, fromFont.Style, fromFont.Weight, fromFont.Stretch);
+		}
+
+		public Font WithSettings (double size, FontStyle style, FontWeight weight, FontStretch stretch)
+		{
+			var newHandler = handler.SetSize (Backend, size);
+			newHandler = handler.SetStyle (Backend, style);
+			newHandler = handler.SetWeight (Backend, weight);
+			newHandler = handler.SetStretch (Backend, stretch);
+			return new Font (newHandler, ToolkitEngine);
+		}
+
 		public override string ToString ()
 		{
 			StringBuilder sb = new StringBuilder (Family);

--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -302,7 +302,7 @@ namespace Xwt.Drawing
 
 		public Font WithSize (double size)
 		{
-			return new Font (handler.SetSize (Backend, size));
+			return new Font (handler.SetSize (Backend, size), ToolkitEngine);
 		}
 		
 		public Font WithScaledSize (double scale)

--- a/Xwt/Xwt/Toolkit.cs
+++ b/Xwt/Xwt/Toolkit.cs
@@ -514,14 +514,26 @@ namespace Xwt
 				// to not corrupt the backend of the singletons
 				if (font.ToolkitEngine != null) {
 					var fbh = font.ToolkitEngine.FontBackendHandler;
-					if (font == fbh.SystemFont)
-						return FontBackendHandler.SystemFont;
-					if (font == fbh.SystemMonospaceFont)
-						return FontBackendHandler.SystemMonospaceFont;
-					if (font == fbh.SystemSansSerifFont)
-						return FontBackendHandler.SystemSansSerifFont;
-					if (font == fbh.SystemSerifFont)
-						return FontBackendHandler.SystemSerifFont;
+					if (font.Family == fbh.SystemFont.Family) {
+						if (font == fbh.SystemFont)
+							return FontBackendHandler.SystemFont;
+						return FontBackendHandler.SystemFont.WithSettings (font);
+					}
+					if (font.Family == fbh.SystemMonospaceFont.Family) {
+						if (font == fbh.SystemMonospaceFont)
+							return FontBackendHandler.SystemMonospaceFont;
+						return FontBackendHandler.SystemMonospaceFont.WithSettings (font);
+					}
+					if (font.Family == fbh.SystemSansSerifFont.Family) {
+						if (font == fbh.SystemSansSerifFont)
+							return FontBackendHandler.SystemSansSerifFont;
+						return FontBackendHandler.SystemSansSerifFont.WithSettings (font);
+					}
+					if (font.Family == fbh.SystemSerifFont.Family) {
+						if (font == fbh.SystemSerifFont)
+							return FontBackendHandler.SystemSerifFont;
+						return FontBackendHandler.SystemSerifFont.WithSettings (font);
+					}
 				}
 
 				font.InitForToolkit (this);


### PR DESCRIPTION
This fixes two different bugs with Fonts:

1. when setting the font size, `WithSize` should use its own `ToolkitEngine` instead of `Toolkit.CurrentEngine`
2. When a system font is being validated and initialized for a different toolkit, only its family name should be checked whether its a system font or not and the actual settings should be copied from the source backend. Otherwise a new font with the original system font family was created, which is not necessarily the system font of the target toolkit and which may not be even available for it (i.e. San Francisco fonts on OSX 10.11, which is not supported by Pango).