### PR TITLE
Fix font backend switching Pt.2

### DIFF
--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -80,7 +80,7 @@ namespace Xwt.Drawing
 					Backend = handler.WithSettings (handler.SystemSerifFont.Backend, size, style, weight, stretch);
 				else {
 					var fb = handler.Create (fname, size, style, weight, stretch);
-					Backend = fb ?? handler.GetSystemDefaultFont ();
+					Backend = fb ?? handler.WithSettings(handler.GetSystemDefaultFont (), size, style, weight, stretch);
 				}
 			}
 		}

--- a/Xwt/Xwt.Drawing/TextLayout.cs
+++ b/Xwt/Xwt.Drawing/TextLayout.cs
@@ -129,7 +129,7 @@ namespace Xwt.Drawing
 
 		public Font Font {
 			get { return font; }
-			set { font = value; handler.SetFont (Backend, value); }
+			set { font = value; handler.SetFont (Backend, (Font)ToolkitEngine.ValidateObject (value)); }
 		}
 
 		public string Text {

--- a/Xwt/Xwt/Toolkit.cs
+++ b/Xwt/Xwt/Toolkit.cs
@@ -514,14 +514,14 @@ namespace Xwt
 				// to not corrupt the backend of the singletons
 				if (font.ToolkitEngine != this) {
 					var fbh = font.ToolkitEngine.FontBackendHandler;
-					if (font == fbh.SystemFont)
-						font = FontBackendHandler.SystemFont;
-					if (font == fbh.SystemMonospaceFont)
-						font = FontBackendHandler.SystemMonospaceFont;
-					if (font == fbh.SystemSansSerifFont)
-						font = FontBackendHandler.SystemSansSerifFont;
-					if (font == fbh.SystemSerifFont)
-						font = FontBackendHandler.SystemSerifFont;
+					if (font.Family == fbh.SystemFont.Family)
+						font = FontBackendHandler.SystemFont.WithSettings (font);
+					if (font.Family == fbh.SystemMonospaceFont.Family)
+						font = FontBackendHandler.SystemMonospaceFont.WithSettings (font);
+					if (font.Family == fbh.SystemSansSerifFont.Family)
+						font = FontBackendHandler.SystemSansSerifFont.WithSettings (font);
+					if (font.Family == fbh.SystemSerifFont.Family)
+						font = FontBackendHandler.SystemSerifFont.WithSettings (font);
 				}
 
 				font.InitForToolkit (this);


### PR DESCRIPTION
I have missed to commit some bits required for #583 and here are the missing parts:
* TextLayout should always validate a Font (especially in mixed environments)
* When switching a Font backend and the specific font is missing in the target toolkit, at least the font settings should be applied on the default system font.
* Sytem font swapping should respect the font settings (due to a broken commit, I accidentially reverted that part)