### PR TITLE
Optimize default font handling

### DIFF
--- a/TestApps/Samples/Samples/FontSelectorSample.cs
+++ b/TestApps/Samples/Samples/FontSelectorSample.cs
@@ -42,6 +42,47 @@ namespace Samples
 			PackStart (sel);
 			PackStart (new HSeparator());
 			PackStart (preview);
+
+			var lblSystemFont = new Label ();
+			lblSystemFont.Font = Xwt.Drawing.Font.SystemFont;
+			lblSystemFont.Text = lblSystemFont.Font.ToString ();
+			var selectSystemFont = new Button ("Select");
+			selectSystemFont.Clicked += (sender, e) => sel.SelectedFont = Xwt.Drawing.Font.SystemFont;
+
+			var lblSystemMonospaceFont = new Label ();
+			lblSystemMonospaceFont.Font = Xwt.Drawing.Font.SystemMonospaceFont;
+			lblSystemMonospaceFont.Text = lblSystemMonospaceFont.Font.ToString ();
+			var selectSystemMonospaceFont = new Button ("Select");
+			selectSystemMonospaceFont.Clicked += (sender, e) => sel.SelectedFont = Xwt.Drawing.Font.SystemMonospaceFont;
+
+			var lblSystemSerifFont = new Label ();
+			lblSystemSerifFont.Font = Xwt.Drawing.Font.SystemSerifFont;
+			lblSystemSerifFont.Text = lblSystemSerifFont.Font.ToString ();
+			var selectSystemSerifFont = new Button ("Select");
+			selectSystemSerifFont.Clicked += (sender, e) => sel.SelectedFont = Xwt.Drawing.Font.SystemSerifFont;
+
+			var lblSystemSansSerifFont = new Label ();
+			lblSystemSansSerifFont.Font = Xwt.Drawing.Font.SystemSansSerifFont;
+			lblSystemSansSerifFont.Text = lblSystemSansSerifFont.Font.ToString ();
+			var selectSystemSansSerifFont = new Button ("Select");
+			selectSystemSansSerifFont.Clicked += (sender, e) => sel.SelectedFont = Xwt.Drawing.Font.SystemSansSerifFont;
+
+			var tblSystemFonts = new Table ();
+			tblSystemFonts.Add (new Label ("System Font:"), 0, 0);
+			tblSystemFonts.Add (lblSystemFont, 1, 0);
+			tblSystemFonts.Add (selectSystemFont, 2, 0);
+			tblSystemFonts.Add (new Label ("System Monospace Font:"), 0, 1);
+			tblSystemFonts.Add (lblSystemMonospaceFont, 1, 1);
+			tblSystemFonts.Add (selectSystemMonospaceFont, 2, 1);
+			tblSystemFonts.Add (new Label ("System Serif Font:"), 0, 2);
+			tblSystemFonts.Add (lblSystemSerifFont, 1, 2);
+			tblSystemFonts.Add (selectSystemSerifFont, 2, 2);
+			tblSystemFonts.Add (new Label ("System SansSerif Font:"), 0, 3);
+			tblSystemFonts.Add (lblSystemSansSerifFont, 1, 3);
+			tblSystemFonts.Add (selectSystemSansSerifFont, 2, 3);
+
+			PackStart (new HSeparator());
+			PackStart (tblSystemFonts);
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
@@ -55,7 +55,7 @@ namespace Xwt.Mac
 		public override object GetSystemDefaultMonospaceFont ()
 		{
 			var font = NSFont.SystemFontOfSize (0);
-			return Create ("Menlo", font.PointSize, FontStyle.Normal, FontWeight.Normal, FontStretch.Normal);
+			return Create (GetDefaultMonospaceFontNames(Desktop.DesktopType), font.PointSize, FontStyle.Normal, FontWeight.Normal, FontStretch.Normal);
 		}
 
 		public override IEnumerable<string> GetInstalledFonts ()

--- a/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
@@ -77,7 +77,15 @@ namespace Xwt.Mac
 		public override object Create (string fontName, double size, FontStyle style, FontWeight weight, FontStretch stretch)
 		{
 			var t = GetStretchTrait (stretch) | GetStyleTrait (style);
-			var f = NSFontManager.SharedFontManager.FontWithFamily (fontName, t, GetWeightValue (weight), (float)size);
+
+			var names = fontName.Split (new char[] {','}, StringSplitOptions.RemoveEmptyEntries);
+			NSFont f = null;
+			foreach (var name in names) {
+				f = NSFontManager.SharedFontManager.FontWithFamily (name.Trim (), t, GetWeightValue (weight), (float)size);
+				if (f != null) break;
+			}
+			if (f == null) return null;
+
 			var fd = FontData.FromFont (NSFontManager.SharedFontManager.ConvertFont (f, t));
 			fd.Style = style;
 			fd.Weight = weight;
@@ -111,7 +119,17 @@ namespace Xwt.Mac
 		{
 			FontData f = (FontData) handle;
 			f = f.Copy ();
-			f.Font = NSFontManager.SharedFontManager.ConvertFontToFamily (f.Font, family);
+
+			var names = family.Split (new char[] {','}, StringSplitOptions.RemoveEmptyEntries);
+			NSFont font = null;
+			foreach (var name in names) {
+				font = NSFontManager.SharedFontManager.ConvertFontToFamily (f.Font, name.Trim ());
+				if (font != null) {
+					f.Font = font;
+					break;
+				}
+			}
+
 			return f;
 		}
 

--- a/Xwt/Xwt.Backends/FontBackendHandler.cs
+++ b/Xwt/Xwt.Backends/FontBackendHandler.cs
@@ -37,6 +37,48 @@ namespace Xwt.Backends
 		Font systemSerifFont;
 		Font systemSansSerifFont;
 
+		protected static string GetDefaultMonospaceFontNames (DesktopType forDesktop)
+		{
+			switch(Desktop.DesktopType) {
+				case DesktopType.Linux:
+					return "FreeMono, Nimbus Mono L, Courier New, Courier, monospace";
+
+				case DesktopType.Mac:
+					return "Menlo, Monaco, Courier New, Courier, monospace";
+
+				default:
+					return "Lucida Console, Courier New, Courier, monospace";
+			}
+		}
+
+		protected static string GetDefaultSerifFontNames (DesktopType forDesktop)
+		{
+			switch(forDesktop) {
+				case DesktopType.Linux:
+				return "FreeSerif, Bitstream Vera Serif, DejaVu Serif, Likhan, Norasi, Rekha, Times New Roman, Times, serif";
+
+				case DesktopType.Mac:
+				return "Georgia, Palatino, Times New Roman, Times, serif";
+
+				default:
+				return "Times New Roman, Times, serif";
+			}
+		}
+
+		protected static string GetDefaultSansSerifFontNames (DesktopType forDesktop)
+		{
+			switch(forDesktop) {
+				case DesktopType.Linux:
+				return "FreeSans, Nimbus Sans L, Garuda, Utkal, Arial, Helvetica, sans-serif";
+
+				case DesktopType.Mac:
+				return "SF UI Text, Helvetica Neue, Helvetica, Lucida Grande, Lucida Sans Unicode, Arial, sans-serif";
+
+				default:
+				return "Segoe UI, Tahoma, Arial, Helvetica, Lucida Sans Unicode, Lucida Grande, sans-serif";
+			}
+		}
+
 		internal Font SystemFont {
 			get {
 				if (systemFont == null)
@@ -52,21 +94,7 @@ namespace Xwt.Backends
 					if (f != null)
 						systemMonospaceFont = new Font (f, ApplicationContext.Toolkit);
 					else
-					{
-						switch(Desktop.DesktopType) {
-							case DesktopType.Linux:
-								systemMonospaceFont = SystemFont.WithFamily ("FreeMono, Nimbus Mono L, Courier New, Courier, monospace");
-							break;
-
-							case DesktopType.Mac:
-								systemMonospaceFont = SystemFont.WithFamily ("Menlo, Monaco, Courier New, Courier, monospace");
-							break;
-
-							default:
-								systemMonospaceFont = SystemFont.WithFamily ("Lucida Console, Courier New, Courier, monospace");
-								break;
-						}
-					}
+						systemMonospaceFont = SystemFont.WithFamily (GetDefaultMonospaceFontNames(Desktop.DesktopType));
 				}
 				return systemMonospaceFont;
 			}
@@ -79,21 +107,7 @@ namespace Xwt.Backends
 					if (f != null)
 						systemSerifFont = new Font (f, ApplicationContext.Toolkit);
 					else
-					{
-						switch(Desktop.DesktopType) {
-							case DesktopType.Linux:
-								systemSerifFont = SystemFont.WithFamily ("FreeSerif, Bitstream Vera Serif, DejaVu Serif, Likhan, Norasi, Rekha, Times New Roman, Times, serif");
-								break;
-
-							case DesktopType.Mac:
-								systemSerifFont = SystemFont.WithFamily ("Georgia, Palatino, Times New Roman, Times, serif");
-								break;
-
-							default:
-								systemSerifFont = SystemFont.WithFamily ("Times New Roman, Times, serif");
-								break;
-						}
-					}
+						systemSerifFont = SystemFont.WithFamily (GetDefaultSerifFontNames(Desktop.DesktopType));
 				}
 				return systemSerifFont;
 			}
@@ -106,21 +120,7 @@ namespace Xwt.Backends
 					if (f != null)
 						systemSansSerifFont = new Font (f, ApplicationContext.Toolkit);
 					else
-					{
-						switch(Desktop.DesktopType) {
-							case DesktopType.Linux:
-								systemSansSerifFont = SystemFont.WithFamily ("FreeSans, Nimbus Sans L, Garuda, Utkal, Arial, Helvetica, sans-serif");
-							break;
-
-							case DesktopType.Mac:
-								systemSansSerifFont = SystemFont.WithFamily ("SF UI Text, Helvetica Neue, Helvetica, Lucida Grande, Lucida Sans Unicode, Arial, sans-serif");
-							break;
-
-							default:
-								systemSansSerifFont = SystemFont.WithFamily ("Segoe UI, Tahoma, Arial, Helvetica, Lucida Sans Unicode, Lucida Grande, sans-serif");
-								break;
-						}
-					}
+						systemSansSerifFont = SystemFont.WithFamily (GetDefaultSansSerifFontNames(Desktop.DesktopType));
 				}
 				return systemSansSerifFont;
 			}


### PR DESCRIPTION
This PR adds some optimizeation to the Font handling in XWT.

* better handling of default font names
* Mac backend supports (comma separated) alternative names when creating new fonts
* Adds system fonts to the FontSelector example