### PR TITLE
WebView fixes / new features

### DIFF
--- a/TestApps/Samples/Samples/WebViewSample.cs
+++ b/TestApps/Samples/Samples/WebViewSample.cs
@@ -131,6 +131,8 @@ namespace Samples
 				"Lorem ipsum dolor sit amet.</p>" +
 				"</body></html>";
 			wb.LoadHtml (html, "sample.html");
+			wb.CustomCss =
+				"body {\n    color: red;\n    background-color: black;\n}";
 		}
 
 		public void UpdateProgress (object sender, ElapsedEventArgs args)

--- a/TestApps/Samples/Samples/WebViewSample.cs
+++ b/TestApps/Samples/Samples/WebViewSample.cs
@@ -62,10 +62,7 @@ namespace Samples
 			var title = new Label ("Title: ");
 			PackStart (title);
 
-			var wbscroll = new ScrollView (wb);
-			wbscroll.VerticalScrollPolicy = ScrollPolicy.Automatic;
-			wbscroll.HorizontalScrollPolicy = ScrollPolicy.Automatic;
-			PackStart (wbscroll, true);
+			PackStart (wb, true);
 
 			pg.Fraction = 0.0;
 			var timer = new Timer (100);

--- a/Xwt.Gtk.Mac/WebViewBackend.cs
+++ b/Xwt.Gtk.Mac/WebViewBackend.cs
@@ -28,6 +28,7 @@ using System;
 using Xwt.GtkBackend;
 using Xwt.Backends;
 using Foundation;
+using AppKit;
 
 namespace Xwt.Gtk.Mac
 {
@@ -45,6 +46,7 @@ namespace Xwt.Gtk.Mac
 			base.Initialize ();
 
 			view = new WebKit.WebView ();
+			view.UIDelegate = new XwtWebUIDelegate (this);
 			Widget = GtkMacInterop.NSViewToGtkWidget (view);
 			Widget.Show ();
 		}
@@ -79,6 +81,8 @@ namespace Xwt.Gtk.Mac
 				return view.CanGoForward ();
 			}
 		}
+
+		public bool ContextMenuEnabled { get; set; }
 
 		public void GoBack ()
 		{
@@ -171,6 +175,24 @@ namespace Xwt.Gtk.Mac
 				EventSink.OnTitleChanged ();
 			});
 		}
+
+		class XwtWebUIDelegate : WebKit.WebUIDelegate
+		{
+			readonly WebViewBackend backend;
+
+			public XwtWebUIDelegate (WebViewBackend backend)
+			{
+				this.backend = backend;
+			}
+
+			public override NSMenuItem [] UIGetContextMenuItems (WebKit.WebView sender, NSDictionary forElement, NSMenuItem [] defaultMenuItems)
+			{
+				if (backend.ContextMenuEnabled)
+					return defaultMenuItems;
+				return null;
+			}
+		}
+
 		#endregion
 	}
 }

--- a/Xwt.Gtk.Mac/WebViewBackend.cs
+++ b/Xwt.Gtk.Mac/WebViewBackend.cs
@@ -87,6 +87,15 @@ namespace Xwt.Gtk.Mac
 
 		public bool ContextMenuEnabled { get; set; }
 
+		public bool ScrollBarsEnabled {
+			get {
+				return view.MainFrame.FrameView.AllowsScrolling;
+			}
+			set {
+				view.MainFrame.FrameView.AllowsScrolling = value;
+			}
+		}
+
 		public string CustomCss {
 			get {
 				return customCss;

--- a/Xwt.Gtk.Mac/WebViewBackend.cs
+++ b/Xwt.Gtk.Mac/WebViewBackend.cs
@@ -84,6 +84,8 @@ namespace Xwt.Gtk.Mac
 
 		public bool ContextMenuEnabled { get; set; }
 
+		public string CustomCss { get; set; }
+
 		public void GoBack ()
 		{
 			view.GoBack ();

--- a/Xwt.Gtk.Windows/WebViewBackend.cs
+++ b/Xwt.Gtk.Windows/WebViewBackend.cs
@@ -134,6 +134,15 @@ namespace Xwt.Gtk.Windows
 			}
 		}
 
+		public bool ScrollBarsEnabled {
+			get {
+				return view.ScrollBarsEnabled;
+			}
+			set {
+				view.ScrollBarsEnabled = value;
+			}
+		}
+
 		public void GoBack ()
 		{
 			view.GoBack ();

--- a/Xwt.Gtk.Windows/WebViewBackend.cs
+++ b/Xwt.Gtk.Windows/WebViewBackend.cs
@@ -118,6 +118,8 @@ namespace Xwt.Gtk.Windows
 
 		public bool ContextMenuEnabled { get; set; }
 
+		public string CustomCss { get; set; }
+
 		public void GoBack ()
 		{
 			view.GoBack ();

--- a/Xwt.Gtk.Windows/WebViewBackend.cs
+++ b/Xwt.Gtk.Windows/WebViewBackend.cs
@@ -61,7 +61,7 @@ namespace Xwt.Gtk.Windows
 			view.Navigated += HandleNavigated;
 			view.DocumentTitleChanged += HandleDocumentTitleChanged;
 			view.DocumentCompleted += HandleDocumentCompleted;
-			view.Navigate("about:blank"); // force Document initialization
+			view.DocumentText = ""; // force Document initialization
 
 			socket = new Socket ();
 			Widget = socket;
@@ -282,7 +282,7 @@ namespace Xwt.Gtk.Windows
 		}
 
 		#region IDocHostUIHandler implementation
-		int IDocHostUIHandler.ShowContextMenu(uint dwID, ref POINT ppt, object pcmdtReserved, object pdispReserved)
+		int IDocHostUIHandler.ShowContextMenu (DOCHOSTUICONTEXTMENU dwID, ref POINT ppt, object pcmdtReserved, object pdispReserved)
 		{
 			return (int)(ContextMenuEnabled ? HResult.S_FALSE : HResult.S_OK);
 		}
@@ -290,9 +290,7 @@ namespace Xwt.Gtk.Windows
 		void IDocHostUIHandler.GetHostInfo(ref DOCHOSTUIINFO pInfo)
 		{
 			if (!ScrollBarsEnabled)
-				pInfo.dwFlags = (int)(DOCHOSTUIFLAG.DOCHOSTUIFLAG_SCROLL_NO | DOCHOSTUIFLAG.DOCHOSTUIFLAG_NO3DOUTERBORDER);
-			else
-				pInfo.dwFlags = 0;
+				pInfo.dwFlags = DOCHOSTUIFLAG.DOCHOSTUIFLAG_SCROLL_NO | DOCHOSTUIFLAG.DOCHOSTUIFLAG_NO3DOUTERBORDER;
 			if (!string.IsNullOrEmpty(CustomCss))
 				pInfo.pchHostCss = CustomCss;
 		}
@@ -330,8 +328,9 @@ namespace Xwt.Gtk.Windows
 			return (int)HResult.S_FALSE;
 		}
 
-		void IDocHostUIHandler.GetOptionKeyPath(ref string pchKey, uint dw)
+		void IDocHostUIHandler.GetOptionKeyPath(out string pchKey, uint dw)
 		{
+			pchKey = null;
 		}
 
 		int IDocHostUIHandler.GetDropTarget(object pDropTarget, out object ppDropTarget)
@@ -342,17 +341,19 @@ namespace Xwt.Gtk.Windows
 
 		void IDocHostUIHandler.GetExternal(out object ppDispatch)
 		{
-			throw new NotImplementedException();
+			ppDispatch = null;
 		}
 
-		int IDocHostUIHandler.TranslateUrl(uint dwTranslate, string pchURLIn, ref string ppchURLOut)
+		int IDocHostUIHandler.TranslateUrl(uint dwTranslate, string pchURLIn, out string ppchURLOut)
 		{
+			ppchURLOut = pchURLIn;
 			return (int)HResult.S_FALSE;
 		}
 
-		IDataObject IDocHostUIHandler.FilterDataObject(IDataObject pDO)
+		int IDocHostUIHandler.FilterDataObject(IDataObject pDO, out IDataObject ppDORet)
 		{
-			throw new NotImplementedException();
+			ppDORet = null;
+			return (int)HResult.S_FALSE;
 		}
 		#endregion
 	}

--- a/Xwt.Gtk.Windows/WebViewBackend.cs
+++ b/Xwt.Gtk.Windows/WebViewBackend.cs
@@ -210,9 +210,11 @@ namespace Xwt.Gtk.Windows
 		void HandleNavigating (object sender, SWF.WebBrowserNavigatingEventArgs e)
 		{
 			if (enableNavigatingEvent) {
-				var url = e.Url.AbsoluteUri;
+				var newurl = string.Empty;
+				if (e.Url != null)
+					newurl = e.Url.AbsoluteUri;
 				ApplicationContext.InvokeUserCode (delegate {
-					e.Cancel = EventSink.OnNavigateToUrl (url);
+					e.Cancel = EventSink.OnNavigateToUrl (newurl);
 				});
 			}
 		}

--- a/Xwt.Gtk.Windows/WebViewBackend.cs
+++ b/Xwt.Gtk.Windows/WebViewBackend.cs
@@ -116,6 +116,8 @@ namespace Xwt.Gtk.Windows
 			}
 		}
 
+		public bool ContextMenuEnabled { get; set; }
+
 		public void GoBack ()
 		{
 			view.GoBack ();
@@ -231,12 +233,27 @@ namespace Xwt.Gtk.Windows
 				});
 		}
 
+		SWF.HtmlDocument currentDocument;
+
 		void HandleLoaded (object sender, EventArgs e)
 		{
+			if (currentDocument != view.Document) {
+				if (currentDocument != null)
+					view.Document.ContextMenuShowing -= HandleContextMenu;
+
+				currentDocument = view.Document;
+				view.Document.ContextMenuShowing += HandleContextMenu;
+			}
+
 			if (enableLoadedEvent)
 				ApplicationContext.InvokeUserCode (delegate {
 					EventSink.OnLoaded ();
 				});
+		}
+
+		void HandleContextMenu (object sender, SWF.HtmlElementEventArgs e)
+		{
+			e.ReturnValue = ContextMenuEnabled;
 		}
 	}
 }

--- a/Xwt.Gtk.Windows/WebViewBackend.cs
+++ b/Xwt.Gtk.Windows/WebViewBackend.cs
@@ -287,7 +287,7 @@ namespace Xwt.Gtk.Windows
 		}
 
 		#region IDocHostUIHandler implementation
-		int IDocHostUIHandler.ShowContextMenu(int dwID, ref tagPOINT ppt, object pcmdtReserved, object pdispReserved)
+		int IDocHostUIHandler.ShowContextMenu(uint dwID, ref POINT ppt, object pcmdtReserved, object pdispReserved)
 		{
 			return (int)(ContextMenuEnabled ? HResult.S_FALSE : HResult.S_OK);
 		}
@@ -302,7 +302,7 @@ namespace Xwt.Gtk.Windows
 				pInfo.pchHostCss = CustomCss;
 		}
 
-		void IDocHostUIHandler.ShowUI(int dwID, ref object pActiveObject, ref object pCommandTarget, ref object pFrame, ref object pDoc)
+		void IDocHostUIHandler.ShowUI(uint dwID, ref object pActiveObject, ref object pCommandTarget, ref object pFrame, ref object pDoc)
 		{
 		}
 
@@ -326,11 +326,11 @@ namespace Xwt.Gtk.Windows
 		{
 		}
 
-		void IDocHostUIHandler.ResizeBorder(ref LPCRECT prcBorder, object pUIWindow, bool fFrameWindow)
+		void IDocHostUIHandler.ResizeBorder(ref RECT prcBorder, object pUIWindow, bool fFrameWindow)
 		{
 		}
 
-		int IDocHostUIHandler.TranslateAccelerator(ref LPMSG lpMsg, ref Guid pguidCmdGroup, uint nCmdID)
+		int IDocHostUIHandler.TranslateAccelerator(ref MSG lpMsg, ref Guid pguidCmdGroup, uint nCmdID)
 		{
 			return (int)HResult.S_FALSE;
 		}
@@ -339,8 +339,9 @@ namespace Xwt.Gtk.Windows
 		{
 		}
 
-		int IDocHostUIHandler.GetDropTarget(int pDropTarget, ref int ppDropTarget)
+		int IDocHostUIHandler.GetDropTarget(object pDropTarget, out object ppDropTarget)
 		{
+			ppDropTarget = pDropTarget;
 			return (int)HResult.S_FALSE;
 		}
 

--- a/Xwt.Gtk.Windows/WebViewBackend.cs
+++ b/Xwt.Gtk.Windows/WebViewBackend.cs
@@ -201,7 +201,7 @@ namespace Xwt.Gtk.Windows
 				loadProgress = 1;
 				HandleLoaded(view, EventArgs.Empty);
 			}
-			else if (e.MaximumProgress == 0)
+			else if (e.MaximumProgress == 0 || e.MaximumProgress < e.CurrentProgress)
 				loadProgress = 1;
 			else
 				loadProgress = (double)e.CurrentProgress / (double)e.MaximumProgress;

--- a/Xwt.Gtk.Windows/WebViewBackend.cs
+++ b/Xwt.Gtk.Windows/WebViewBackend.cs
@@ -74,17 +74,12 @@ namespace Xwt.Gtk.Windows
 
 		void HandleGtkRealized (object sender, EventArgs e)
 		{
-			var size = new System.Drawing.Size (Widget.WidthRequest, Widget.HeightRequest);
+			var size = new System.Drawing.Size (Widget.Allocation.Width, Widget.Allocation.Height);
 			view.Size = size;
 
 			var browser_handle = view.Handle;
 			IntPtr window_handle = (IntPtr)socket.Id;
 			SetParent (browser_handle, window_handle);
-
-			// load requested url if the view is still not initialized
-			// otherwise it would already have been loaded
-			if (!initialized && url != null)
-				view.Navigate(url);
 		}
 
 		void HandleGtkSizeAllocated (object sender, SizeAllocatedArgs e)
@@ -95,13 +90,13 @@ namespace Xwt.Gtk.Windows
 
 		public string Url {
 			get {
-				if (view?.Url != null)
+				if (initialized && view?.Url != null)
 					url = view.Url.AbsoluteUri;
 				return url;
 			}
 			set {
 				url = value;
-				if (view != null)
+				if (initialized && view != null)
 					view.Navigate (url);
 			}
 		}
@@ -271,7 +266,7 @@ namespace Xwt.Gtk.Windows
 			if (currentDocument != null && !initialized)
 			{
 				initialized = true;
-				if (url != null)
+				if (!string.IsNullOrEmpty (url))
 					view.Navigate(url);
 			}
 		}

--- a/Xwt.Gtk.Windows/WebViewBackend.cs
+++ b/Xwt.Gtk.Windows/WebViewBackend.cs
@@ -74,6 +74,7 @@ namespace Xwt.Gtk.Windows
 			view.Navigating += HandleNavigating;
 			view.Navigated += HandleNavigated;
 			view.DocumentTitleChanged += HandleDocumentTitleChanged;
+			view.DocumentCompleted += HandleDocumentCompleted;
 			if (url != null)
 				view.Navigate (url);
 		}
@@ -142,6 +143,7 @@ namespace Xwt.Gtk.Windows
 
 		public void LoadHtml (string content, string base_uri)
 		{
+			loadProgress = 0;
 			view.DocumentText = content;
 		}
 
@@ -199,11 +201,9 @@ namespace Xwt.Gtk.Windows
 
 		void HandleProgressChanged (object sender, SWF.WebBrowserProgressChangedEventArgs e)
 		{
-			if (e.CurrentProgress == -1) {
-				loadProgress = 1;
-				HandleLoaded(view, EventArgs.Empty);
-			}
-			else if (e.MaximumProgress == 0 || e.MaximumProgress < e.CurrentProgress)
+			if (e.CurrentProgress == -1)
+				return;
+			if (e.MaximumProgress == 0 || e.MaximumProgress < e.CurrentProgress)
 				loadProgress = 1;
 			else
 				loadProgress = (double)e.CurrentProgress / (double)e.MaximumProgress;
@@ -239,7 +239,7 @@ namespace Xwt.Gtk.Windows
 
 		SWF.HtmlDocument currentDocument;
 
-		void HandleLoaded (object sender, EventArgs e)
+		void HandleDocumentCompleted (object sender, SWF.WebBrowserDocumentCompletedEventArgs e)
 		{
 			if (currentDocument != view.Document) {
 				if (currentDocument != null)

--- a/Xwt.Gtk.Windows/Win32.cs
+++ b/Xwt.Gtk.Windows/Win32.cs
@@ -22,6 +22,12 @@ using System.Runtime.InteropServices;
 
 namespace Xwt.Gtk.Windows
 {
+	enum HResult
+	{
+		S_OK = 0x00000000,
+		S_FALSE = 0x00000001,
+	}
+
 	public static class Win32
 	{
 		[StructLayout (LayoutKind.Sequential, CharSet = CharSet.Auto)]

--- a/Xwt.Gtk.Windows/Xwt.Gtk.Windows.csproj
+++ b/Xwt.Gtk.Windows/Xwt.Gtk.Windows.csproj
@@ -44,6 +44,9 @@
     <Compile Include="Win32.cs" />
     <Compile Include="WindowsPlatformBackend.cs" />
     <Compile Include="WebViewBackend.cs" />
+    <Compile Include="..\Xwt.WPF\Xwt.WPFBackend.Interop\IDocHostUIHandler.cs">
+      <Link>IDocHostUIHandler.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWebKitMini.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWebKitMini.cs
@@ -216,6 +216,16 @@ namespace Xwt.GtkBackend.WebKit
 			}
 		}
 
+		[GLib.Signal ("context-menu")]
+		public event EventHandler<ContextMenuArgs> ContextMenu {
+			add {
+				this.AddSignalHandler ("context-menu", value, typeof (ContextMenuArgs));
+			}
+			remove {
+				this.RemoveSignalHandler ("context-menu", value);
+			}
+		}
+
 		static WebView ()
 		{
 			Initialize ();
@@ -378,6 +388,30 @@ namespace Xwt.GtkBackend.WebKit
 		{
 			get {
 				return (string)Args [1];
+			}
+		}
+	}
+
+	public class ContextMenuArgs : GLib.SignalArgs
+	{
+		public Gtk.Widget DefaultMenu {
+			get {
+				return Args [0] as Gtk.Widget;
+			}
+			set {
+				Args [0] = value;
+			}
+		}
+
+		public GLib.Object HitTestResult {
+			get {
+				return Args [1] as GLib.Object;
+			}
+		}
+
+		public bool TriggeredWithKeyboard {
+			get {
+				return (bool)Args [2];
 			}
 		}
 	}

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWebKitMini.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWebKitMini.cs
@@ -75,6 +75,20 @@ namespace Xwt.GtkBackend.WebKit
 			}
 		}
 
+		[GLib.Property ("self-scrolling")]
+		public bool SelfScrolling {
+			get {
+				using (GLib.Value property = GetProperty ("self-scrolling")) {
+					return (bool) property.Val;
+				}
+			}
+			set {
+				using (GLib.Value val = new GLib.Value (value)) {
+					SetProperty ("self-scrolling", val);
+				}
+			}
+		}
+
 		#if XWT_GTK3 // Gtk.IScrollable
 		[GLib.Property ("hadjustment")]
 		public Gtk.Adjustment Hadjustment {
@@ -89,6 +103,7 @@ namespace Xwt.GtkBackend.WebKit
 				}
 			}
 		}
+
 		[GLib.Property ("vadjustment")]
 		public Gtk.Adjustment Vadjustment {
 			get {

--- a/Xwt.Gtk/Xwt.GtkBackend/WebViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WebViewBackend.cs
@@ -82,6 +82,8 @@ namespace Xwt.GtkBackend
 
 		public bool ContextMenuEnabled { get; set; }
 
+		public string CustomCss { get; set; }
+
 		public void GoBack ()
 		{
 			view.GoBack ();

--- a/Xwt.Gtk/Xwt.GtkBackend/WebViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WebViewBackend.cs
@@ -44,6 +44,7 @@ namespace Xwt.GtkBackend
 			base.Initialize ();
 
 			view = new WebKit.WebView ();
+			view.ContextMenu += HandleContextMenuRequest;
 			Widget = view;
 			Widget.Show ();
 		}
@@ -78,6 +79,8 @@ namespace Xwt.GtkBackend
 				return view.CanGoForward ();
 			}
 		}
+
+		public bool ContextMenuEnabled { get; set; }
 
 		public void GoBack ()
 		{
@@ -161,6 +164,11 @@ namespace Xwt.GtkBackend
 			ApplicationContext.InvokeUserCode (delegate {
 				EventSink.OnTitleChanged ();
 			});
+		}
+
+		void HandleContextMenuRequest (object sender, ContextMenuArgs e)
+		{
+			e.RetVal = !ContextMenuEnabled;
 		}
 	}
 }

--- a/Xwt.Gtk/Xwt.GtkBackend/WebViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WebViewBackend.cs
@@ -82,6 +82,15 @@ namespace Xwt.GtkBackend
 
 		public bool ContextMenuEnabled { get; set; }
 
+		public bool ScrollBarsEnabled {
+			get {
+				return view.SelfScrolling;
+			}
+			set {
+				view.SelfScrolling = value;
+			}
+		}
+
 		public string CustomCss { get; set; }
 
 		public void GoBack ()

--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Xwt.WPFBackend\WebViewBackend.cs" />
     <Compile Include="Xwt.WPFBackend\ScrollControlBackend.cs" />
     <Compile Include="Xwt.WPFBackend\CalendarBackend.cs" />
+    <Compile Include="Xwt.WPFBackend.Interop\IDocHostUIHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Xwt.WPF/Xwt.WPFBackend.Interop/IDocHostUIHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Interop/IDocHostUIHandler.cs
@@ -1,0 +1,160 @@
+﻿//
+// IDocHostUIHandler.cs
+//
+// Author:
+//       Vsevolod Kukol <sevo@sevo.org>
+//
+// Copyright (c) 2016 (c) Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Xwt.NativeMSHTML
+{
+	enum DOCHOSTUIDBLCLK
+	{
+		DOCHOSTUIDBLCLK_DEFAULT = 0,
+		DOCHOSTUIDBLCLK_SHOWPROPERTIES = 1,
+		DOCHOSTUIDBLCLK_SHOWCODE = 2
+	}
+
+	[Flags]
+	enum DOCHOSTUIFLAG
+	{
+		DOCHOSTUIFLAG_DIALOG = 0x00000001,
+		DOCHOSTUIFLAG_DISABLE_HELP_MENU = 0x00000002,
+		DOCHOSTUIFLAG_NO3DBORDER = 0x00000004,
+		DOCHOSTUIFLAG_SCROLL_NO = 0x00000008,
+		DOCHOSTUIFLAG_DISABLE_SCRIPT_INACTIVE = 0x00000010,
+		DOCHOSTUIFLAG_OPENNEWWIN = 0x00000020,
+		DOCHOSTUIFLAG_DISABLE_OFFSCREEN = 0x00000040,
+		DOCHOSTUIFLAG_FLAT_SCROLLBAR = 0x00000080,
+		DOCHOSTUIFLAG_DIV_BLOCKDEFAULT = 0x00000100,
+		DOCHOSTUIFLAG_ACTIVATE_CLIENTHIT_ONLY = 0x00000200,
+		DOCHOSTUIFLAG_OVERRIDEBEHAVIORFACTORY = 0x00000400,
+		DOCHOSTUIFLAG_CODEPAGELINKEDFONTS = 0x00000800,
+		DOCHOSTUIFLAG_URL_ENCODING_DISABLE_UTF8 = 0x00001000,
+		DOCHOSTUIFLAG_URL_ENCODING_ENABLE_UTF8 = 0x00002000,
+		DOCHOSTUIFLAG_ENABLE_FORMS_AUTOCOMPLETE = 0x00004000,
+		DOCHOSTUIFLAG_ENABLE_INPLACE_NAVIGATION = 0x00010000,
+		DOCHOSTUIFLAG_IME_ENABLE_RECONVERSION = 0x00020000,
+		DOCHOSTUIFLAG_THEME = 0x00040000,
+		DOCHOSTUIFLAG_NOTHEME = 0x00080000,
+		DOCHOSTUIFLAG_NOPICS = 0x00100000,
+		DOCHOSTUIFLAG_NO3DOUTERBORDER = 0x00200000,
+		DOCHOSTUIFLAG_DISABLE_EDIT_NS_FIXUP = 0x400000,
+		DOCHOSTUIFLAG_LOCAL_MACHINE_ACCESS_CHECK = 0x800000,
+		DOCHOSTUIFLAG_DISABLE_UNTRUSTEDPROTOCOL = 0x1000000
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	struct DOCHOSTUIINFO
+	{
+		public int cbSize;
+		public int dwFlags;
+		public int dwDoubleClick;
+		[MarshalAs(UnmanagedType.BStr)]
+		public string pchHostCss;
+		[MarshalAs(UnmanagedType.BStr)]
+		public string pchHostNS;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	struct LPMSG
+	{
+		public IntPtr hwnd;
+		public uint message;
+		public uint wParam;
+		public int lParam;
+		public uint time;
+		public tagPOINT pt;
+	}
+
+	[StructLayout(LayoutKind.Sequential, Pack = 4)]
+	struct LPCRECT
+	{
+		public int left;
+		public int top;
+		public int right;
+		public int bottom;
+	}
+
+	[StructLayout(LayoutKind.Sequential, Pack = 4)]
+	struct tagPOINT
+	{
+		public int x;
+		public int y;
+	}
+
+	[ComImport, Guid("3050F3F0-98B5-11CF-BB82-00AA00BDCE0B"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	interface ICustomDoc
+	{
+		[PreserveSig]
+		int SetUIHandler (IDocHostUIHandler pUIHandler);
+	}
+
+	[ComImport, Guid("BD3F23C0-D43E-11CF-893B-00AA00BDCE1A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	interface IDocHostUIHandler
+	{
+		[PreserveSig]
+		int ShowContextMenu(
+			int dwID,
+			ref tagPOINT ppt,
+			[MarshalAs(UnmanagedType.IUnknown)]  object pcmdtReserved,
+			[MarshalAs(UnmanagedType.IDispatch)] object pdispReserved
+		);
+
+		void GetHostInfo (ref DOCHOSTUIINFO pInfo);
+
+		void ShowUI (int dwID, ref object pActiveObject, ref object pCommandTarget, ref object pFrame, ref object pDoc);
+
+		void HideUI ();
+
+		void UpdateUI ();
+
+		void EnableModeless ([In, MarshalAs(UnmanagedType.Bool)] bool fEnable);
+
+		void OnDocWindowActivate ([In, MarshalAs(UnmanagedType.Bool)] bool fActivate);
+
+		void OnFrameWindowActivate ([In, MarshalAs(UnmanagedType.Bool)] bool fActivate);
+
+		void ResizeBorder (ref LPCRECT prcBorder, object pUIWindow, [In, MarshalAs(UnmanagedType.Bool)] bool fFrameWindow);
+
+		[PreserveSig]
+		int TranslateAccelerator (ref LPMSG lpMsg, ref Guid pguidCmdGroup, uint nCmdID);
+
+		void GetOptionKeyPath ([MarshalAs(UnmanagedType.BStr)] ref string pchKey, uint dw);
+
+		[PreserveSig]
+		int GetDropTarget (int pDropTarget, ref int ppDropTarget);
+
+		void GetExternal ([MarshalAs(UnmanagedType.IDispatch)] out object ppDispatch);
+
+		[PreserveSig]
+		int TranslateUrl (
+			uint dwTranslate,
+			[MarshalAs(UnmanagedType.BStr)] string pchURLIn,
+			[MarshalAs(UnmanagedType.BStr)] ref string ppchURLOut
+		);
+
+		IDataObject FilterDataObject (IDataObject pDO);
+	}
+}

--- a/Xwt.WPF/Xwt.WPFBackend.Interop/IDocHostUIHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Interop/IDocHostUIHandler.cs
@@ -60,15 +60,21 @@ namespace Xwt.NativeMSHTML
 		DOCHOSTUIFLAG_NOTHEME = 0x00080000,
 		DOCHOSTUIFLAG_NOPICS = 0x00100000,
 		DOCHOSTUIFLAG_NO3DOUTERBORDER = 0x00200000,
-		DOCHOSTUIFLAG_DISABLE_EDIT_NS_FIXUP = 0x400000,
-		DOCHOSTUIFLAG_LOCAL_MACHINE_ACCESS_CHECK = 0x800000,
-		DOCHOSTUIFLAG_DISABLE_UNTRUSTEDPROTOCOL = 0x1000000
+		DOCHOSTUIFLAG_DISABLE_EDIT_NS_FIXUP = 0x00400000,
+		DOCHOSTUIFLAG_LOCAL_MACHINE_ACCESS_CHECK = 0x00800000,
+		DOCHOSTUIFLAG_DISABLE_UNTRUSTEDPROTOCOL = 0x01000000,
+		DOCHOSTUIFLAG_HOST_NAVIGATES = 0x02000000,
+		DOCHOSTUIFLAG_ENABLE_REDIRECT_NOTIFICATION = 0x04000000,
+		DOCHOSTUIFLAG_USE_WINDOWLESS_SELECTCONTROL = 0x08000000,
+		DOCHOSTUIFLAG_USE_WINDOWED_SELECTCONTROL = 0x10000000,
+		DOCHOSTUIFLAG_ENABLE_ACTIVEX_INACTIVATE_MODE = 0x20000000,
+		DOCHOSTUIFLAG_DPI_AWARE = 0x40000000
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
 	struct DOCHOSTUIINFO
 	{
-		public int cbSize;
+		public UIntPtr cbSize;
 		public int dwFlags;
 		public int dwDoubleClick;
 		[MarshalAs(UnmanagedType.BStr)]
@@ -78,30 +84,30 @@ namespace Xwt.NativeMSHTML
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
-	struct LPMSG
+	struct MSG
 	{
 		public IntPtr hwnd;
 		public uint message;
-		public uint wParam;
-		public int lParam;
+		public UIntPtr wParam;
+		public IntPtr lParam;
 		public uint time;
-		public tagPOINT pt;
+		public POINT pt;
 	}
 
-	[StructLayout(LayoutKind.Sequential, Pack = 4)]
-	struct LPCRECT
+	[StructLayout(LayoutKind.Sequential)]
+	struct RECT
 	{
-		public int left;
-		public int top;
-		public int right;
-		public int bottom;
+		public IntPtr left;
+		public IntPtr top;
+		public IntPtr right;
+		public IntPtr bottom;
 	}
 
-	[StructLayout(LayoutKind.Sequential, Pack = 4)]
-	struct tagPOINT
+	[StructLayout(LayoutKind.Sequential)]
+	struct POINT
 	{
-		public int x;
-		public int y;
+		public IntPtr x;
+		public IntPtr y;
 	}
 
 	[ComImport, Guid("3050F3F0-98B5-11CF-BB82-00AA00BDCE0B"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
@@ -116,15 +122,15 @@ namespace Xwt.NativeMSHTML
 	{
 		[PreserveSig]
 		int ShowContextMenu(
-			int dwID,
-			ref tagPOINT ppt,
+			uint dwID,
+			ref POINT ppt,
 			[MarshalAs(UnmanagedType.IUnknown)]  object pcmdtReserved,
 			[MarshalAs(UnmanagedType.IDispatch)] object pdispReserved
 		);
 
 		void GetHostInfo (ref DOCHOSTUIINFO pInfo);
 
-		void ShowUI (int dwID, ref object pActiveObject, ref object pCommandTarget, ref object pFrame, ref object pDoc);
+		void ShowUI (uint dwID, ref object pActiveObject, ref object pCommandTarget, ref object pFrame, ref object pDoc);
 
 		void HideUI ();
 
@@ -136,15 +142,18 @@ namespace Xwt.NativeMSHTML
 
 		void OnFrameWindowActivate ([In, MarshalAs(UnmanagedType.Bool)] bool fActivate);
 
-		void ResizeBorder (ref LPCRECT prcBorder, object pUIWindow, [In, MarshalAs(UnmanagedType.Bool)] bool fFrameWindow);
+		void ResizeBorder (ref RECT prcBorder, object pUIWindow, [In, MarshalAs(UnmanagedType.Bool)] bool fFrameWindow);
 
 		[PreserveSig]
-		int TranslateAccelerator (ref LPMSG lpMsg, ref Guid pguidCmdGroup, uint nCmdID);
+		int TranslateAccelerator (ref MSG lpMsg, ref Guid pguidCmdGroup, uint nCmdID);
 
 		void GetOptionKeyPath ([MarshalAs(UnmanagedType.BStr)] ref string pchKey, uint dw);
 
 		[PreserveSig]
-		int GetDropTarget (int pDropTarget, ref int ppDropTarget);
+		int GetDropTarget (
+			[In, MarshalAs(UnmanagedType.Interface)] object pDropTarget,
+			[Out, MarshalAs(UnmanagedType.Interface)] out object ppDropTarget
+		);
 
 		void GetExternal ([MarshalAs(UnmanagedType.IDispatch)] out object ppDispatch);
 

--- a/Xwt.WPF/Xwt.WPFBackend.Interop/IDocHostUIHandler.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Interop/IDocHostUIHandler.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices.ComTypes;
 
 namespace Xwt.NativeMSHTML
 {
-	enum DOCHOSTUIDBLCLK
+	enum DOCHOSTUIDBLCLK : uint
 	{
 		DOCHOSTUIDBLCLK_DEFAULT = 0,
 		DOCHOSTUIDBLCLK_SHOWPROPERTIES = 1,
@@ -37,7 +37,7 @@ namespace Xwt.NativeMSHTML
 	}
 
 	[Flags]
-	enum DOCHOSTUIFLAG
+	enum DOCHOSTUIFLAG : uint
 	{
 		DOCHOSTUIFLAG_DIALOG = 0x00000001,
 		DOCHOSTUIFLAG_DISABLE_HELP_MENU = 0x00000002,
@@ -71,19 +71,38 @@ namespace Xwt.NativeMSHTML
 		DOCHOSTUIFLAG_DPI_AWARE = 0x40000000
 	}
 
-	[StructLayout(LayoutKind.Sequential)]
+	enum DOCHOSTUICONTEXTMENU : uint
+	{
+		CONTEXT_MENU_DEFAULT = 0,
+		CONTEXT_MENU_IMAGE = 1,
+		CONTEXT_MENU_CONTROL = 2,
+		CONTEXT_MENU_TABLE = 3,
+		CONTEXT_MENU_TEXTSELECT = 4,
+		CONTEXT_MENU_ANCHOR = 5,
+		CONTEXT_MENU_UNKNOWN = 6,
+		CONTEXT_MENU_IMGDYNSRC = 7,
+		CONTEXT_MENU_DEBUG = 8,
+		CONTEXT_MENU_VSCROLL = 9,
+		CONTEXT_MENU_HSCROLL = 10,
+		CONTEXT_MENU_MEDIA = 11
+	}
+
+	[StructLayout (LayoutKind.Sequential)]
 	struct DOCHOSTUIINFO
 	{
-		public UIntPtr cbSize;
-		public int dwFlags;
-		public int dwDoubleClick;
-		[MarshalAs(UnmanagedType.BStr)]
+		[MarshalAs (UnmanagedType.U4)]
+		public uint cbSize;
+		[MarshalAs (UnmanagedType.U4)]
+		public DOCHOSTUIFLAG dwFlags;
+		[MarshalAs (UnmanagedType.U4)]
+		public DOCHOSTUIDBLCLK dwDoubleClick;
+		[MarshalAs (UnmanagedType.LPWStr)]
 		public string pchHostCss;
-		[MarshalAs(UnmanagedType.BStr)]
+		[MarshalAs (UnmanagedType.LPWStr)]
 		public string pchHostNS;
 	}
 
-	[StructLayout(LayoutKind.Sequential)]
+	[StructLayout (LayoutKind.Sequential)]
 	struct MSG
 	{
 		public IntPtr hwnd;
@@ -94,7 +113,7 @@ namespace Xwt.NativeMSHTML
 		public POINT pt;
 	}
 
-	[StructLayout(LayoutKind.Sequential)]
+	[StructLayout (LayoutKind.Sequential)]
 	struct RECT
 	{
 		public IntPtr left;
@@ -103,28 +122,29 @@ namespace Xwt.NativeMSHTML
 		public IntPtr bottom;
 	}
 
-	[StructLayout(LayoutKind.Sequential)]
+	[StructLayout (LayoutKind.Sequential)]
 	struct POINT
 	{
 		public IntPtr x;
 		public IntPtr y;
 	}
 
-	[ComImport, Guid("3050F3F0-98B5-11CF-BB82-00AA00BDCE0B"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	[ComImport, Guid ("3050F3F0-98B5-11CF-BB82-00AA00BDCE0B"), InterfaceType (ComInterfaceType.InterfaceIsIUnknown)]
 	interface ICustomDoc
 	{
 		[PreserveSig]
 		int SetUIHandler (IDocHostUIHandler pUIHandler);
 	}
 
-	[ComImport, Guid("BD3F23C0-D43E-11CF-893B-00AA00BDCE1A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	[ComImport, Guid ("BD3F23C0-D43E-11CF-893B-00AA00BDCE1A"), InterfaceType (ComInterfaceType.InterfaceIsIUnknown)]
 	interface IDocHostUIHandler
 	{
 		[PreserveSig]
-		int ShowContextMenu(
-			uint dwID,
+		[return: MarshalAs(UnmanagedType.Error)]
+		int ShowContextMenu (
+			[MarshalAs(UnmanagedType.U4)] DOCHOSTUICONTEXTMENU dwID,
 			ref POINT ppt,
-			[MarshalAs(UnmanagedType.IUnknown)]  object pcmdtReserved,
+			[MarshalAs(UnmanagedType.IUnknown)] object pcmdtReserved,
 			[MarshalAs(UnmanagedType.IDispatch)] object pdispReserved
 		);
 
@@ -142,28 +162,33 @@ namespace Xwt.NativeMSHTML
 
 		void OnFrameWindowActivate ([In, MarshalAs(UnmanagedType.Bool)] bool fActivate);
 
-		void ResizeBorder (ref RECT prcBorder, object pUIWindow, [In, MarshalAs(UnmanagedType.Bool)] bool fFrameWindow);
+		void ResizeBorder (ref RECT prcBorder, object pUIWindow, [In, MarshalAs (UnmanagedType.Bool)] bool fFrameWindow);
 
 		[PreserveSig]
+		[return: MarshalAs (UnmanagedType.Error)]
 		int TranslateAccelerator (ref MSG lpMsg, ref Guid pguidCmdGroup, uint nCmdID);
 
-		void GetOptionKeyPath ([MarshalAs(UnmanagedType.BStr)] ref string pchKey, uint dw);
+		void GetOptionKeyPath ([MarshalAs(UnmanagedType.BStr)] out string pchKey, uint dw);
 
 		[PreserveSig]
+		[return: MarshalAs (UnmanagedType.Error)]
 		int GetDropTarget (
-			[In, MarshalAs(UnmanagedType.Interface)] object pDropTarget,
-			[Out, MarshalAs(UnmanagedType.Interface)] out object ppDropTarget
+			[In, MarshalAs (UnmanagedType.Interface)] object pDropTarget,
+			[Out, MarshalAs (UnmanagedType.Interface)] out object ppDropTarget
 		);
 
-		void GetExternal ([MarshalAs(UnmanagedType.IDispatch)] out object ppDispatch);
+		void GetExternal ([MarshalAs (UnmanagedType.IDispatch)] out object ppDispatch);
 
 		[PreserveSig]
+		[return: MarshalAs (UnmanagedType.Error)]
 		int TranslateUrl (
 			uint dwTranslate,
-			[MarshalAs(UnmanagedType.BStr)] string pchURLIn,
-			[MarshalAs(UnmanagedType.BStr)] ref string ppchURLOut
+			[MarshalAs (UnmanagedType.BStr)] string pchURLIn,
+			[MarshalAs (UnmanagedType.BStr)] out string ppchURLOut
 		);
 
-		IDataObject FilterDataObject (IDataObject pDO);
+		[PreserveSig]
+		[return: MarshalAs (UnmanagedType.Error)]
+		int FilterDataObject (IDataObject pDO, out IDataObject pDOppDORet);
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend.Interop/NativeMethods.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Interop/NativeMethods.cs
@@ -32,6 +32,12 @@ using System.Windows.Media.Imaging;
 
 namespace Xwt.WPFBackend.Interop
 {
+	enum HResult
+	{
+		S_OK = 0x00000000,
+		S_FALSE = 0x00000001,
+	}
+
 	internal static class NativeMethods
 	{
 		[StructLayout (LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
@@ -85,6 +85,8 @@ namespace Xwt.WPFBackend
 
 		public bool ContextMenuEnabled { get; set; }
 
+		public bool ScrollBarsEnabled { get; set; }
+
 		public string CustomCss
 		{
 			get

--- a/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
@@ -40,6 +40,7 @@ namespace Xwt.WPFBackend
 		string url;
 		SWC.WebBrowser view;
 		bool enableNavigatingEvent, enableLoadingEvent, enableLoadedEvent, enableTitleChangedEvent;
+		bool initialized;
 
 		ICustomDoc currentDocument;
 		static object mshtmlBrowser;
@@ -81,6 +82,15 @@ namespace Xwt.WPFBackend
 					currentDocument.SetUIHandler(null);
 				currentDocument = doc;
 			}
+
+			// on initialization we load "about:blank" to initialize the document,
+			// in that case we load the requested url
+			if (currentDocument != null && !initialized)
+			{
+				initialized = true;
+				if (!string.IsNullOrEmpty (url))
+					view.Navigate(url);
+			}
 		}
 
 		void HandleViewLoaded(object sender, System.Windows.RoutedEventArgs e)
@@ -98,18 +108,24 @@ namespace Xwt.WPFBackend
 			if (stopMethod == null)
 				stopMethod = mshtmlBrowserField?.FieldType?.GetMethod("Stop");
 
-			if (!string.IsNullOrEmpty(url))
+			// load requested url if the view is still not initialized
+			// otherwise it would already have been loaded
+			if (!initialized && !string.IsNullOrEmpty(url))
+			{
+				initialized = true;
 				view.Navigate(url);
+			}
 
 			DisableJsErrors();
 			UpdateDocumentRef();
 		}
 
 		public string Url {
-			get { return url; }
+			get {
+				return url; }
 			set {
 				url = value;
-				if (view.IsLoaded)
+				if (initialized && view.IsLoaded)
 					view.Navigate(url);
 			}
 		}

--- a/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
@@ -303,7 +303,7 @@ namespace Xwt.WPFBackend
 
 		#region IDocHostUIHandler implementation
 
-		int IDocHostUIHandler.ShowContextMenu(uint dwID, ref POINT ppt, object pcmdtReserved, object pdispReserved)
+		int IDocHostUIHandler.ShowContextMenu(DOCHOSTUICONTEXTMENU dwID, ref POINT ppt, object pcmdtReserved, object pdispReserved)
 		{
 			return (int)(ContextMenuEnabled ? HResult.S_FALSE : HResult.S_OK);
 		}
@@ -311,9 +311,7 @@ namespace Xwt.WPFBackend
 		void IDocHostUIHandler.GetHostInfo(ref DOCHOSTUIINFO pInfo)
 		{
 			if (!ScrollBarsEnabled)
-				pInfo.dwFlags = (int)(DOCHOSTUIFLAG.DOCHOSTUIFLAG_SCROLL_NO | DOCHOSTUIFLAG.DOCHOSTUIFLAG_NO3DOUTERBORDER);
-			else
-				pInfo.dwFlags = 0;
+				pInfo.dwFlags = DOCHOSTUIFLAG.DOCHOSTUIFLAG_SCROLL_NO | DOCHOSTUIFLAG.DOCHOSTUIFLAG_NO3DOUTERBORDER;
 			if (!string.IsNullOrEmpty(CustomCss))
 				pInfo.pchHostCss = CustomCss;
 		}
@@ -358,8 +356,9 @@ namespace Xwt.WPFBackend
 			return (int)HResult.S_FALSE;
 		}
 
-		void IDocHostUIHandler.GetOptionKeyPath(ref string pchKey, uint dw)
+		void IDocHostUIHandler.GetOptionKeyPath(out string pchKey, uint dw)
 		{
+			pchKey = null;
 		}
 
 		int IDocHostUIHandler.GetDropTarget(object pDropTarget, out object ppDropTarget)
@@ -370,21 +369,21 @@ namespace Xwt.WPFBackend
 
 		void IDocHostUIHandler.GetExternal(out object ppDispatch)
 		{
-			throw new NotImplementedException();
+			ppDispatch = null;
 		}
 
-		int IDocHostUIHandler.TranslateUrl(uint dwTranslate, string pchURLIn, ref string ppchURLOut)
+		int IDocHostUIHandler.TranslateUrl(uint dwTranslate, string pchURLIn, out string ppchURLOut)
 		{
+			ppchURLOut = pchURLIn;
 			return (int)HResult.S_FALSE;
 		}
-
-		IDataObject IDocHostUIHandler.FilterDataObject(IDataObject pDO)
+		int IDocHostUIHandler.FilterDataObject(IDataObject pDO, out IDataObject ppDORet)
 		{
-			throw new NotImplementedException();
+			ppDORet = null;
+			return (int)HResult.S_FALSE;
 		}
 
 		#endregion
 	}
-
 }
 

--- a/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
@@ -82,6 +82,8 @@ namespace Xwt.WPFBackend
 
 		public bool ContextMenuEnabled { get; set; }
 
+		public string CustomCss { get; set; }
+
 		public void GoBack ()
 		{
 			view.GoBack ();

--- a/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WebViewBackend.cs
@@ -287,7 +287,7 @@ namespace Xwt.WPFBackend
 
 		#region IDocHostUIHandler implementation
 
-		int IDocHostUIHandler.ShowContextMenu(int dwID, ref tagPOINT ppt, object pcmdtReserved, object pdispReserved)
+		int IDocHostUIHandler.ShowContextMenu(uint dwID, ref POINT ppt, object pcmdtReserved, object pdispReserved)
 		{
 			return (int)(ContextMenuEnabled ? HResult.S_FALSE : HResult.S_OK);
 		}
@@ -302,7 +302,7 @@ namespace Xwt.WPFBackend
 				pInfo.pchHostCss = CustomCss;
 		}
 
-		void IDocHostUIHandler.ShowUI(int dwID, ref object pActiveObject, ref object pCommandTarget, ref object pFrame, ref object pDoc)
+		void IDocHostUIHandler.ShowUI(uint dwID, ref object pActiveObject, ref object pCommandTarget, ref object pFrame, ref object pDoc)
 		{
 		}
 
@@ -333,11 +333,11 @@ namespace Xwt.WPFBackend
 		{
 		}
 
-		void IDocHostUIHandler.ResizeBorder(ref LPCRECT prcBorder, object pUIWindow, bool fFrameWindow)
+		void IDocHostUIHandler.ResizeBorder(ref RECT prcBorder, object pUIWindow, bool fFrameWindow)
 		{
 		}
 
-		int IDocHostUIHandler.TranslateAccelerator(ref LPMSG lpMsg, ref Guid pguidCmdGroup, uint nCmdID)
+		int IDocHostUIHandler.TranslateAccelerator(ref MSG lpMsg, ref Guid pguidCmdGroup, uint nCmdID)
 		{
 			return (int)HResult.S_FALSE;
 		}
@@ -346,8 +346,9 @@ namespace Xwt.WPFBackend
 		{
 		}
 
-		int IDocHostUIHandler.GetDropTarget(int pDropTarget, ref int ppDropTarget)
+		int IDocHostUIHandler.GetDropTarget(object pDropTarget, out object ppDropTarget)
 		{
+			ppDropTarget = pDropTarget;
 			return (int)HResult.S_FALSE;
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/WebViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WebViewBackend.cs
@@ -97,6 +97,8 @@ namespace Xwt.Mac
 
 		public bool ContextMenuEnabled { get; set; }
 
+		public string CustomCss { get; set; }
+
 		public void GoBack ()
 		{
 			Widget.GoBack ();

--- a/Xwt.XamMac/Xwt.Mac/WebViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WebViewBackend.cs
@@ -179,7 +179,7 @@ namespace Xwt.Mac
 			if (eventId is WebViewEvent) {
 				switch ((WebViewEvent)eventId) {
 					case WebViewEvent.NavigateToUrl: Widget.StartedProvisionalLoad -= HandleStartedProvisionalLoad; break;
-					case WebViewEvent.Loading: Widget.CommitedLoad += HandleLoadStarted; break;
+					case WebViewEvent.Loading: Widget.CommitedLoad -= HandleLoadStarted; break;
 					case WebViewEvent.Loaded: Widget.FinishedLoad -= HandleLoadFinished; break;
 					case WebViewEvent.TitleChanged: Widget.ReceivedTitle -= HandleTitleChanged; break;
 				}

--- a/Xwt.XamMac/Xwt.Mac/WebViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WebViewBackend.cs
@@ -59,7 +59,9 @@ namespace Xwt.Mac
 		public override void Initialize()
 		{
 			base.Initialize ();
-			ViewObject = new MacWebView ();
+			ViewObject = new MacWebView {
+				UIDelegate = new XwtWebUIDelegate (this)
+			};
 		}
 
 		public string Url {
@@ -92,6 +94,8 @@ namespace Xwt.Mac
 				return Widget.CanGoForward ();
 			}
 		}
+
+		public bool ContextMenuEnabled { get; set; }
 
 		public void GoBack ()
 		{
@@ -193,6 +197,23 @@ namespace Xwt.Mac
 
 		public NSView View {
 			get { return this; }
+		}
+	}
+
+	class XwtWebUIDelegate : WebUIDelegate
+	{
+		readonly WebViewBackend backend;
+
+		public XwtWebUIDelegate (WebViewBackend backend)
+		{
+			this.backend = backend;
+		}
+
+		public override NSMenuItem [] UIGetContextMenuItems (WebKitView sender, NSDictionary forElement, NSMenuItem [] defaultMenuItems)
+		{
+			if (backend.ContextMenuEnabled)
+				return defaultMenuItems;
+			return null;
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac/WebViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WebViewBackend.cs
@@ -101,6 +101,15 @@ namespace Xwt.Mac
 
 		public bool ContextMenuEnabled { get; set; }
 
+		public bool ScrollBarsEnabled {
+			get {
+				return Widget.MainFrame.FrameView.AllowsScrolling;
+			}
+			set {
+				Widget.MainFrame.FrameView.AllowsScrolling = value;
+			}
+		}
+
 		public string CustomCss {
 			get {
 				return customCss;

--- a/Xwt/Xwt.Backends/IWebViewBackend.cs
+++ b/Xwt/Xwt.Backends/IWebViewBackend.cs
@@ -41,6 +41,7 @@ namespace Xwt.Backends
 		void StopLoading ();
 		void LoadHtml (string content, string base_uri);
 		bool ContextMenuEnabled { get; set; }
+		bool ScrollBarsEnabled { get; set; }
 		string CustomCss { get; set; }
 	}
 

--- a/Xwt/Xwt.Backends/IWebViewBackend.cs
+++ b/Xwt/Xwt.Backends/IWebViewBackend.cs
@@ -40,6 +40,7 @@ namespace Xwt.Backends
 		void Reload ();
 		void StopLoading ();
 		void LoadHtml (string content, string base_uri);
+		bool ContextMenuEnabled { get; set; }
 	}
 
 	public interface IWebViewEventSink : IWidgetEventSink

--- a/Xwt/Xwt.Backends/IWebViewBackend.cs
+++ b/Xwt/Xwt.Backends/IWebViewBackend.cs
@@ -41,6 +41,7 @@ namespace Xwt.Backends
 		void StopLoading ();
 		void LoadHtml (string content, string base_uri);
 		bool ContextMenuEnabled { get; set; }
+		string CustomCss { get; set; }
 	}
 
 	public interface IWebViewEventSink : IWidgetEventSink

--- a/Xwt/Xwt/WebView.cs
+++ b/Xwt/Xwt/WebView.cs
@@ -132,6 +132,12 @@ namespace Xwt
 			set { Backend.ContextMenuEnabled = value; }
 		}
 
+		[DefaultValue (null)]
+		public string CustomCss {
+			get { return Backend.CustomCss; }
+			set { Backend.CustomCss = value; }
+		}
+
 		public void GoBack ()
 		{
 			Backend.GoBack ();

--- a/Xwt/Xwt/WebView.cs
+++ b/Xwt/Xwt/WebView.cs
@@ -77,6 +77,7 @@ namespace Xwt
 		public WebView ()
 		{
 			ContextMenuEnabled = true;
+			ScrollBarsEnabled = true;
 		}
 
 		public WebView (string url)

--- a/Xwt/Xwt/WebView.cs
+++ b/Xwt/Xwt/WebView.cs
@@ -138,6 +138,20 @@ namespace Xwt
 			set { Backend.CustomCss = value; }
 		}
 
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="T:Xwt.WebView"/> has own scroll bars.
+		/// </summary>
+		/// <value><c>true</c> if the scroll bars are enabled; otherwise, <c>false</c>.</value>
+		/// <remarks>
+		/// By default all WebView backends support scrolling and don't need to be packed into a
+		/// ScrollView. Setting this to <c>false</c> will disable the internal scrolling feature.
+		/// </remarks>
+		[DefaultValue (true)]
+		public bool ScrollBarsEnabled {
+			get { return Backend.ScrollBarsEnabled; }
+			set { Backend.ScrollBarsEnabled = value; }
+		}
+
 		public void GoBack ()
 		{
 			Backend.GoBack ();

--- a/Xwt/Xwt/WebView.cs
+++ b/Xwt/Xwt/WebView.cs
@@ -76,6 +76,7 @@ namespace Xwt
 
 		public WebView ()
 		{
+			ContextMenuEnabled = true;
 		}
 
 		public WebView (string url)
@@ -123,6 +124,12 @@ namespace Xwt
 		[DefaultValue(false)]
 		public bool CanGoForward {
 			get { return Backend.CanGoForward; }
+		}
+
+		[DefaultValue (true)]
+		public bool ContextMenuEnabled {
+			get { return Backend.ContextMenuEnabled; }
+			set { Backend.ContextMenuEnabled = value; }
 		}
 
 		public void GoBack ()


### PR DESCRIPTION
This PR includes following changes to WebView:

* `ContextMenuEnabled` property: disables the context menu if set to `false`
* `CustomCss` property: injects custom CSS code into the loaded HTML page. **Gtk/Mac:** For now the the custom css code is simply added to the DOM at the beginning of the `head` section. **Windows:** Uses IDocHostUIHandler API. In the future it could inject the style using a special API without DOM modification if supported by the backend (already done on Windows, Linux: WebKitGtk2 supports this)
* `ScrollBarsEnabled` property: disables native WebView scrolling if set to `false` and supported by the backend (~~doesn't work with Wpf~~). This is enabled by default (like before) and disabling the native scrolling is very experimental.
* many small fixes on `Windows`