### PR TITLE
[GTK] Fix Uri drop on Windows

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/Util.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Util.cs
@@ -91,7 +91,7 @@ namespace Xwt.GtkBackend
 			else if (data.TargetsIncludeImage (false))
 				target.AddImage (context.Toolkit.WrapImage (data.Pixbuf));
 			else if (type == TransferDataType.Uri) {
-				var uris = System.Text.Encoding.UTF8.GetString (data.Data).Split ('\n').Where (u => !string.IsNullOrEmpty(u)).Select (u => new Uri (u)).ToArray ();
+				var uris = System.Text.Encoding.UTF8.GetString (data.Data).Split ('\n').Where (u => !(string.IsNullOrEmpty(u) || u == "\0")).Select (u => new Uri (u)).ToArray ();
 				target.AddUris (uris);
 			}
 			else


### PR DESCRIPTION
When you drop files on Windows the last splinted string is always "\0".