### PR TITLE
[Wpf] Optimize wpf webview

### DIFF
--- a/TestApps/WpfTest/Main.cs
+++ b/TestApps/WpfTest/Main.cs
@@ -2,6 +2,7 @@
 //  
 // Author:
 //       Luís Reis <luiscubal@gmail.com>
+//       Vsevolod Kukol <sevoku@microsoft.com>
 // 
 // Copyright (c) 2012 Luís Reis
 // 
@@ -34,7 +35,63 @@ namespace WpfTest
 		[STAThread]
 		public static void Main(string[] args)
 		{
+			/*
+			 WORKAROUND for Xwt.WebView on Windows using WPF:
+			 The WPF WebView Backend is based on System.Windows.Controls.WebView
+			 which runs in IE7 emulation mode by default. This behaviour can only be
+			 changed by modifying the Windows registry, which is not part of the Xwt
+			 API. See https://msdn.microsoft.com/de-de/library/ee330730.aspx#browser_emulation
+			 for more information.
+			 Uncomment the next line to set different IE Emulation modes
+			*/
+			//WebViewEmulationMode = IEEmulationMode.IE11;
+
 			App.Run (ToolkitType.Wpf);
+		}
+
+		/// <summary>
+		/// Gets or sets the System.Windows.Controls.WebView Emulation mode
+		/// </summary>
+		/// <remarks>This is a simple example on how to change the WebView emulation mode</remarks>
+		public static IEEmulationMode WebViewEmulationMode
+		{
+			get
+			{
+				var regKey = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BROWSER_EMULATION", true);
+				if (regKey == null)
+					return IEEmulationMode.Default;
+
+				string myProgramName = System.IO.Path.GetFileName(System.Reflection.Assembly.GetEntryAssembly().Location);
+				var currentValue = regKey.GetValue(myProgramName);
+				return currentValue != null ? (IEEmulationMode)currentValue : IEEmulationMode.Default;
+			}
+			set
+			{
+				var regKey = Microsoft.Win32.Registry.CurrentUser.OpenSubKey(@"Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BROWSER_EMULATION", true);
+				if (regKey == null)
+					regKey = Microsoft.Win32.Registry.CurrentUser.CreateSubKey(@"Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BEHAVIORS", Microsoft.Win32.RegistryKeyPermissionCheck.ReadWriteSubTree);
+
+				string executableName = System.IO.Path.GetFileName(System.Reflection.Assembly.GetEntryAssembly().Location);
+				var currentValue = regKey.GetValue(executableName);
+				if (currentValue == null || (int)currentValue != (int)value)
+					regKey.SetValue(executableName, (int)value, Microsoft.Win32.RegistryValueKind.DWord);
+			}
+		}
+
+		/// <summary>Internet Explorer Emulation Modes</summary>
+		/// <remarks>https://msdn.microsoft.com/de-de/library/ee330730.aspx#browser_emulation</remarks>
+		public enum IEEmulationMode
+		{
+			IE7 = 0x00001b58,
+			IE8 = 0x00001f40,
+			IE8Force = 0x000022b8,
+			IE9 = 0x00002328,
+			IE9Force = 0x0000270f,
+			IE10 = 0x00002710,
+			IE10Force = 0x00002711,
+			IE11 = 0x00002af8,
+			IE11Force = 0x00002af9,
+			Default = IE7,
 		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
@@ -96,6 +96,7 @@ namespace Xwt.WPFBackend
 		public void LoadHtml (string content, string base_uri)
 		{
 			view.NavigateToString (content);
+			url = base_uri;
 		}
 
 		string prevTitle = String.Empty;
@@ -151,9 +152,11 @@ namespace Xwt.WPFBackend
 		void HandleNavigating (object sender, System.Windows.Navigation.NavigatingCancelEventArgs e)
 		{
 			if (enableNavigatingEvent) {
-				var url = e.Uri.AbsoluteUri;
+				var newurl = string.Empty;
+				if (e.Uri != null)
+					newurl = e.Uri.AbsoluteUri;
 				Context.InvokeUserCode (delegate {
-					e.Cancel = EventSink.OnNavigateToUrl (url);
+					e.Cancel = EventSink.OnNavigateToUrl (newurl);
 				});
 			}
 		}
@@ -172,7 +175,8 @@ namespace Xwt.WPFBackend
 		void HandleNavigated (object sender, System.Windows.Navigation.NavigationEventArgs e)
 		{
 			LoadProgress = 0;
-			url = e.Uri.AbsoluteUri;
+			if (e.Uri != null)
+				this.url = e.Uri.AbsoluteUri;
 			if (enableLoadingEvent)
 				Context.InvokeUserCode (delegate {
 					EventSink.OnLoading ();

--- a/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
@@ -26,7 +26,7 @@
 // THE SOFTWARE.
 
 using System;
-using System.Windows;
+using System.Reflection;
 using SWC = System.Windows.Controls;
 using Xwt.Backends;
 
@@ -37,6 +37,9 @@ namespace Xwt.WPFBackend
 		string url;
 		SWC.WebBrowser view;
 		bool enableNavigatingEvent, enableLoadingEvent, enableLoadedEvent, enableTitleChangedEvent;
+
+		static PropertyInfo titleProperty;
+		static bool canGetDocumentTitle = true;
 
 		public WebViewBackend () : this (new SWC.WebBrowser ())
 		{
@@ -101,7 +104,45 @@ namespace Xwt.WPFBackend
 
 		string prevTitle = String.Empty;
 
-		public string Title { get; private set; }
+		public string Title
+		{
+			get
+			{
+				if (view.Document != null && titleProperty == null && canGetDocumentTitle)
+				{
+					var mshtmlDocType = view.Document.GetType();
+					// Get the property with the document Title,
+					// property name depends on .NET Version
+					titleProperty = mshtmlDocType?.GetProperty("Title") ?? mshtmlDocType?.GetProperty("IHTMLDocument2_nameProp");
+					canGetDocumentTitle = titleProperty == null;
+				}
+
+				string title = null;
+				if (canGetDocumentTitle)
+				{
+					try
+					{
+						title = titleProperty.GetValue(view.Document, null) as string;
+					}
+					catch
+					{
+						canGetDocumentTitle = false;
+					}
+				}
+				// try to get the title using a script, if reflection fails
+				if (title == null)
+				{
+					#pragma warning disable RECS0022 // A catch clause that catches System.Exception and has an empty body
+					try
+					{
+						title = (string)view.InvokeScript("eval", "document.title.toString()");
+					}
+					catch { }
+					#pragma warning restore RECS0022 // A catch clause that catches System.Exception and has an empty body
+				}
+				return title;
+			}
+		}
 
 		protected new IWebViewEventSink EventSink {
 			get { return (IWebViewEventSink)base.EventSink; }
@@ -166,7 +207,7 @@ namespace Xwt.WPFBackend
 			LoadProgress = 1;
 			if (enableLoadedEvent)
 				Context.InvokeUserCode (EventSink.OnLoaded);
-			Title = (string)view.InvokeScript("eval", "document.title.toString()");
+
 			if (enableTitleChangedEvent && (prevTitle != Title))
 				Context.InvokeUserCode (EventSink.OnTitleChanged);
 			prevTitle = Title;


### PR DESCRIPTION
The WPF WebView has only a very limited API and hides its internal IWebBrowser2 (ActiveX) control. This PR optimizes the WPF WebView backend, by trying to access the ActiveX control using reflection.

* use reflection (without MSHTML reference) to handle the document title
* suppress JS Error messages (using reflection again)
* add example on how to switch to a different WebView IE Emulation mode (i.e. Internet Explorer 11)