### PR TITLE
Update WindowFrameBackend.cs

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -231,6 +231,11 @@ namespace Xwt.WPFBackend
 
 		public void SetSize (double width, double height)
 		{
+			if (width == -1)
+				width = Bounds.Width;
+			if (height == -1)
+				height = Bounds.Height;
+
 			var r = Bounds;
 			r.Width = width;
 			r.Height = height;


### PR DESCRIPTION
If you update Width or Height property instead of Size, it's will be change other side size to minimum value
Ex: this.Width = 100; // Height will be 0 now!

https://github.com/mono/xwt/pull/581