### PR TITLE
[Gtk] Fix WebView scrolling

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWebKitMini.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWebKitMini.cs
@@ -28,9 +28,11 @@ using System.Runtime.InteropServices;
 
 namespace Xwt.GtkBackend.WebKit
 {
-
-
+	#if XWT_GTK3
+	public class WebView : Gtk.Container, Gtk.IScrollable
+	#else
 	public class WebView : Gtk.Container
+	#endif
 	{
 		public WebView(IntPtr raw) : base(raw)
 		{
@@ -72,6 +74,63 @@ namespace Xwt.GtkBackend.WebKit
 				webkit_web_view_set_full_content_zoom(Handle, value);
 			}
 		}
+
+		#if XWT_GTK3 // Gtk.IScrollable
+		[GLib.Property ("hadjustment")]
+		public Gtk.Adjustment Hadjustment {
+			get {
+				using (GLib.Value property = GetProperty ("hadjustment")) {
+					return property.Val as Gtk.Adjustment;
+				}
+			}
+			set {
+				using (GLib.Value val = new GLib.Value (value)) {
+					SetProperty ("hadjustment", val);
+				}
+			}
+		}
+		[GLib.Property ("vadjustment")]
+		public Gtk.Adjustment Vadjustment {
+			get {
+				using (GLib.Value property = GetProperty ("vadjustment")) {
+					return property.Val as Gtk.Adjustment;
+				}
+			}
+			set {
+				using (GLib.Value val = new GLib.Value (value)) {
+					SetProperty ("vadjustment", val);
+				}
+			}
+		}
+
+		[GLib.Property ("hscroll-policy")]
+		public Gtk.ScrollablePolicy HscrollPolicy {
+			get {
+				using (GLib.Value property = GetProperty ("hscroll-policy")) {
+					return (Gtk.ScrollablePolicy)property.Val;
+				}
+			}
+			set {
+				using (GLib.Value val = new GLib.Value (value)) {
+					SetProperty ("hscroll-policy", val);
+				}
+			}
+		}
+
+		[GLib.Property ("vscroll-policy")]
+		public Gtk.ScrollablePolicy VscrollPolicy {
+			get {
+				using (GLib.Value property = GetProperty ("vscroll-policy")) {
+					return (Gtk.ScrollablePolicy)property.Val;
+				}
+			}
+			set {
+				using (GLib.Value val = new GLib.Value (value)) {
+					SetProperty ("vscroll-policy", val);
+				}
+			}
+		}
+		#endif
 
 		public void StopLoading() {
 			webkit_web_view_stop_loading(Handle);

--- a/Xwt.Gtk/Xwt.GtkBackend/ScrollViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ScrollViewBackend.cs
@@ -74,8 +74,16 @@ namespace Xwt.GtkBackend
 					vp.Add (w);
 					Widget.Child = vp;
 				}
-				else if (w is Gtk.Viewport)
+				#if XWT_GTK3
+				else if (w is Gtk.IScrollable)
 					Widget.Child = w;
+				#else
+				// Gtk2 has no interface for natively scrollable widgets, therefore we manually check
+				// for types that should not be packed into a Viewport.
+				// see: https://developer.gnome.org/gtk2/stable/GtkScrolledWindow.html#gtk-scrolled-window-add-with-viewport
+				else if (w is Gtk.Viewport || w is Gtk.TreeView || w is Gtk.TextView || w is Gtk.Layout || w is WebKit.WebView)
+					Widget.Child = w;
+				#endif
 				else {
 					Gtk.Viewport vp = new Gtk.Viewport ();
 					vp.Show ();


### PR DESCRIPTION
WebKitGtk supports native scrolling and should not be packed into a Gtk.Viewport.

This PR fixes #604, but the horizontal scrolling is still partially broken (the scrollbar does not disappear if the content fits the window). It seems to be related to the problems discussed here: https://lists.webkit.org/pipermail/webkit-gtk/2011-May/000512.html. A possible solution could be to listen to the `web-view-ready` event and to set a customized size request based on [WebKitWebWindowFeatures](https://webkitgtk.org/reference/webkitgtk/stable/WebKitWebWindowFeatures.html).