### PR TITLE
[GtkBackend] Add custom Gtk.MissingIcon for Gtk3

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk3Extensions.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk3Extensions.cs
@@ -58,6 +58,20 @@ namespace Xwt.GtkBackend
 			widget.SetStateFlags(Gtk.StateFlags.Normal, true);
 		}
 
+		[DllImport (GtkInterop.LIBGDK, CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr gdk_pixbuf_get_from_surface (IntPtr surface, int src_x, int src_y, int width, int height);
+
+		public static Gdk.Pixbuf GetFromSurface (Cairo.Surface surface, int src_x, int src_y, int width, int height)
+		{
+			IntPtr raw_ret = gdk_pixbuf_get_from_surface (surface.Handle, src_x, src_y, width, height);
+			Gdk.Pixbuf ret;
+			if (raw_ret == IntPtr.Zero)
+				ret = null;
+			else
+				ret = (Gdk.Pixbuf)GLib.Object.GetObject (raw_ret);
+			return ret;
+		}
+
 		[DllImport (GtkInterop.LIBGDK)]
 		static extern IntPtr gdk_pixbuf_get_from_window(IntPtr win, int src_x, int src_y, int width, int height);
 


### PR DESCRIPTION
For Gtk3 (as well as for Gtk2), draws a custom Gtk.MissingIcon if Stock icon cannot be loaded