### PR TITLE
[Gtk] Always take the custom drawn image for Multisize

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/ImageHandler.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ImageHandler.cs
@@ -70,6 +70,9 @@ namespace Xwt.GtkBackend
 		{
 			if (images.Count () == 1)
 				return images.Cast<GtkImage> ().First ();
+			var customDrawn = images.Cast<GtkImage> ().FirstOrDefault (img => (img.Frames == null || img.Frames.Length == 0) && img.HasMultipleSizes);
+			if (customDrawn != null)
+				return customDrawn;
 			var frames = images.Cast<GtkImage> ().SelectMany (img => img.Frames);
 			return new GtkImage (frames);
 		}


### PR DESCRIPTION
This is a quick workaround for the case when a multisize
image is created from a set of custom drawn images.
GtkImage does not support combinations of custom drawing
and bitmap frames for the same image. In that case the
custom drawn multisize image is selected.
