### PR TITLE
[Gtk.Mac] Remove broken Popover window border

### DIFF
--- a/Xwt.Gtk.Mac/GtkMacPopoverBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacPopoverBackend.cs
@@ -1,10 +1,10 @@
 ﻿//
-// GtkMacEngine.cs
+// GtkMacPopoverBackend.cs
 //
 // Author:
-//       Lluis Sanchez Gual <lluis@xamarin.com>
+//       Vsevolod Kukol <sevo@sevo.org>
 //
-// Copyright (c) 2014 Xamarin, Inc (http://www.xamarin.com)
+// Copyright (c) 2016 Vsevolod Kukol
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,18 +25,25 @@
 // THE SOFTWARE.
 using System;
 using Xwt.GtkBackend;
-using Xwt.Backends;
+using GTK = Gtk;
 
 namespace Xwt.Gtk.Mac
 {
-	public class MacPlatformBackend: GtkPlatformBackend
+	public class GtkMacPopoverBackend : PopoverBackend
 	{
-		public override void Initialize (ToolkitEngineBackend toolit)
+		public override void Initialize (Backends.IPopoverEventSink sink)
 		{
-			toolit.RegisterBackend <IWebViewBackend,WebViewBackend> ();
-			toolit.RegisterBackend <DesktopBackend,GtkMacDesktopBackend> ();
-			toolit.RegisterBackend <FontBackendHandler,GtkMacFontBackendHandler> ();
-			toolit.RegisterBackend <IPopoverBackend,GtkMacPopoverBackend> ();
+			base.Initialize (sink);
+			Popover.Shown += RemoveShadow;
+		}
+
+		static void RemoveShadow (object sender, EventArgs e)
+		{
+			var popover = sender as GTK.Window;
+			if (popover != null) {
+				var window = GtkQuartz.GetWindow (popover);
+				window.HasShadow = false;
+			}
 		}
 	}
 }

--- a/Xwt.Gtk.Mac/GtkQuartz.cs
+++ b/Xwt.Gtk.Mac/GtkQuartz.cs
@@ -1,10 +1,10 @@
 ﻿//
-// GtkMacEngine.cs
+// GtkQuartz.cs
 //
 // Author:
-//       Lluis Sanchez Gual <lluis@xamarin.com>
+//       Vsevolod Kukol <sevo@sevo.org>
 //
-// Copyright (c) 2014 Xamarin, Inc (http://www.xamarin.com)
+// Copyright (c) 2016 Vsevolod Kukol
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,20 +24,38 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
-using Xwt.GtkBackend;
-using Xwt.Backends;
+using System.Runtime.InteropServices;
+using AppKit;
 
 namespace Xwt.Gtk.Mac
 {
-	public class MacPlatformBackend: GtkPlatformBackend
+	public static class GtkQuartz
 	{
-		public override void Initialize (ToolkitEngineBackend toolit)
+		const string LIBQUARTZ = "libgtk-quartz-2.0.dylib";
+
+		public static NSWindow GetWindow (global::Gtk.Window window)
 		{
-			toolit.RegisterBackend <IWebViewBackend,WebViewBackend> ();
-			toolit.RegisterBackend <DesktopBackend,GtkMacDesktopBackend> ();
-			toolit.RegisterBackend <FontBackendHandler,GtkMacFontBackendHandler> ();
-			toolit.RegisterBackend <IPopoverBackend,GtkMacPopoverBackend> ();
+			if (window.GdkWindow == null)
+				return null;
+			var ptr = gdk_quartz_window_get_nswindow (window.GdkWindow.Handle);
+			if (ptr == IntPtr.Zero)
+				return null;
+			return ObjCRuntime.Runtime.GetNSObject<NSWindow> (ptr);
 		}
+
+		public static NSView GetView (global::Gtk.Widget widget)
+		{
+			var ptr = gdk_quartz_window_get_nsview (widget.GdkWindow.Handle);
+			if (ptr == IntPtr.Zero)
+				return null;
+			return ObjCRuntime.Runtime.GetNSObject<NSView> (ptr);
+		}
+
+		[DllImport (LIBQUARTZ)]
+		static extern IntPtr gdk_quartz_window_get_nsview (IntPtr window);
+
+		[DllImport (LIBQUARTZ)]
+		static extern IntPtr gdk_quartz_window_get_nswindow (IntPtr window);
 	}
 }
 

--- a/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
+++ b/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
@@ -45,6 +45,8 @@
     <Compile Include="GtkMacDesktopBackend.cs" />
     <Compile Include="Carbon.cs" />
     <Compile Include="GtkMacFontBackendHandler.cs" />
+    <Compile Include="GtkMacInterop.cs" />
+    <Compile Include="GtkMacPopoverBackend.cs" />
   </ItemGroup>
   <Import Project="..\BuildHelpers.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
+++ b/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
@@ -45,7 +45,7 @@
     <Compile Include="GtkMacDesktopBackend.cs" />
     <Compile Include="Carbon.cs" />
     <Compile Include="GtkMacFontBackendHandler.cs" />
-    <Compile Include="GtkMacInterop.cs" />
+    <Compile Include="GtkQuartz.cs" />
     <Compile Include="GtkMacPopoverBackend.cs" />
   </ItemGroup>
   <Import Project="..\BuildHelpers.targets" />

--- a/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
@@ -129,8 +129,6 @@ namespace Xwt.GtkBackend
 			{
 				int w, h;
 				this.GdkWindow.GetSize (out w, out h);
-				var bounds = new Xwt.Rectangle (0.5, 0.5, w - 1, h - 1);
-				var black = Xwt.Drawing.Color.FromBytes (0xee, 0xee, 0xee);
 				
 				// We clear the surface with a transparent color if possible
 				if (supportAlpha)
@@ -139,11 +137,12 @@ namespace Xwt.GtkBackend
 					cr.SetSourceRGB (1.0, 1.0, 1.0);
 				cr.Operator = Operator.Source;
 				cr.Paint ();
-				
+
+				cr.LineWidth = GtkWorkarounds.GetScaleFactor (Content) > 1 ? 2 : 1;
+				var bounds = new Xwt.Rectangle (cr.LineWidth / 2, cr.LineWidth / 2, w - cr.LineWidth, h - cr.LineWidth);
 				var calibratedRect = RecalibrateChildRectangle (bounds);
 				// Fill it with one round rectangle
 				RoundRectangle (cr, calibratedRect, radius);
-				cr.LineWidth = 1;
 				
 				// Triangle
 				// We first begin by positionning ourselves at the top-center or bottom center of the previous rectangle
@@ -154,7 +153,10 @@ namespace Xwt.GtkBackend
 				DrawTriangle (cr);
 
 				// We use it
-				cr.SetSourceRGBA (black.Red, black.Green, black.Blue, black.Alpha);
+				if (supportAlpha)
+					cr.SetSourceRGBA (0.0, 0.0, 0.0, 0.2);
+				else
+					cr.SetSourceRGB (238d / 255d, 238d / 255d, 238d / 255d);
 				cr.StrokePreserve ();
 				cr.SetSourceRGBA (BackgroundColor.R, BackgroundColor.G, BackgroundColor.B, BackgroundColor.A);
 				cr.Fill ();

--- a/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
@@ -37,7 +37,7 @@ namespace Xwt.GtkBackend
 {
 	public class PopoverBackend : IPopoverBackend
 	{
-		sealed class PopoverWindow : GtkPopoverWindow
+		public sealed class PopoverWindow : GtkPopoverWindow
 		{
 			const int arrowPadding = 10;
 			const int radius = 6;
@@ -78,7 +78,7 @@ namespace Xwt.GtkBackend
 					padding = value;
 					alignment.LeftPadding = radius + (uint) padding.Left;
 					alignment.RightPadding = radius + (uint) padding.Right;
-					if (arrowPosition == Popover.Position.Top) {
+					if (arrowPosition == Xwt.Popover.Position.Top) {
 						alignment.TopPadding = radius + arrowPadding + (uint) padding.Top;
 						alignment.BottomPadding = radius + (uint) padding.Bottom;
 					} else {
@@ -206,7 +206,12 @@ namespace Xwt.GtkBackend
 
 		public Xwt.Drawing.Color BackgroundColor { get; set; }
 
-		public void Initialize (IPopoverEventSink sink)
+		public PopoverWindow Popover {
+			get { return popover; }
+			protected set { popover = value; }
+		}
+
+		public virtual void Initialize (IPopoverEventSink sink)
 		{
 			this.sink = sink;
 			this.BackgroundColor = Xwt.Drawing.Color.FromBytes (0xee, 0xee, 0xee, 0xf9);
@@ -262,7 +267,7 @@ namespace Xwt.GtkBackend
 
 		void UpdatePopoverPosition (Rectangle positionRect, int width, int height)
 		{
-			var position = new Point (positionRect.Center.X, popover.ArrowPosition == Popover.Position.Top ? positionRect.Bottom : positionRect.Top);
+			var position = new Point (positionRect.Center.X, popover.ArrowPosition == Xwt.Popover.Position.Top ? positionRect.Bottom : positionRect.Top);
 			var x = (int)position.X - width / 2;
 			int wx, wy, ww, wh;
 			popover.TransientFor.GetSize (out ww, out wh);
@@ -270,11 +275,11 @@ namespace Xwt.GtkBackend
 
 			// If the popover height would overflow, we flip the arrow position if possible
 			var arrowPos = popover.ArrowPosition;
-			var overflowing = arrowPos == Popover.Position.Top ? position.Y + height > wy + wh : position.Y - height < wy;
-			var otherOverflow = arrowPos == Popover.Position.Top ? position.Y - height < wy : position.Y + height > wy + wh;
+			var overflowing = arrowPos == Xwt.Popover.Position.Top ? position.Y + height > wy + wh : position.Y - height < wy;
+			var otherOverflow = arrowPos == Xwt.Popover.Position.Top ? position.Y - height < wy : position.Y + height > wy + wh;
 			if (overflowing && !otherOverflow) {
 				popover.ArrowPosition = arrowPos == Xwt.Popover.Position.Bottom ? Xwt.Popover.Position.Top : Xwt.Popover.Position.Bottom;
-				position = new Point (positionRect.Center.X, popover.ArrowPosition == Popover.Position.Top ? positionRect.Bottom : positionRect.Top);
+				position = new Point (positionRect.Center.X, popover.ArrowPosition == Xwt.Popover.Position.Top ? positionRect.Bottom : positionRect.Top);
 			}
 
 			// If the popover width would overflow out of the screen, we balance this
@@ -286,7 +291,7 @@ namespace Xwt.GtkBackend
 			x -= delta;
 			popover.ArrowDelta = delta;
 
-			if (popover.ArrowPosition == Popover.Position.Top)
+			if (popover.ArrowPosition == Xwt.Popover.Position.Top)
 				popover.Move (x, (int)position.Y);
 			else
 				popover.Move (x, (int)position.Y - height);


### PR DESCRIPTION
This PR removes the border around the Gtk Popover window on Mac.

Before:
<img width="229" alt="Unpatched: wrong border" src="https://cloud.githubusercontent.com/assets/951587/13707512/4fe9acd2-e7aa-11e5-8016-aa6a42102430.png">

After:
<img width="224" alt="Patched: no border" src="https://cloud.githubusercontent.com/assets/951587/13707517/54a124c6-e7aa-11e5-99a5-822e7bd75666.png">
