### PR TITLE
[Mac] Fixed AppDelegate.OpenUrl not being invoked

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacEngine.cs
@@ -306,11 +306,14 @@ namespace Xwt.Mac
 			launched = true;
 			foreach (var w in pendingWindows)
 				w.InternalShow ();
+		}
 
+		public override void WillFinishLaunching(NSNotification notification)
+		{
 			NSAppleEventManager eventManager = NSAppleEventManager.SharedAppleEventManager;
 			eventManager.SetEventHandler (this, new Selector ("handleGetURLEvent:withReplyEvent:"), AEEventClass.Internet, AEEventID.GetUrl);
 		}
-			
+
 		[Export("handleGetURLEvent:withReplyEvent:")]
 		void HandleGetUrlEvent(NSAppleEventDescriptor descriptor, NSAppleEventDescriptor reply)
 		{


### PR DESCRIPTION
Fixed AppDelegate.OpenUrl not being invoked when the application is being launched because an url has been opened which has been specified in the Info.plist file