### PR TITLE
Update WindowFrame.cs

### DIFF
--- a/Xwt/Xwt/WindowFrame.cs
+++ b/Xwt/Xwt/WindowFrame.cs
@@ -383,6 +383,13 @@ namespace Xwt
 
 		internal virtual void SetBackendSize (double width, double height)
 		{
+			//Fix problem of change Width or Height property
+			if (width == -1)
+        			width = Width;
+
+		        if (height == -1)
+		        	height = Height;
+
 			Backend.SetSize (width, height);
 		}
 


### PR DESCRIPTION
If you update Width or Height property instead of Size, it's will be change other side size to minimum value
Ex: this.Width = 100; // Height will be 0 now!