### PR TITLE
Rectangle.Contains(point) and Rectangle.Contains(rect) are inconsistent

### DIFF
--- a/Xwt/Xwt/Rectangle.cs
+++ b/Xwt/Xwt/Rectangle.cs
@@ -104,8 +104,8 @@ namespace Xwt
 		
 		public bool Contains (double x, double y)
 		{
-			return ((x >= Left) && (x < Right) && 
-				(y >= Top) && (y < Bottom));
+			return ((x >= Left) && (x <= Right) && 
+				(y >= Top) && (y <= Bottom));
 		}
 		
 		public bool IntersectsWith (Rectangle r)


### PR DESCRIPTION
Contains (Rectangle rect)
includes the whole rect 

Contains (double x, double y)
excludes right and bottom borders of rectangle

this is inconsistent