### PR TITLE
Fix Font backend switching on Toolkit changes

### DIFF
--- a/Xwt/Xwt.Backends/FontBackendHandler.cs
+++ b/Xwt/Xwt.Backends/FontBackendHandler.cs
@@ -174,6 +174,15 @@ namespace Xwt.Backends
 		/// <param name="fontPath">Font path.</param>
 		public abstract bool RegisterFontFromFile (string fontPath);
 
+		internal object WithSettings (object handle, double size, FontStyle style, FontWeight weight, FontStretch stretch)
+		{
+			var backend = SetSize (Copy (handle), size);
+			backend = SetStyle (backend, style);
+			backend = SetWeight (backend, weight);
+			backend = SetStretch (backend, stretch);
+			return backend;
+		}
+
 		public abstract object Copy (object handle);
 		
 		public abstract object SetSize (object handle, double size);

--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -66,10 +66,22 @@ namespace Xwt.Drawing
 				var style = Style;
 				var weight = Weight;
 				var stretch = Stretch;
+				var oldHandler = ToolkitEngine.FontBackendHandler;
 				ToolkitEngine = tk;
 				handler = tk.FontBackendHandler;
-				var fb = handler.Create (fname, size, style, weight, stretch);
-				Backend = fb ?? handler.GetSystemDefaultFont ();
+
+				if (fname == oldHandler.SystemFont.Family)
+					Backend = handler.WithSettings (handler.SystemFont.Backend, size, style, weight, stretch);
+				else if (fname == oldHandler.SystemMonospaceFont.Family)
+					Backend = handler.WithSettings (handler.SystemMonospaceFont.Backend, size, style, weight, stretch);
+				else if (fname == oldHandler.SystemSansSerifFont.Family)
+					Backend = handler.WithSettings (handler.SystemSansSerifFont.Backend, size, style, weight, stretch);
+				else if (fname == oldHandler.SystemSerifFont.Family)
+					Backend = handler.WithSettings (handler.SystemSerifFont.Backend, size, style, weight, stretch);
+				else {
+					var fb = handler.Create (fname, size, style, weight, stretch);
+					Backend = fb ?? handler.GetSystemDefaultFont ();
+				}
 			}
 		}
 

--- a/Xwt/Xwt/Toolkit.cs
+++ b/Xwt/Xwt/Toolkit.cs
@@ -512,31 +512,20 @@ namespace Xwt
 
 				// If the font instance is a system font, we swap instances
 				// to not corrupt the backend of the singletons
-				if (font.ToolkitEngine != null) {
+				if (font.ToolkitEngine != this) {
 					var fbh = font.ToolkitEngine.FontBackendHandler;
-					if (font.Family == fbh.SystemFont.Family) {
-						if (font == fbh.SystemFont)
-							return FontBackendHandler.SystemFont;
-						return FontBackendHandler.SystemFont.WithSettings (font);
-					}
-					if (font.Family == fbh.SystemMonospaceFont.Family) {
-						if (font == fbh.SystemMonospaceFont)
-							return FontBackendHandler.SystemMonospaceFont;
-						return FontBackendHandler.SystemMonospaceFont.WithSettings (font);
-					}
-					if (font.Family == fbh.SystemSansSerifFont.Family) {
-						if (font == fbh.SystemSansSerifFont)
-							return FontBackendHandler.SystemSansSerifFont;
-						return FontBackendHandler.SystemSansSerifFont.WithSettings (font);
-					}
-					if (font.Family == fbh.SystemSerifFont.Family) {
-						if (font == fbh.SystemSerifFont)
-							return FontBackendHandler.SystemSerifFont;
-						return FontBackendHandler.SystemSerifFont.WithSettings (font);
-					}
+					if (font == fbh.SystemFont)
+						font = FontBackendHandler.SystemFont;
+					if (font == fbh.SystemMonospaceFont)
+						font = FontBackendHandler.SystemMonospaceFont;
+					if (font == fbh.SystemSansSerifFont)
+						font = FontBackendHandler.SystemSansSerifFont;
+					if (font == fbh.SystemSerifFont)
+						font = FontBackendHandler.SystemSerifFont;
 				}
 
 				font.InitForToolkit (this);
+				obj = font;
 			} else if (obj is Gradient) {
 				((Gradient)obj).InitForToolkit (this);
 			} else if (obj is IFrontend) {


### PR DESCRIPTION
* always call InitForToolkit when font is being validated
* replace the whole font object if it is a system font reference
* let the FontBackendHandler do the system font conversions