### PR TITLE
[Mac] Support different row heights in Lists/Trees

### DIFF
--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -177,8 +177,6 @@ namespace Xwt.Mac
 			}
 
 			var s = CellSize;
-			if (s.Height > source.RowHeight)
-				source.RowHeight = s.Height;
 		}
 
 		IEnumerable<ICellRenderer> VisibleCells {

--- a/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
@@ -49,9 +49,24 @@ namespace Xwt.Mac
 		protected ApplicationContext context;
 		NSTrackingArea trackingArea;	// Captures Mouse Entered, Exited, and Moved events
 
+		class ListDelegate: NSTableViewDelegate
+		{
+			public override nfloat GetRowHeight (NSTableView tableView, nint row)
+			{
+				var height = tableView.RowHeight;
+				for (int i = 0; i < tableView.ColumnCount; i++) {
+					var cell = tableView.GetCell (i, row);
+					if (cell != null)
+						height = (nfloat) Math.Max (height, cell.CellSize.Height);
+				}
+				return height;
+			}
+		}
+
 		public NSTableViewBackend(IWidgetEventSink eventSink, ApplicationContext context) {
 			this.context = context;
 			this.eventSink = eventSink;
+			this.Delegate = new ListDelegate () ;
 		}
 
 

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -69,7 +69,19 @@ namespace Xwt.Mac
 			public override void ItemWillCollapse (NSNotification notification)
 			{
 				Backend.EventSink.OnRowCollapsing (((TreeItem)notification.UserInfo["NSObject"]).Position);
-			}		
+			}
+
+			public override nfloat GetRowHeight (NSOutlineView outlineView, NSObject item)
+			{
+				var height = outlineView.RowHeight;
+				var row = outlineView.RowForItem (item);
+				for (int i = 0; i < outlineView.ColumnCount; i++) {
+					var cell = outlineView.GetCell (i, row);
+					if (cell != null)
+						height = (nfloat) Math.Max (height, cell.CellSize.Height);
+				}
+				return height;
+			}
 		}
 		
 		NSOutlineView Tree {


### PR DESCRIPTION
Previousy the height was fixed to the height of the highest row, because NSTableView/NSOutlineView use always the fixed RowHeight property in the deprecated NSCell based mode.
Now we use protocol delegates to calculate the height for each row dynamically.

The difference can be verified in the FontSelector widget, where the rows have different heights due to different font metrics. The Font parsing bug (fixed in #544) makes it even worse by rendering some fonts with extremely large sizes.
Before:
<img width="724" alt="bildschirmfoto 2016-02-14 um 12 26 38" src="https://cloud.githubusercontent.com/assets/951587/13033442/7a96dd5e-d316-11e5-8a5e-2a057a25d9e0.png">
After:
<img width="725" alt="bildschirmfoto 2016-02-14 um 12 24 10" src="https://cloud.githubusercontent.com/assets/951587/13033445/86ea6314-d316-11e5-9a0f-26f2ec758282.png">
