### PR TITLE
Markup support for RichTextView (+ some new features)

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
@@ -1350,96 +1350,112 @@ namespace Xwt.GtkBackend
 		{
 			tag = new Gtk.TextTag (name);
 			bool result = false;
-			Pango.Attribute attr;
 
-			if (iter.SafeGet (Pango.AttrType.Family, out attr)) {
-				tag.Family = ((Pango.AttrFamily)attr).Family;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Family)) {
+				if (attr != null) {
+					tag.Family = ((Pango.AttrFamily)attr).Family;
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Style, out attr)) {
-				tag.Style = ((Pango.AttrStyle)attr).Style;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Style)) {
+				if (attr != null) {
+					tag.Style = ((Pango.AttrStyle)attr).Style;
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Style, out attr)) {
-				tag.Style = ((Pango.AttrStyle)attr).Style;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Weight)) {
+				if (attr != null) {
+					tag.Weight = ((Pango.AttrWeight)attr).Weight;
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Weight, out attr)) {
-				tag.Weight = ((Pango.AttrWeight)attr).Weight;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Variant)) {
+				if (attr != null) {
+					tag.Variant = ((Pango.AttrVariant)attr).Variant;
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Variant, out attr)) {
-				tag.Variant = ((Pango.AttrVariant)attr).Variant;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Stretch)) {
+				if (attr != null) {
+					tag.Stretch = ((Pango.AttrStretch)attr).Stretch;
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Stretch, out attr)) {
-				tag.Stretch = ((Pango.AttrStretch)attr).Stretch;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.FontDesc)) {
+				if (attr != null) {
+					tag.FontDesc = ((Pango.AttrFontDesc)attr).Desc;
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.FontDesc, out attr)) {
-				tag.FontDesc = ((Pango.AttrFontDesc)attr).Desc;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Foreground)) {
+				if (attr != null) {
+					tag.Foreground = ((Gdk.PangoAttrEmbossColor)attr).Color.ToString ();
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Foreground, out attr)) {
-				tag.Foreground = ((Pango.AttrForeground)attr).Color.ToString ();
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Background)) {
+				if (attr != null) {
+					tag.Background = ((Gdk.PangoAttrEmbossColor)attr).Color.ToString ();
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Background, out attr)) {
-				tag.Background = ((Pango.AttrBackground)attr).Color.ToString ();
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Underline)) {
+				if (attr != null) {
+					tag.Underline = ((Pango.AttrUnderline)attr).Underline;
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Underline, out attr)) {
-				tag.Underline = ((Pango.AttrUnderline)attr).Underline;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Strikethrough)) {
+				if (attr != null) {
+					tag.Strikethrough = ((Pango.AttrStrikethrough)attr).Strikethrough;
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Strikethrough, out attr)) {
-				tag.Strikethrough = ((Pango.AttrStrikethrough)attr).Strikethrough;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Rise)) {
+				if (attr != null) {
+					tag.Rise = ((Pango.AttrRise)attr).Rise;
+					result = true;
+				}
 			}
 
-			if (iter.SafeGet (Pango.AttrType.Strikethrough, out attr)) {
-				tag.Strikethrough = ((Pango.AttrStrikethrough)attr).Strikethrough;
-				result = true;
-			}
-
-			if (iter.SafeGet (Pango.AttrType.Rise, out attr)) {
-				tag.Rise = ((Pango.AttrRise)attr).Rise;
-				result = true;
-			}
-
-			if (iter.SafeGet (Pango.AttrType.Scale, out attr)) {
-				tag.Scale = ((Pango.AttrScale)attr).Scale;
-				result = true;
+			using (var attr = iter.SafeGetCopy (Pango.AttrType.Scale)) {
+				if (attr != null) {
+					tag.Scale = ((Pango.AttrScale)attr).Scale;
+					result = true;
+				}
 			}
 
 			return result;
 		}
 
 		[DllImport (GtkInterop.LIBPANGO, CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr pango_attribute_copy (IntPtr raw);
+
+		[DllImport (GtkInterop.LIBPANGO, CallingConvention = CallingConvention.Cdecl)]
 		private static extern IntPtr pango_attr_iterator_get (IntPtr raw, int type);
 
-		public static bool SafeGet (this Pango.AttrIterator iter, Pango.AttrType type, out Pango.Attribute attr)
+		public static Pango.Attribute SafeGetCopy (this Pango.AttrIterator iter, Pango.AttrType type)
 		{
-			attr = null;
 			try {
 				IntPtr raw = pango_attr_iterator_get (iter.Handle, (int)type);
 				if (raw != IntPtr.Zero) {
-					attr = Pango.Attribute.GetAttribute (raw);
-					return true;
+					var copy = pango_attribute_copy (raw);
+					var attr = Pango.Attribute.GetAttribute (copy);
+					return attr;
 				} else
-					return false;
+					return null;
 			} catch {
-				return false;
+				return null;
 			}
 		}
 	}

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
@@ -1345,6 +1345,103 @@ namespace Xwt.GtkBackend
 			var strPtr = gtk_selection_data_get_uris (data.Handle);
 			return GLib.Marshaller.PtrToStringArrayGFree (strPtr);
 		}
+
+		public static bool GetTagForAttributes (this Pango.AttrIterator iter, string name, out Gtk.TextTag tag)
+		{
+			tag = new Gtk.TextTag (name);
+			bool result = false;
+			Pango.Attribute attr;
+
+			if (iter.SafeGet (Pango.AttrType.Family, out attr)) {
+				tag.Family = ((Pango.AttrFamily)attr).Family;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Style, out attr)) {
+				tag.Style = ((Pango.AttrStyle)attr).Style;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Style, out attr)) {
+				tag.Style = ((Pango.AttrStyle)attr).Style;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Weight, out attr)) {
+				tag.Weight = ((Pango.AttrWeight)attr).Weight;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Variant, out attr)) {
+				tag.Variant = ((Pango.AttrVariant)attr).Variant;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Stretch, out attr)) {
+				tag.Stretch = ((Pango.AttrStretch)attr).Stretch;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.FontDesc, out attr)) {
+				tag.FontDesc = ((Pango.AttrFontDesc)attr).Desc;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Foreground, out attr)) {
+				tag.Foreground = ((Pango.AttrForeground)attr).Color.ToString ();
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Background, out attr)) {
+				tag.Background = ((Pango.AttrBackground)attr).Color.ToString ();
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Underline, out attr)) {
+				tag.Underline = ((Pango.AttrUnderline)attr).Underline;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Strikethrough, out attr)) {
+				tag.Strikethrough = ((Pango.AttrStrikethrough)attr).Strikethrough;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Strikethrough, out attr)) {
+				tag.Strikethrough = ((Pango.AttrStrikethrough)attr).Strikethrough;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Rise, out attr)) {
+				tag.Rise = ((Pango.AttrRise)attr).Rise;
+				result = true;
+			}
+
+			if (iter.SafeGet (Pango.AttrType.Scale, out attr)) {
+				tag.Scale = ((Pango.AttrScale)attr).Scale;
+				result = true;
+			}
+
+			return result;
+		}
+
+		[DllImport (GtkInterop.LIBPANGO, CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr pango_attr_iterator_get (IntPtr raw, int type);
+
+		public static bool SafeGet (this Pango.AttrIterator iter, Pango.AttrType type, out Pango.Attribute attr)
+		{
+			attr = null;
+			try {
+				IntPtr raw = pango_attr_iterator_get (iter.Handle, (int)type);
+				if (raw != IntPtr.Zero) {
+					attr = Pango.Attribute.GetAttribute (raw);
+					return true;
+				} else
+					return false;
+			} catch {
+				return false;
+			}
+		}
 	}
 	
 	public struct KeyboardShortcut : IEquatable<KeyboardShortcut>

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkWorkarounds.cs
@@ -1395,14 +1395,22 @@ namespace Xwt.GtkBackend
 
 			using (var attr = iter.SafeGetCopy (Pango.AttrType.Foreground)) {
 				if (attr != null) {
+					#if XWT_GTK3
+					tag.Foreground = ((Pango.AttrForeground)attr).Color.ToString();
+					#else
 					tag.Foreground = ((Gdk.PangoAttrEmbossColor)attr).Color.ToString ();
+					#endif
 					result = true;
 				}
 			}
 
 			using (var attr = iter.SafeGetCopy (Pango.AttrType.Background)) {
 				if (attr != null) {
+				#if XWT_GTK3
+					tag.Foreground = ((Pango.AttrBackground)attr).Color.ToString();
+					#else
 					tag.Background = ((Gdk.PangoAttrEmbossColor)attr).Color.ToString ();
+					#endif
 					result = true;
 				}
 			}

--- a/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
@@ -349,6 +349,11 @@ namespace Xwt.GtkBackend
 			{
 				//FIXME
 			}
+
+			public void EmitText (FormattedText markup)
+			{
+				EmitText (markup.Text, RichTextInlineStyle.Normal);
+			}
 		}
 	}
 }

--- a/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
@@ -165,6 +165,15 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		public bool Selectable {
+			get {
+				return Widget.Sensitive;
+			}
+			set {
+				Widget.Sensitive = value;
+			}
+		}
+
 		void HandleNavigateToUrl (object sender, NavigateToUrlEventArgs e)
 		{
 			if (NavigateToUrlEnabled) {

--- a/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
@@ -184,6 +184,17 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		protected override void OnSetBackgroundColor(Drawing.Color color)
+		{
+			base.OnSetBackgroundColor(color);
+			Widget.SetBackgroundColor(Gtk.StateType.Normal, color);
+			Widget.SetBackgroundColor(Gtk.StateType.Insensitive, color);
+			#if !XWT_GTK3
+			Widget.ModifyBase(Gtk.StateType.Normal, color.ToGtkValue());
+			Widget.ModifyBase(Gtk.StateType.Insensitive, color.ToGtkValue());
+			#endif
+		}
+
 		void HandleNavigateToUrl (object sender, NavigateToUrlEventArgs e)
 		{
 			if (NavigateToUrlEnabled) {

--- a/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
@@ -386,7 +386,7 @@ namespace Xwt.GtkBackend
 					var indexer = new TextIndexer (markup.Text);
 					list.AddAttributes (indexer, markup.Attributes);
 	
-					var attrList = GLib.Opaque.GetOpaque (list.Handle, false) as Pango.AttrList;
+					var attrList = GLib.Opaque.GetOpaque (list.Handle, typeof(Pango.AttrList), false) as Pango.AttrList;
 					var iter = EndIter;
 					var mark = CreateMark (null, iter, false);
 					var attrIter = attrList.Iterator;

--- a/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
@@ -382,35 +382,36 @@ namespace Xwt.GtkBackend
 
 			public void EmitText (FormattedText markup)
 			{
-				var list = new FastPangoAttrList ();
-				var indexer = new TextIndexer (markup.Text);
-				list.AddAttributes (indexer, markup.Attributes);
-
-				var attrList = new Pango.AttrList (list.Handle);
-				var iter = EndIter;
-				var mark = CreateMark (null, iter, false);
-				var attrIter = attrList.Iterator;
-
-				do {
-					int start, end;
-
-					attrIter.Range (out start, out end);
-
-					if (end == int.MaxValue) // last chunk
-						end = markup.Text.Length - 1;
-					if (end <= start)
-						break;
-
-					Gtk.TextTag tag;
-					if (attrIter.GetTagForAttributes (null, out tag)) {
-						TagTable.Add (tag);
-						InsertWithTags (ref iter, markup.Text.Substring (start, end - start), tag);
-					} else
-						Insert (ref iter, markup.Text.Substring (start, end - start));
-
-					iter = GetIterAtMark (mark);
+				using (var list = new FastPangoAttrList ()) {
+					var indexer = new TextIndexer (markup.Text);
+					list.AddAttributes (indexer, markup.Attributes);
+	
+					var attrList = GLib.Opaque.GetOpaque (list.Handle, false) as Pango.AttrList;
+					var iter = EndIter;
+					var mark = CreateMark (null, iter, false);
+					var attrIter = attrList.Iterator;
+	
+					do {
+						int start, end;
+	
+						attrIter.Range (out start, out end);
+	
+						if (end == int.MaxValue) // last chunk
+							end = markup.Text.Length - 1;
+						if (end <= start)
+							break;
+	
+						Gtk.TextTag tag;
+						if (attrIter.GetTagForAttributes (null, out tag)) {
+							TagTable.Add (tag);
+							InsertWithTags (ref iter, markup.Text.Substring (start, end - start), tag);
+						} else
+							Insert (ref iter, markup.Text.Substring (start, end - start));
+	
+						iter = GetIterAtMark (mark);
+					}
+					while (attrIter.Next ());
 				}
-				while (attrIter.Next ());
 			}
 		}
 	}

--- a/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
@@ -174,6 +174,16 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		public int LineSpacing {
+			get {
+				return Widget.PixelsInsideWrap;
+			}
+			set {
+				Widget.PixelsInsideWrap = value;
+				Widget.PixelsBelowLines = value;
+			}
+		}
+
 		void HandleNavigateToUrl (object sender, NavigateToUrlEventArgs e)
 		{
 			if (NavigateToUrlEnabled) {

--- a/Xwt.WPF/Xwt.WPFBackend/ExRichTextBox.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExRichTextBox.cs
@@ -23,16 +23,18 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 
 namespace Xwt.WPFBackend.Utilities
 {
 	public class ExRichTextBox : RichTextBox, IWpfWidget
 	{
+		Style paragraphStyle;
+		int lineSpacing;
+
 		public WidgetBackend Backend {
 			get; set;
 		}
@@ -41,6 +43,31 @@ namespace Xwt.WPFBackend.Utilities
 		{
 			var s = base.MeasureOverride (constraint);
 			return Backend.MeasureOverride (constraint, s);
+		}
+
+		public int LineSpacing {
+			get {
+				return lineSpacing;
+			}
+
+			set {
+				lineSpacing = value;
+				UpdateParagraphStyle ();
+			}
+		}
+
+		void UpdateParagraphStyle ()
+		{
+			if (paragraphStyle != null) {
+				Resources.Remove (typeof (Paragraph));
+				paragraphStyle = null;
+			}
+
+			paragraphStyle = new Style (typeof (Paragraph));
+			var lineHeightSetter = new Setter (Block.LineHeightProperty, FontSize + lineSpacing);
+			paragraphStyle.Setters.Add (lineHeightSetter);
+
+			Resources.Add (typeof (Paragraph), paragraphStyle);
 		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/LabelBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/LabelBackend.cs
@@ -117,7 +117,7 @@ namespace Xwt.WPFBackend
 					s.TextDecorations.Add (dec);
 				}
 				else if (at is Drawing.StrikethroughTextAttribute) {
-					var xa = (Drawing.UnderlineTextAttribute)at;
+					var xa = (Drawing.StrikethroughTextAttribute)at;
 					var dec = new TextDecoration (TextDecorationLocation.Strikethrough, null, 0, TextDecorationUnit.FontRecommended, TextDecorationUnit.FontRecommended);
 					s.TextDecorations.Add (dec);
 				}

--- a/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
@@ -144,6 +144,16 @@ namespace Xwt.WPFBackend
 			}
 		}
 
+		public int LineSpacing {
+			get {
+				return Widget.LineSpacing;
+			}
+
+			set {
+				Widget.LineSpacing = value;
+			}
+		}
+
 		class RichTextBuffer : IRichTextBuffer
 		{
 			const int FontSize = 16;

--- a/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
@@ -26,17 +26,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Xml;
+using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Documents;
-using System.Windows.Markup;
-using Xwt.Backends;
-
-using Xwt.WPFBackend.Utilities;
 using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Media;
 using System.Windows.Navigation;
+using Xwt.Backends;
+using Xwt.WPFBackend.Utilities;
 
 namespace Xwt.WPFBackend
 {
@@ -131,15 +128,23 @@ namespace Xwt.WPFBackend
 			const int FontSize = 16;
 			const int HeaderIncrement = 8;
 
-			StringBuilder builder;
-			XmlWriter writer;
 			FlowDocument doc;
 
 			public RichTextBuffer ()
 			{
-				builder = new StringBuilder ();
-				writer = XmlWriter.Create (builder, new XmlWriterSettings () { OmitXmlDeclaration = true, NewLineOnAttributes = true, Indent = true, IndentChars = "\t" });
-				writer.WriteStartElement ("FlowDocument", "http://schemas.microsoft.com/winfx/2006/xaml/presentation");
+				doc = new FlowDocument();
+			}
+
+			Stack<InlineCollection> blockStack = new Stack<InlineCollection>();
+
+			bool GetOrCreateInline (out InlineCollection block)
+			{
+				if (blockStack.Count == 0) {
+					block = EmitStartParagraph().Inlines;
+					return true;
+				}
+				block = blockStack.Peek();
+				return false;
 			}
 
 			public void EmitText (string text)
@@ -149,155 +154,199 @@ namespace Xwt.WPFBackend
 
 				var lines = text.Split (new[] { Environment.NewLine }, StringSplitOptions.None);
 				var first = true;
+				InlineCollection block;
+				var inlineCreated = GetOrCreateInline(out block);
 				foreach (var line in lines) {
-					if (!first) {
-						writer.WriteStartElement ("LineBreak");
-						writer.WriteEndElement ();
-					}
-					if (!string.IsNullOrEmpty (line)) {
-						writer.WriteElementString ("Run", line);
-					}
+					if (!first)
+						block.Add(new LineBreak ());
+					if (!string.IsNullOrEmpty (line))
+						block.Add(new Run (line));
 					first = false;
 				}
+				if (inlineCreated)
+					EmitEndParagraph();
 			}
 
 			public void EmitStartHeader (int level)
 			{
-				EmitStartParagraph (0);
-				writer.WriteStartElement ("Span");
-				writer.WriteAttributeString ("FontSize", (FontSize + HeaderIncrement * level).ToString ());
+				var block = EmitStartParagraph().Inlines;
+				var header = new Span() { FontSize = FontSize + HeaderIncrement * level };
+				block.Add(header);
+				blockStack.Push(header.Inlines);
 			}
 
 			public void EmitEndHeader()
 			{
-				writer.WriteEndElement();
+				var span = blockStack.Pop();
 				EmitEndParagraph();
 			}
 
+			List currentList;
+			ListItem currentListItem;
+
 			public void EmitOpenList ()
 			{
-				writer.WriteStartElement ("List");
+				if (currentList != null)
+					throw new InvalidOperationException("A new List can not be added to an existing List.");
+				if (blockStack.Count > 0)
+					throw new InvalidOperationException("A list can not be added to an other block.");
+				currentList = new List();
+				doc.Blocks.Add(currentList);
 			}
 
 			public void EmitOpenBullet ()
 			{
-				writer.WriteStartElement ("ListItem");
-				EmitStartParagraph (0);
+				if (currentList == null)
+					throw new InvalidOperationException("Not inside a List.");
+				var paragraph = new Paragraph();
+				currentListItem  = new ListItem(paragraph);
+				currentList.ListItems.Add(currentListItem);
+				blockStack.Push(paragraph.Inlines);
 			}
 
 			public void EmitCloseBullet ()
 			{
-				writer.WriteEndElement ();
-				writer.WriteEndElement ();
+				if (currentList == null)
+					throw new InvalidOperationException("Not inside a List.");
+				if (currentListItem == null)
+					throw new InvalidOperationException("Not inside a ListItem.");
+				currentListItem = null;
+				blockStack.Pop();
 			}
 
 			public void EmitCloseList ()
 			{
-				// Close the list
-				writer.WriteEndElement ();
+				if (currentList == null)
+					throw new InvalidOperationException("Not inside a List.");
+				if (currentListItem != null)
+					EmitCloseBullet();
+				currentList = null;
 			}
+
+			bool localLinkParagraph;
 
 			public void EmitStartLink (string href, string title)
 			{
-				writer.WriteStartElement ("Hyperlink");
-				writer.WriteAttributeString ("NavigateUri", href);
-				if (!string.IsNullOrEmpty (title))
-					writer.WriteAttributeString ("ToolTip", title);
+				InlineCollection block;
+				localLinkParagraph = GetOrCreateInline(out block);
+				var link = new Hyperlink();
+				link.NavigateUri = new Uri (href);
+				if (!string.IsNullOrEmpty(title))
+					link.ToolTip = title;
+				block.Add(link);
+				blockStack.Push(link.Inlines);
 			}
 
 			public void EmitEndLink()
 			{
-				writer.WriteEndElement();
+				blockStack.Pop();
+				if (localLinkParagraph)
+					EmitEndParagraph();
+				localLinkParagraph = false;
 			}
 
 			int rtbCounter;
 			public void EmitCodeBlock (string code)
 			{
-				writer.WriteStartElement ("BlockUIContainer");
-				writer.WriteAttributeString ("Margin", "15");
+				if (blockStack.Count > 0)
+					throw new InvalidOperationException("A Code Block can not be added to an other block.");
 
-				string name = "rtb" + (rtbCounter++);
+				var rtb = new RichTextBox();
+				rtb.Name = "rtb" + (rtbCounter++);
+				rtb.HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden;
+				var codeDoc = new FlowDocument();
+				var widthBinding = new Binding();
+				widthBinding.Path = new PropertyPath("ActualWidth");
+				widthBinding.ElementName = rtb.Name;
+				codeDoc.SetBinding(FlowDocument.PageWidthProperty, widthBinding);
+				var p = new Paragraph();
+				p.FontFamily = new FontFamily("Global Monospace");
+				p.Inlines.Add(code);
+				codeDoc.Blocks.Add(p);
+				rtb.Document = codeDoc;
 
-				writer.WriteStartElement ("RichTextBox");
-				writer.WriteAttributeString ("Name", name);
-				writer.WriteAttributeString ("HorizontalScrollBarVisibility", "Hidden");
 
-				writer.WriteStartElement ("FlowDocument");
-				//writer.WriteAttributeString ("PageWidth", "1000");
-				writer.WriteAttributeString ("PageWidth", "{Binding ElementName=" + name + ",Path=ActualWidth}");
-				writer.WriteStartElement ("Paragraph");
+				var container = new BlockUIContainer(rtb);
+				container.Margin = new Thickness(15, 15, 15, 15);
 
-				writer.WriteAttributeString ("xml", "space", null, "preserve");
-				writer.WriteAttributeString ("FontFamily", "Global Monospace");
-				writer.WriteString (code);
-
-				writer.WriteEndElement ();
-				writer.WriteEndElement ();
-				writer.WriteEndElement ();
-				writer.WriteEndElement ();
+				doc.Blocks.Add(container);
 			}
 
 			public void EmitText (string text, RichTextInlineStyle style)
 			{
+				InlineCollection block;
+				var inlineCreated = GetOrCreateInline(out block);
+
 				switch (style) {
 				case RichTextInlineStyle.Bold:
+					var bold = new Bold();
+					blockStack.Push(bold.Inlines);
+					EmitText(text);
+					blockStack.Pop();
+					break;
+					
 				case RichTextInlineStyle.Italic:
-					writer.WriteStartElement (style.ToString ());
-					EmitText (text);
+					var italic = new Italic();
+					blockStack.Push(italic.Inlines);
+					EmitText(text);
+					blockStack.Pop();
 					break;
 
 				case RichTextInlineStyle.Monospace:
-					writer.WriteStartElement ("Run");
-					writer.WriteAttributeString ("FontFamily", "Global Monospace");
-					writer.WriteString (text);
+					var run = new Run(text);
+					run.FontFamily = new FontFamily("Global Monospace");
+					block.Add(run);
 					break;
 
 				default:
 					EmitText (text);
 					return;
 				}
-				writer.WriteEndElement ();
+				if (inlineCreated)
+					EmitEndParagraph();
 			}
 
-			public void EmitText (FormattedText text)
+			public void EmitText (FormattedText markup)
 			{
-				EmitText (text.Text, RichTextInlineStyle.Normal);
+				EmitText (markup.Text, RichTextInlineStyle.Normal);
+			}
+
+			Paragraph EmitStartParagraph ()
+			{
+				var paragraph = new Paragraph();
+				blockStack.Push(paragraph.Inlines);
+				doc.Blocks.Add(paragraph);
+				return paragraph;
 			}
 
 			public void EmitStartParagraph (int indentLevel)
 			{
 				//FIXME: indentLevel
-				writer.WriteStartElement ("Paragraph");
+				EmitStartParagraph();
 			}
 
 			public void EmitEndParagraph ()
 			{
-				writer.WriteEndElement ();
+				blockStack.Pop();
 			}
 
 			public void EmitHorizontalRuler ()
 			{
-				writer.WriteStartElement("BlockUIContainer");
-				writer.WriteAttributeString ("Margin", "0,0,0,0");
-				writer.WriteElementString("Separator", "");
-				writer.WriteEndElement();
+				if (blockStack.Count > 0)
+					throw new InvalidOperationException("A Ruler can not be added to an other block.");
+				var ruler = new BlockUIContainer(new System.Windows.Controls.Separator ());
+				ruler.Margin = new Thickness (0, 0, 0, 0);
+				doc.Blocks.Add(ruler);
 			}
 
 			public FlowDocument ToFlowDocument ()
 			{
-				if (doc == null) {
-					writer.WriteEndElement ();
-					writer.Flush ();
-					doc = (FlowDocument) XamlReader.Parse (builder.ToString ());
-					writer = null;
-				}
 				return doc;
 			}
 
 			public string PlainText { 
 				get {
-					var flowDoc = ToFlowDocument();
-					string text = new TextRange (flowDoc.ContentStart, flowDoc.ContentEnd).Text;
+					string text = new TextRange (doc.ContentStart, doc.ContentEnd).Text;
 					return text;
 				}
 			}

--- a/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
@@ -30,6 +30,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Navigation;
 using Xwt.Backends;
@@ -41,6 +42,9 @@ namespace Xwt.WPFBackend
 		: WidgetBackend, IRichTextViewBackend
 	{
 		RichTextBuffer currentBuffer;
+		bool selectable;
+		readonly double defaultSelectionOpacity;
+
 		public new IRichTextViewEventSink EventSink {
 			get { return (IRichTextViewEventSink) base.EventSink; }
 		}
@@ -54,6 +58,7 @@ namespace Xwt.WPFBackend
 		public RichTextViewBackend ()
 		{
 			Widget = new ExRichTextBox ();
+			defaultSelectionOpacity = Widget.SelectionOpacity;
 			Widget.BorderThickness = new System.Windows.Thickness (0);
 		}
 
@@ -120,6 +125,22 @@ namespace Xwt.WPFBackend
 			} 
 			set {
 				Widget.IsReadOnly = value;
+			}
+		}
+
+		public bool Selectable {
+			get {
+				return selectable;
+			}
+			set {
+				selectable = value;
+				if (selectable) {
+					Widget.Cursor = Cursors.IBeam;
+					Widget.SelectionOpacity = defaultSelectionOpacity;
+				} else {
+					Widget.Cursor = Cursors.Arrow;
+					Widget.SelectionOpacity = 0;
+				}
 			}
 		}
 

--- a/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
@@ -259,6 +259,11 @@ namespace Xwt.WPFBackend
 				writer.WriteEndElement ();
 			}
 
+			public void EmitText (FormattedText text)
+			{
+				EmitText (text.Text, RichTextInlineStyle.Normal);
+			}
+
 			public void EmitStartParagraph (int indentLevel)
 			{
 				//FIXME: indentLevel

--- a/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
@@ -124,6 +124,19 @@ namespace Xwt.Mac
 			}
 		}
 
+		public bool Selectable {
+			get {
+				return Widget.Selectable;
+			}
+			set {
+				Widget.Selectable = value;
+				// force NSTextView not to draw its (white) background
+				// making it look like a label, which is the default Gtk/Wpf behaviour
+				// the background color can still be set manually with the BackgroundColor property
+				Widget.DrawsBackground = value;
+			}
+		}
+
 		public IRichTextBuffer CurrentBuffer {
 			get {
 				return currentBuffer;

--- a/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
@@ -138,6 +138,16 @@ namespace Xwt.Mac
 			}
 		}
 
+		public override Drawing.Color BackgroundColor {
+			get {
+				return base.BackgroundColor;
+			}
+			set {
+				base.BackgroundColor = value;
+				Widget.BackgroundColor = value.ToNSColor ();
+			}
+		}
+
 		int? lineSpacing = null;
 		public int LineSpacing {
 			get {

--- a/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
@@ -357,6 +357,11 @@ namespace Xwt.Mac
 				xmlWriter.WriteEndElement ();
 		}
 
+		public void EmitText (FormattedText text)
+		{
+			EmitText (text.Text, RichTextInlineStyle.Normal);
+		}
+
 		public void EmitStartHeader (int level)
 		{
 			if (level < 1)

--- a/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
@@ -80,6 +80,9 @@ namespace Xwt.Mac
 			ViewObject = tv;
 			tv.VerticallyResizable = false;
 			tv.HorizontallyResizable = false;
+			// Use cached font since Widget.Font size increases for each LoadText... It has to do
+			// with the 'style' attribute for the 'body' element - not sure why that happens
+			font = tv.Font;
 		}
 
 		double CalcHeight (double width)
@@ -110,9 +113,7 @@ namespace Xwt.Mac
 
 		public IRichTextBuffer CreateBuffer ()
 		{
-			// Use cached font since Widget.Font size increases for each LoadText... It has to do
-			// with the 'style' attribute for the 'body' element - not sure why that happens
-			return new MacRichTextBuffer (font ?? Widget.Font);
+			return new MacRichTextBuffer ();
 		}
 
 		public bool ReadOnly { 
@@ -137,9 +138,27 @@ namespace Xwt.Mac
 			}
 		}
 
+		int? lineSpacing = null;
+		public int LineSpacing {
+			get {
+				return lineSpacing.HasValue ? (int)lineSpacing : 0;
+			}
+			set {
+				lineSpacing = value;
+
+				if (currentBuffer != null)
+					Widget.TextStorage.SetString (currentBuffer.ToAttributedString (font, lineSpacing));
+			}
+		}
+
 		public IRichTextBuffer CurrentBuffer {
 			get {
 				return currentBuffer;
+			}
+			private set {
+				if (currentBuffer != null)
+					currentBuffer.Dispose ();
+				currentBuffer = value as MacRichTextBuffer;
 			}
 		}
 
@@ -148,12 +167,12 @@ namespace Xwt.Mac
 			var macBuffer = buffer as MacRichTextBuffer;
 			if (macBuffer == null)
 				throw new ArgumentException ("Passed buffer is of incorrect type", "buffer");
-			currentBuffer = macBuffer;
+			CurrentBuffer = macBuffer;
 			var tview = ViewObject as MacTextView;
 			if (tview == null)
 				return;
 
-			tview.TextStorage.SetString (macBuffer.ToAttributedString ());
+			tview.TextStorage.SetString (macBuffer.ToAttributedString (font, lineSpacing));
 		}
 
 		public override void EnableEvent (object eventId)
@@ -178,6 +197,13 @@ namespace Xwt.Mac
 			if (tview == null)
 				return;
 			tview.DisableEvent ((RichTextViewEvent)eventId);
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (currentBuffer != null)
+				currentBuffer.Dispose ();
+			base.Dispose (disposing);
 		}
 	}
 
@@ -250,26 +276,41 @@ namespace Xwt.Mac
 		}
 	}
 
-	class MacRichTextBuffer : IRichTextBuffer
+	class MacRichTextBuffer : IRichTextBuffer, IDisposable
 	{
 		const int HeaderIncrement = 8;
 
 		static readonly string[] lineSplitChars = new string[] { Environment.NewLine };
 		static readonly IntPtr selInitWithHTMLDocumentAttributes_Handle = Selector.GetHandle ("initWithHTML:documentAttributes:");
 
-		StringBuilder text;
-		XmlWriter xmlWriter;
+		readonly StringBuilder text;
+		readonly XmlWriter xmlWriter;
 		Stack <int> paragraphIndent;
 
-		public MacRichTextBuffer (NSFont font)
+		public MacRichTextBuffer ()
 		{
 			text = new StringBuilder ();
 			xmlWriter = XmlWriter.Create (text, new XmlWriterSettings {
 				OmitXmlDeclaration = true,
 				Encoding = Encoding.UTF8,
 				Indent = true,
+				IndentChars = "\t",
+				ConformanceLevel = ConformanceLevel.Fragment
+			});
+		}
+
+		public NSAttributedString ToAttributedString (NSFont font, int? lineSpacing)
+		{
+			xmlWriter.Flush ();
+
+			var finaltext = new StringBuilder ();
+			var finalxmlWriter = XmlWriter.Create (finaltext, new XmlWriterSettings {
+				OmitXmlDeclaration = true,
+				Encoding = Encoding.UTF8,
+				Indent = true,
 				IndentChars = "\t"
 			});
+
 
 			float fontSize;
 			string fontFamily;
@@ -282,31 +323,34 @@ namespace Xwt.Mac
 				fontFamily = "sans-serif";
 			}
 
-			xmlWriter.WriteDocType ("html", "-//W3C//DTD XHTML 1.0", "Strict//EN", null);
-			xmlWriter.WriteStartElement ("html");
-			xmlWriter.WriteStartElement ("meta");
-			xmlWriter.WriteAttributeString ("http-equiv", "Content-Type");
-			xmlWriter.WriteAttributeString ("content", "text/html; charset=utf-8");
-			xmlWriter.WriteEndElement ();
-			xmlWriter.WriteStartElement ("body");
-			xmlWriter.WriteAttributeString ("style", String.Format ("font-family: {0}; font-size: {1}", fontFamily, fontSize));
-		}
+			finalxmlWriter.WriteDocType ("html", "-//W3C//DTD XHTML 1.0", "Strict//EN", null);
+			finalxmlWriter.WriteStartElement ("html");
+			finalxmlWriter.WriteStartElement ("meta");
+			finalxmlWriter.WriteAttributeString ("http-equiv", "Content-Type");
+			finalxmlWriter.WriteAttributeString ("content", "text/html; charset=utf-8");
+			finalxmlWriter.WriteEndElement ();
+			finalxmlWriter.WriteStartElement ("body");
 
-		public NSAttributedString ToAttributedString ()
-		{
-			xmlWriter.WriteEndElement (); // body
-			xmlWriter.WriteEndElement (); // html
-			xmlWriter.Flush ();
-			if (text == null || text.Length == 0)
+			string style = String.Format ("font-family: {0}; font-size: {1}", fontFamily, fontSize);
+			if (lineSpacing.HasValue)
+				style += "; line-height: " + (lineSpacing.Value + fontSize) + "px";
+
+			finalxmlWriter.WriteAttributeString ("style", style);
+			finalxmlWriter.WriteRaw (text.ToString ());
+			finalxmlWriter.WriteEndElement (); // body
+			finalxmlWriter.WriteEndElement (); // html
+			finalxmlWriter.Flush ();
+
+			if (finaltext == null || finaltext.Length == 0)
 				return new NSAttributedString (String.Empty);
 
 			NSDictionary docAttributes;
 			try {
-				return CreateStringFromHTML (text.ToString (), out docAttributes);
+				return CreateStringFromHTML (finaltext.ToString (), out docAttributes);
 			} finally {
-				text = null;
-				xmlWriter.Dispose ();
-				xmlWriter = null;
+				finaltext = null;
+				finalxmlWriter.Dispose ();
+				finalxmlWriter = null;
 				docAttributes = null;
 			}
 		}
@@ -501,6 +545,11 @@ namespace Xwt.Mac
 		{
 			xmlWriter.WriteStartElement ("hr");
 			xmlWriter.WriteEndElement ();
+		}
+
+		public void Dispose ()
+		{
+			xmlWriter.Dispose ();
 		}
 	}
 }

--- a/Xwt/Xwt.Backends/IRichTextViewBackend.cs
+++ b/Xwt/Xwt.Backends/IRichTextViewBackend.cs
@@ -29,6 +29,8 @@ namespace Xwt.Backends
 
 		bool Selectable { get; set; }
 
+		int LineSpacing { get; set; }
+
 		IRichTextBuffer CurrentBuffer { get; }
 	}
 

--- a/Xwt/Xwt.Backends/IRichTextViewBackend.cs
+++ b/Xwt/Xwt.Backends/IRichTextViewBackend.cs
@@ -34,6 +34,7 @@ namespace Xwt.Backends
 	{
 		// Emit text using specified style mask
 		void EmitText (string text, RichTextInlineStyle style);
+		void EmitText (FormattedText text);
 
 		// Emit a header (h1, h2, ...)
 		void EmitStartHeader (int level);

--- a/Xwt/Xwt.Backends/IRichTextViewBackend.cs
+++ b/Xwt/Xwt.Backends/IRichTextViewBackend.cs
@@ -27,6 +27,8 @@ namespace Xwt.Backends
 
 		bool ReadOnly { get; set; }
 
+		bool Selectable { get; set; }
+
 		IRichTextBuffer CurrentBuffer { get; }
 	}
 

--- a/Xwt/Xwt.Formats/MarkupTextFormat.cs
+++ b/Xwt/Xwt.Formats/MarkupTextFormat.cs
@@ -1,10 +1,10 @@
-//
-// TextFormat.cs
+﻿//
+// MarkupTextFormat.cs
 //
 // Author:
-//       Alex Corrado <corrado@xamarin.com>
+//       Vsevolod Kukol <sevoku@microsoft.com>
 //
-// Copyright (c) 2012 Xamarin Inc.
+// Copyright (c) 2016 Microsoft Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,22 +23,32 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 using System;
 using System.IO;
-
 using Xwt.Backends;
 
 namespace Xwt.Formats
 {
-	public abstract class TextFormat
+	public class MarkupTextFormat : TextFormat
 	{
-		public static readonly TextFormat Markdown = new MarkdownTextFormat ();
-		public static readonly TextFormat Plain = new PlainTextFormat ();
-		public static readonly TextFormat Markup = new MarkupTextFormat ();
+		public override void Parse (Stream input, IRichTextBuffer buffer)
+		{
+			using (var reader = new StreamReader (input))
+				ParseMarkup (reader.ReadToEnd (), buffer);
+		}
 
-		// Parses the given input stream into the given buffer
-		public abstract void Parse (Stream input, IRichTextBuffer buffer);
+		static void ParseMarkup (string markup, IRichTextBuffer buffer)
+		{
+			var paragraphs = markup.Replace ("\r\n", "\n").Split (new [] { "\n\n" }, StringSplitOptions.None);
+			foreach (var p in paragraphs) {
+				buffer.EmitStartParagraph (0);
+				var formatted = FormattedText.FromMarkup (p);
+				if (formatted.Attributes.Count > 0)
+					buffer.EmitText (formatted);
+				else
+					buffer.EmitText (p, RichTextInlineStyle.Normal);
+				buffer.EmitEndParagraph ();
+			}
+		}
 	}
 }
-

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -264,6 +264,7 @@
     <Compile Include="Xwt.Drawing\DrawingImage.cs" />
     <Compile Include="Xwt.Drawing\BitmapImage.cs" />
     <Compile Include="Xwt.Formats\PlainTextFormat.cs" />
+    <Compile Include="Xwt.Formats\MarkupTextFormat.cs" />
     <Compile Include="Xwt.Drawing\ImageFileType.cs" />
     <Compile Include="Xwt\Slider.cs" />
     <Compile Include="Xwt.Backends\ISliderBackend.cs" />

--- a/Xwt/Xwt/RichTextView.cs
+++ b/Xwt/Xwt/RichTextView.cs
@@ -117,6 +117,15 @@ namespace Xwt
 			}
 		}
 
+		public int LineSpacing {
+			get {
+				return Backend.LineSpacing;
+			}
+			set {
+				Backend.LineSpacing = value;
+			}
+		}
+
 		protected override BackendHost CreateBackendHost ()
 		{
 			return new WidgetBackendHost ();

--- a/Xwt/Xwt/RichTextView.cs
+++ b/Xwt/Xwt/RichTextView.cs
@@ -146,5 +146,24 @@ namespace Xwt
 			Markdown = string.Empty;
 		}
 	}
+
+	public class MarkupView : RichTextView
+	{
+		string markup;
+		public string Markup {
+			get {
+				return markup;
+			}
+			set {
+				markup = value;
+				LoadText (value, TextFormat.Markup);
+			}
+		}
+
+		public MarkupView ()
+		{
+			Markup = string.Empty;
+		}
+	}
 }
 

--- a/Xwt/Xwt/RichTextView.cs
+++ b/Xwt/Xwt/RichTextView.cs
@@ -108,6 +108,15 @@ namespace Xwt
 			}
 		}
 
+		public bool Selectable {
+			get {
+				return Backend.Selectable;
+			}
+			set {
+				Backend.Selectable = value;
+			}
+		}
+
 		protected override BackendHost CreateBackendHost ()
 		{
 			return new WidgetBackendHost ();


### PR DESCRIPTION
This PR adds Markup support to `RichTextView`. This includes a new `MarkupTextFormat` to parse the Markup and a new `MarkupView` widget (works similar to `MarkdownView`).
Additionally the new Parser supports Paragraphs which will be emitted for every double line break (`\n\n`).

Additional Features:

* `RichTextView.Selectable`: `false` disables selection mode and makes the RichTextView look like a label - 0cbe062
* `RichTextView.LineSpacing` can be used to change the spacing between the lines/paragraphs - 9140554

Bugfixes/Optimizations:

* `BackgroundColor` fixed on Gtk/Mac - 23df2cf / 8817f91
* `strikethrough` span tag fixed on Wpf - 40f5c55
* No Xml parsing in Wpf (use `FlowDocument` API directly) -  	fb10edf
* Fixed Pango.AttrList leak (thx @Therzok) - c8e0627