### PR TITLE
Fix Gtk3 Build

### DIFF
--- a/Xwt.Gtk/Xwt.Gtk3.csproj
+++ b/Xwt.Gtk/Xwt.Gtk3.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>True</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
+    <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
@@ -1299,7 +1299,7 @@ namespace Xwt.GtkBackend
 		[DllImport (GtkInterop.LIBGTK, CallingConvention = CallingConvention.Cdecl)]
 		static extern void gtk_object_set_data (IntPtr raw, IntPtr key, IntPtr data);
 
-		public static void SetData<T> (Gtk.Object gtkobject, string key, T data) where T : struct
+		public static void SetData<T> (GLib.Object gtkobject, string key, T data) where T : struct
 		{
 			IntPtr pkey = GLib.Marshaller.StringToPtrGStrdup (key);
 			IntPtr pdata = Marshal.AllocHGlobal (Marshal.SizeOf (data));


### PR DESCRIPTION
Fixes 2 things:
1) Build output for Gtk3 Release was set to "Debug" folder instead of "Release"
2) Gtk.Object does not exist in Gtk 3, GLib.Object does however exist in both Gtk 2 and 3