### PR TITLE
Extended dialog buttons

### DIFF
--- a/TestApps/Samples/Samples/Windows.cs
+++ b/TestApps/Samples/Samples/Windows.cs
@@ -73,6 +73,12 @@ namespace Samples
 				d.Buttons.Add (new DialogButton ("Custom OK", Command.Ok));
 				d.Buttons.Add (new DialogButton (Command.Cancel));
 				d.Buttons.Add (new DialogButton (Command.Ok));
+
+				d.CommandActivated += (sender, e) => {
+					if (e.Command == custom) {
+						e.Handled = !MessageDialog.Confirm ("Really close?", Command.Close);
+					}
+				};
 				
 				var r = d.Run (this.ParentWindow);
 				db.Label = "Result: " + (r != null ? r.Label : "(Closed)");

--- a/TestApps/Samples/Samples/Windows.cs
+++ b/TestApps/Samples/Samples/Windows.cs
@@ -74,6 +74,8 @@ namespace Samples
 				d.Buttons.Add (new DialogButton (Command.Cancel));
 				d.Buttons.Add (new DialogButton (Command.Ok));
 
+				d.DefaultCommand = custom;
+
 				d.CommandActivated += (sender, e) => {
 					if (e.Command == custom) {
 						e.Handled = !MessageDialog.Confirm ("Really close?", Command.Close);

--- a/Xwt.Gtk/Xwt.GtkBackend/DialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/DialogBackend.cs
@@ -64,7 +64,7 @@ namespace Xwt.GtkBackend
 					b.Destroy ();
 				}
 			}
-			dialogButtons = newButtons.ToArray ();
+			dialogButtons = newButtons.OrderBy (b => b.PackOrigin).ToArray ();
 			buttons = new Gtk.Button [dialogButtons.Length];
 			
 			for (int n=0; n<dialogButtons.Length; n++) {

--- a/Xwt.Gtk/Xwt.GtkBackend/DialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/DialogBackend.cs
@@ -34,6 +34,7 @@ namespace Xwt.GtkBackend
 	public class DialogBackend: WindowBackend, IDialogBackend
 	{
 		DialogButton[] dialogButtons;
+		DialogButton defaultButton;
 		Gtk.Button[] buttons;
 		
 		public DialogBackend ()
@@ -55,7 +56,17 @@ namespace Xwt.GtkBackend
 		new IDialogEventSink EventSink {
 			get { return (IDialogEventSink) base.EventSink; }
 		}
-		
+
+		public DialogButton DefaultButton {
+			get {
+				return defaultButton;
+			}
+			set {
+				defaultButton = value;
+				SetButtons (dialogButtons);
+			}
+		}
+
 		public void SetButtons (IEnumerable<DialogButton> newButtons)
 		{
 			if (buttons != null) {
@@ -64,7 +75,9 @@ namespace Xwt.GtkBackend
 					b.Destroy ();
 				}
 			}
-			dialogButtons = newButtons.OrderBy (b => b.PackOrigin).ToArray ();
+			dialogButtons = newButtons
+				.OrderBy (b => b.PackOrigin)
+				.OrderBy (b => b == DefaultButton).ToArray ();
 			buttons = new Gtk.Button [dialogButtons.Length];
 			
 			for (int n=0; n<dialogButtons.Length; n++) {
@@ -76,6 +89,10 @@ namespace Xwt.GtkBackend
 				UpdateButton (db, b);
 				buttons[n] = b;
 				buttons[n].Clicked += HandleButtonClicked;
+				if (db == DefaultButton) {
+					b.CanDefault = true;
+					b.GrabDefault ();
+				}
 			}
 			UpdateActionAreaVisibility ();
 		}

--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -115,7 +115,10 @@ namespace Xwt.Mac
 				};
 				button.MinWidth = 77; // Dialog buttons have a minimal width of 77px on Mac
 
-				buttonBox.PackEnd (button);
+				if (b.PackOrigin == PackOrigin.End)
+					buttonBox.PackEnd (button);
+				else
+					buttonBox.PackStart (button);
 				buttons [b] = button;
 				UpdateButton (b, button);
 			}

--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -54,9 +54,21 @@ namespace Xwt.Mac
 		Widget dialogChild;
 		Size minSize;
 		Dictionary<DialogButton,Button> buttons = new Dictionary<DialogButton, Button> ();
+		DialogButton defaultButton;
 		WidgetSpacing buttonBoxPadding = new WidgetSpacing (12, 6, 12, 12);
 
 		bool modalSessionRunning;
+
+		public DialogButton DefaultButton {
+			get {
+				return defaultButton;
+			}
+
+			set {
+				defaultButton = value;
+				SetButtons (buttons.Keys.ToArray ());
+			}
+		}
 
 		public DialogBackend ()
 		{
@@ -107,7 +119,7 @@ namespace Xwt.Mac
 		{
 			buttonBox.Clear ();
 
-			foreach (var b in buttonList.Reverse ()) {
+			foreach (var b in buttonList.OrderBy (b => b == DefaultButton).Reverse ()) {
 				var button = new Button { Font = Font.SystemFont };
 				var tb = b;
 				button.Clicked += delegate {
@@ -153,6 +165,10 @@ namespace Xwt.Mac
 			realButton.WidthRequest = -1;
 			var s = realButton.Surface.GetPreferredSize ();
 			realButton.WidthRequest = s.Width + 16;
+			if (b == defaultButton) {
+				var nativeButton = realButton.Surface.NativeWidget as NSButton;
+				nativeButton.Window.DefaultButtonCell = nativeButton.Cell;
+			}
 		}
 
 		public void RunLoop (IWindowFrameBackend parent)

--- a/Xwt/Xwt.Backends/IDialogBackend.cs
+++ b/Xwt/Xwt.Backends/IDialogBackend.cs
@@ -39,6 +39,8 @@ namespace Xwt.Backends
 		/// Called when the properties of a button have changed
 		/// </summary>
 		void UpdateButton (DialogButton btn);
+
+		DialogButton DefaultButton { get; set; }
 		
 		/// <summary>
 		/// Shows the dialog and starts running the gui loop. The method has to return when EndLoop is called.

--- a/Xwt/Xwt/Dialog.cs
+++ b/Xwt/Xwt/Dialog.cs
@@ -99,7 +99,11 @@ namespace Xwt
 		/// <param name="cmd">The command</param>
 		protected virtual void OnCommandActivated (Command cmd)
 		{
-			Respond (cmd);
+			var args = new DialogCommandActivatedEventArgs (cmd);
+			if (CommandActivated != null)
+				CommandActivated (this, args);
+			if (!args.Handled)
+				Respond (cmd);
 		}
 		
 		public Command Run ()
@@ -181,6 +185,8 @@ namespace Xwt
 		{
 			Backend.UpdateButton (btn);
 		}
+
+		public event EventHandler<DialogCommandActivatedEventArgs> CommandActivated;
 	}
 	
 	public class DialogButton
@@ -295,6 +301,18 @@ namespace Xwt
 		}
 		
 		public event EventHandler Clicked;
+	}
+
+	public class DialogCommandActivatedEventArgs : EventArgs
+	{
+		public Command Command { get; }
+
+		public bool Handled { get; set; }
+
+		public DialogCommandActivatedEventArgs (Command command)
+		{
+			Command = command;
+		}
 	}
 }
 

--- a/Xwt/Xwt/Dialog.cs
+++ b/Xwt/Xwt/Dialog.cs
@@ -186,6 +186,20 @@ namespace Xwt
 			Backend.UpdateButton (btn);
 		}
 
+		public Command DefaultCommand {
+			get {
+				return Backend.DefaultButton?.Command;
+			}
+			set {
+				var btn = Buttons.GetCommandButton (value);
+				if (btn == null) {
+					Buttons.Add (value);
+					btn = Buttons.GetCommandButton (value);
+				}
+				Backend.DefaultButton = btn;
+			}
+		}
+
 		public event EventHandler<DialogCommandActivatedEventArgs> CommandActivated;
 	}
 	

--- a/Xwt/Xwt/Dialog.cs
+++ b/Xwt/Xwt/Dialog.cs
@@ -190,6 +190,7 @@ namespace Xwt
 		Image image;
 		bool visible = true;
 		bool sensitive = true;
+		PackOrigin packOrigin = PackOrigin.End;
 		internal Dialog ParentDialog;
 		
 		public DialogButton (string label)
@@ -271,6 +272,16 @@ namespace Xwt
 			get { return sensitive; }
 			set {
 				sensitive = value;
+				if (ParentDialog != null) {
+					ParentDialog.UpdateButton (this);
+				}
+			}
+		}
+
+		public PackOrigin PackOrigin {
+			get { return packOrigin; }
+			set {
+				packOrigin = value;
 				if (ParentDialog != null) {
 					ParentDialog.UpdateButton (this);
 				}


### PR DESCRIPTION
This PR includes the following new Dialog Button features:

1. `DialogButton.PackOrigin` can be used to align buttons on the left side of the button area in a dialog (this is similar to Box packing)
2. `Dialog.CommandActivated` event can be subscribed to intercept command activation and to prevent a Dialog from responding (returning with the activated command from the loop) by setting the `Handled` property of the EventArgs object
3. `Dialog.DefaultCommand` can be set to make a command the default button of a dialog. It depends on the toolkit how the default command works (in most cases the default button is highlighted and will be activated when the user presses the `Return` key)