### PR TITLE
Add RadioButtonCellView

### DIFF
--- a/TestApps/Samples/Samples/TreeViews.cs
+++ b/TestApps/Samples/Samples/TreeViews.cs
@@ -32,13 +32,16 @@ namespace Samples
 	{
 		DataField<CheckBoxState> triState = new DataField<CheckBoxState>();
 		DataField<bool> check = new DataField<bool>();
+		DataField<bool> option1 = new DataField<bool> ();
+		DataField<bool> option2 = new DataField<bool> ();
+		DataField<bool> option3 = new DataField<bool> ();
 		DataField<string> text = new DataField<string> ();
 		DataField<string> desc = new DataField<string> ();
 		
 		public TreeViews ()
 		{
 			TreeView view = new TreeView ();
-			TreeStore store = new TreeStore (triState, check, text, desc);
+			TreeStore store = new TreeStore (triState, check, option1, option2, option3, text, desc);
 			view.GridLinesVisible = GridLines.Both;
 			
 			var triStateCellView = new CheckBoxCellView (triState) { Editable = true, AllowMixed = true };
@@ -56,11 +59,41 @@ namespace Samples
 					MessageDialog.ShowError("CurrentEventRow is null. This is not supposed to happen");
 				}
 				else {
-					store.GetNavigatorAt(view.CurrentEventRow).SetValue(text, "Toggled");
+					store.GetNavigatorAt(view.CurrentEventRow).SetValue(text, "Toggled " + checkCellView.Active);
 				}
 			};
+			var optionCellView1 = new RadioButtonCellView (option1) { Editable = true };
+			optionCellView1.Toggled += (object sender, WidgetEventArgs e) => {
+				if (view.CurrentEventRow == null) {
+					MessageDialog.ShowError ("CurrentEventRow is null. This is not supposed to happen");
+				} else {
+					store.GetNavigatorAt (view.CurrentEventRow).SetValue (option2, optionCellView1.Active);
+				}
+			};
+			var optionCellView2 = new RadioButtonCellView (option2) { Editable = true };
+			optionCellView2.Toggled += (object sender, WidgetEventArgs e) => {
+				if (view.CurrentEventRow == null) {
+					MessageDialog.ShowError ("CurrentEventRow is null. This is not supposed to happen");
+				} else {
+					store.GetNavigatorAt (view.CurrentEventRow).SetValue (option1, optionCellView2.Active);
+				}
+			};
+
+			TreePosition initialActive = null;
+			var optionCellView3 = new RadioButtonCellView (option3) { Editable = true };
+			optionCellView3.Toggled += (object sender, WidgetEventArgs e) => {
+				if (view.CurrentEventRow == null) {
+					MessageDialog.ShowError ("CurrentEventRow is null. This is not supposed to happen");
+				} else {
+					if (initialActive != null)
+						store.GetNavigatorAt (initialActive).SetValue (option3, false);
+					initialActive = view.CurrentEventRow;
+				}
+			};
+
 			view.Columns.Add ("TriCheck", triStateCellView);
 			view.Columns.Add ("Check", checkCellView);
+			view.Columns.Add ("Radio", optionCellView1, optionCellView2, optionCellView3);
 			view.Columns.Add ("Item", text);
 			view.Columns.Add ("Desc", desc);
 			view.Columns[2].Expands = true; // expand third column, aligning last column to the right side

--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CellUtil.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CellUtil.cs
@@ -61,7 +61,7 @@ namespace Xwt.GtkBackend
 			if (view is ITextCellViewFrontend) {
 				crd = new CustomCellRendererText ();
 			}
-			else if (view is ICheckBoxCellViewFrontend) {
+			else if (view is ICheckBoxCellViewFrontend || view is IRadioButtonCellViewFrontend) {
 				crd = new CustomCellRendererToggle ();
 			}
 			else if (view is IImageCellViewFrontend) {

--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Xwt.WPFBackend\ScrollControlBackend.cs" />
     <Compile Include="Xwt.WPFBackend\CalendarBackend.cs" />
     <Compile Include="Xwt.WPFBackend.Interop\IDocHostUIHandler.cs" />
+    <Compile Include="Xwt.WPFBackend.CellViews\RadioButtonCellViewBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Xwt.WPF/Xwt.WPFBackend.CellViews/RadioButtonCellViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.CellViews/RadioButtonCellViewBackend.cs
@@ -1,0 +1,80 @@
+﻿//
+// RadioButtonCellViewBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2016 (c) Vsevolod Kukol
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Windows;
+using SWC = System.Windows.Controls;
+using Xwt.Backends;
+
+namespace Xwt.WPFBackend
+{
+	class RadioButtonCellViewBackend : CellViewBackend
+	{
+		public override void OnInitialize(CellView cellView, FrameworkElementFactory factory)
+		{
+			factory.AddHandler (UngroupedRadioButton.ToggleEvent, new RoutedEventHandler (HandleToggled));
+			base.OnInitialize(cellView, factory);
+		}
+
+		void HandleToggled(object sender, RoutedEventArgs e)
+		{
+			var view = (IRadioButtonCellViewFrontend)CellView;
+			Load(sender as FrameworkElement);
+			SetCurrentEventRow();
+			e.Handled = view.RaiseToggled();
+		}
+	}
+
+	class UngroupedRadioButton : SWC.RadioButton
+	{
+		public UngroupedRadioButton()
+		{
+			GroupName = Guid.NewGuid().ToString();
+			IsThreeState = false;
+			IsChecked = false;
+		}
+
+		public static readonly RoutedEvent ToggleEvent = EventManager.RegisterRoutedEvent("Toggle", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(UngroupedRadioButton));
+
+		public event RoutedEventHandler Toggle
+		{
+			add { AddHandler(ToggleEvent, value); }
+			remove { RemoveHandler(ToggleEvent, value); }
+		}
+
+		protected virtual void OnToggle(RoutedEventArgs e)
+		{
+			RaiseEvent(e);
+		}
+
+		protected override void OnToggle()
+		{
+			var args = new RoutedEventArgs(ToggleEvent);
+			OnToggle(args);
+			if (!args.Handled)
+				base.OnToggle();
+		}
+	}
+}

--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -165,6 +165,27 @@ namespace Xwt.WPFBackend.Utilities
 				return factory;
 			}
 
+			var radioButton = view as RadioButtonCellView;
+			if (radioButton != null)
+			{
+				FrameworkElementFactory factory = new FrameworkElementFactory(typeof(UngroupedRadioButton));
+				if (radioButton.EditableField == null)
+					factory.SetValue(UIElement.IsEnabledProperty, radioButton.Editable);
+				else
+					factory.SetBinding(UIElement.IsEnabledProperty, new Binding(dataPath + "[" + radioButton.EditableField.Index + "]"));
+
+				factory.SetValue(SWC.Primitives.ToggleButton.IsThreeStateProperty, false);
+				if (radioButton.ActiveField == null)
+					factory.SetValue(SWC.Primitives.ToggleButton.IsCheckedProperty, radioButton.Active);
+				else
+					factory.SetBinding(SWC.Primitives.ToggleButton.IsCheckedProperty, new Binding(dataPath + "[" + radioButton.ActiveField.Index + "]"));
+
+				var cb = new RadioButtonCellViewBackend ();
+				cb.Initialize(view, factory, parent as ICellRendererTarget);
+				fr.AttachBackend(parent.Frontend, cb);
+				return factory;
+			}
+
 			throw new NotImplementedException ();
 		}
 	}

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CellUtil.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CellUtil.cs
@@ -53,6 +53,8 @@ namespace Xwt.Mac
 				cr = new CanvasTableCell ();
 			else if (cell is ICheckBoxCellViewFrontend)
 				cr = new CheckBoxTableCell ();
+			else if (cell is IRadioButtonCellViewFrontend)
+				cr = new RadioButtonTableCell ();
 			else
 				throw new NotImplementedException ();
 			cr.Backend = new CellViewBackend (table, column);

--- a/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
@@ -46,13 +46,31 @@ namespace Xwt.Mac
 			Title = "";
 		}
 
+		public override NSCellStateValue State {
+			get {
+				return base.State;
+			}
+			set {
+				if (base.State != value)
+					stateChanging = true;
+				base.State = value;
+			}
+		}
+
+		bool stateChanging;
 		void HandleActivated (object sender, EventArgs e)
 		{
-			var cellView = Frontend;
-			CellContainer.SetCurrentEventRow ();
-			if (cellView.Editable && !cellView.RaiseToggled () && cellView.ActiveField != null) {
-				CellContainer.SetValue (cellView.ActiveField, State != NSCellStateValue.Off);
+			if (State == NSCellStateValue.On && stateChanging) {
+				var cellView = Frontend;
+				CellContainer.SetCurrentEventRow ();
+				Frontend.Load (CellContainer);
+				if (cellView.Editable && !cellView.RaiseToggled ()) {
+					if (cellView.ActiveField != null)
+						CellContainer.SetValue (cellView.ActiveField, State != NSCellStateValue.Off);
+				} else
+					base.State = NSCellStateValue.Off;
 			}
+			stateChanging = false;
 		}
 
 		public RadioButtonTableCell (IntPtr p): base (p)
@@ -70,7 +88,7 @@ namespace Xwt.Mac
 		public void Fill ()
 		{
 			var cellView = Frontend;
-			State = cellView.Active ? NSCellStateValue.On : NSCellStateValue.Off;
+			base.State = cellView.Active ? NSCellStateValue.On : NSCellStateValue.Off;
 			Editable = cellView.Editable;
 		}
 

--- a/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
@@ -1,0 +1,83 @@
+﻿//
+// RadioButtonTableCell.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2016 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt.Backends;
+
+#if MONOMAC
+using nint = System.Int32;
+using nfloat = System.Single;
+using MonoMac.AppKit;
+#else
+using AppKit;
+#endif
+
+namespace Xwt.Mac
+{
+	class RadioButtonTableCell: NSButtonCell, ICellRenderer
+	{
+		public RadioButtonTableCell ()
+		{
+			SetButtonType (NSButtonType.Radio);
+			AllowsMixedState = false;
+			Activated += HandleActivated;
+			Title = "";
+		}
+
+		void HandleActivated (object sender, EventArgs e)
+		{
+			var cellView = Frontend;
+			CellContainer.SetCurrentEventRow ();
+			if (cellView.Editable && !cellView.RaiseToggled () && cellView.ActiveField != null) {
+				CellContainer.SetValue (cellView.ActiveField, State != NSCellStateValue.Off);
+			}
+		}
+
+		public RadioButtonTableCell (IntPtr p): base (p)
+		{
+		}
+
+		IRadioButtonCellViewFrontend Frontend {
+			get { return (IRadioButtonCellViewFrontend)Backend.Frontend; }
+		}
+
+		public CellViewBackend Backend { get; set; }
+
+		public CompositeCell CellContainer { get; set; }
+
+		public void Fill ()
+		{
+			var cellView = Frontend;
+			State = cellView.Active ? NSCellStateValue.On : NSCellStateValue.Off;
+			Editable = cellView.Editable;
+		}
+
+		public void CopyFrom (object other)
+		{
+			var ob = (RadioButtonTableCell)other;
+			Backend = ob.Backend;
+		}
+	}
+}

--- a/Xwt.XamMac/Xwt.XamMac.csproj
+++ b/Xwt.XamMac/Xwt.XamMac.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Xwt.Mac\CalendarBackend.cs" />
     <Compile Include="Xwt.Mac\SelectFontDialogBackend.cs" />
     <Compile Include="Xwt.Mac\NSApplicationInitializer.cs" />
+    <Compile Include="Xwt.Mac.CellViews\RadioButtonTableCell.cs" />
     <Compile Include="Xwt.Mac\GtkQuartz.cs" />
     <Compile Include="Xwt.Mac\PopupWindowBackend.cs" />
   </ItemGroup>

--- a/Xwt/Xwt.Backends/IRadioButtonCellViewFrontend.cs
+++ b/Xwt/Xwt.Backends/IRadioButtonCellViewFrontend.cs
@@ -1,10 +1,10 @@
-//
-// ICheckBoxCellViewFrontend.cs
+﻿//
+// IRadioButtonCellViewFrontend.cs
 //
 // Author:
-//       Lluis Sanchez <lluis@xamarin.com>
+//       Vsevolod Kukol <sevoku@microsoft.com>
 //
-// Copyright (c) 2013 Xamarin Inc.
+// Copyright (c) 2016 Microsoft Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,16 +23,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
 
 namespace Xwt.Backends
 {
-	public interface ICheckBoxCellViewFrontend: IToggleCellViewFrontend
+	public interface IRadioButtonCellViewFrontend: IToggleCellViewFrontend
 	{
-		CheckBoxState State { get; }
-		bool AllowMixed { get; }
-
-		IDataField<CheckBoxState> StateField { get; }
 	}
 }
-

--- a/Xwt/Xwt.Backends/IToggleCellViewFrontend.cs
+++ b/Xwt/Xwt.Backends/IToggleCellViewFrontend.cs
@@ -1,10 +1,10 @@
 //
-// ICheckBoxCellViewFrontend.cs
+// IToggleCellViewFrontend.cs
 //
 // Author:
-//       Lluis Sanchez <lluis@xamarin.com>
+//       Vsevolod Kukol <sevoku@microsoft.com>
 //
-// Copyright (c) 2013 Xamarin Inc.
+// Copyright (c) 2016 Microsoft Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,16 +23,17 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
 
 namespace Xwt.Backends
 {
-	public interface ICheckBoxCellViewFrontend: IToggleCellViewFrontend
-	{
-		CheckBoxState State { get; }
-		bool AllowMixed { get; }
 
-		IDataField<CheckBoxState> StateField { get; }
+	public interface IToggleCellViewFrontend : ICellViewFrontend
+	{
+		bool Active { get; }
+		bool Editable { get; }
+
+		bool RaiseToggled ();
+
+		IDataField<bool> ActiveField { get; }
 	}
 }
-

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -344,6 +344,9 @@
     <Compile Include="Xwt.Backends\IFolderSelectorBackend.cs" />
     <Compile Include="Xwt\ToolkitDefaults.cs" />
     <Compile Include="Xwt.Backends\IComboBoxCellViewFrontend.cs" />
+    <Compile Include="Xwt\RadioButtonCellView.cs" />
+    <Compile Include="Xwt.Backends\IRadioButtonCellViewFrontend.cs" />
+    <Compile Include="Xwt.Backends\IToggleCellViewFrontend.cs" />
     <Compile Include="Xwt.Backends\IDispatcherBackend.cs" />
     <Compile Include="Xwt\ITranslationCatalog.cs" />
     <Compile Include="Xwt.Backends\IPopupWindowBackend.cs" />

--- a/Xwt/Xwt/RadioButtonCellView.cs
+++ b/Xwt/Xwt/RadioButtonCellView.cs
@@ -1,0 +1,83 @@
+﻿//
+// RadioButtonCellView.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2016 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Xwt.Backends;
+
+namespace Xwt
+{
+	public class RadioButtonCellView: CellView, IRadioButtonCellViewFrontend
+	{
+		bool active;
+		bool editable;
+
+		public IDataField<bool> ActiveField { get; set; }
+		public IDataField<bool> EditableField { get; set; }
+
+		public RadioButtonCellView ()
+		{
+		}
+
+		public RadioButtonCellView (IDataField<bool> field)
+		{
+			ActiveField = field;
+		}
+
+		[DefaultValue (false)]
+		public bool Active {
+			get { return GetValue (ActiveField, active); }
+			set { active = value; }
+		}
+
+		[DefaultValue (false)]
+		public bool Editable {
+			get {
+				return GetValue (EditableField, editable);
+			}
+			set {
+				editable = value;
+			}
+		}
+
+		public event EventHandler<WidgetEventArgs> Toggled;
+
+		/// <summary>
+		/// Raises the toggled event
+		/// </summary>
+		/// <returns><c>true</c>, if the event was handled, <c>false</c> otherwise.</returns>
+		public bool RaiseToggled ()
+		{
+			if (Toggled != null) {
+				var args = new WidgetEventArgs ();
+				Toggled (this, args);
+				return args.Handled;
+			}
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
This PR adds Option-/RadioButton Cells for Lists/Tables.

Limitations:
No Grouping support as in RadioButton.

~~Issues:
WPF impl. lacks Events (like all other Cell Views) and is unusable because the user can't handle the Toggled event.~~ **EDIT:** fixed in #531
