### PR TITLE
Optimizations to the UI thread synchronization API

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
@@ -1030,9 +1031,44 @@ namespace Xwt.WPFBackend
 			if (Widget.IsVisible)
 				Context.InvokeUserCode (this.eventSink.OnBoundsChanged);
 		}
+
+		Task IDispatcherBackend.InvokeAsync(Action action)
+		{
+			var ts = new TaskCompletionSource<int>();
+			var result = Widget.Dispatcher.BeginInvoke((Action)delegate
+			{
+				try
+				{
+					action();
+					ts.SetResult(0);
+				}
+				catch (Exception ex)
+				{
+					ts.SetException(ex);
+				}
+			}, null);
+			return ts.Task;
+		}
+
+		Task<T> IDispatcherBackend.InvokeAsync<T>(Func<T> func)
+		{
+			var ts = new TaskCompletionSource<T>();
+			var result = Widget.Dispatcher.BeginInvoke((Action)delegate
+			{
+				try
+				{
+					ts.SetResult(func());
+				}
+				catch (Exception ex)
+				{
+					ts.SetException(ex);
+				}
+			}, null);
+			return ts.Task;
+		}
 	}
 
-	public interface IWpfWidgetBackend
+	public interface IWpfWidgetBackend : IDispatcherBackend
 	{
 		FrameworkElement Widget { get; }
 	}

--- a/Xwt/Xwt.Backends/IDispatcherBackend.cs
+++ b/Xwt/Xwt.Backends/IDispatcherBackend.cs
@@ -1,0 +1,39 @@
+﻿//
+// IDispatcherBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2016 (c) Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Threading.Tasks;
+
+namespace Xwt.Backends
+{
+	/// <summary>
+	/// Backends implementing IDispatcherBackend support/need component based thread synchronization
+	/// </summary>
+	public interface IDispatcherBackend
+	{
+		Task InvokeAsync (Action action);
+		Task<T> InvokeAsync<T> (Func<T> action);
+	}
+}

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -344,6 +344,7 @@
     <Compile Include="Xwt.Backends\IFolderSelectorBackend.cs" />
     <Compile Include="Xwt\ToolkitDefaults.cs" />
     <Compile Include="Xwt.Backends\IComboBoxCellViewFrontend.cs" />
+    <Compile Include="Xwt.Backends\IDispatcherBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt/Application.cs
+++ b/Xwt/Xwt/Application.cs
@@ -195,9 +195,10 @@ namespace Xwt
 		{
 			if (action == null)
 				throw new ArgumentNullException(nameof (action));
+
 			var ts = new TaskCompletionSource<int>();
-			if (UIThread == Thread.CurrentThread)
-			{
+
+			Action actionCall = () => {
 				try {
 					toolkit.EnterUserCode();
 					action();
@@ -207,22 +208,12 @@ namespace Xwt
 				} finally {
 					toolkit.ExitUserCode(null);
 				}
-			}
+			};
+
+			if (UIThread == Thread.CurrentThread)
+				actionCall();
 			else
-			{
-				engine.InvokeAsync(delegate
-				{
-					try {
-						toolkit.EnterUserCode();
-						action();
-						ts.SetResult(0);
-					} catch (Exception ex) {
-						ts.SetException(ex);
-					} finally {
-						toolkit.ExitUserCode(null);
-					}
-				});
-			}
+				engine.InvokeAsync(actionCall);
 			return ts.Task;
 		}
 
@@ -233,9 +224,10 @@ namespace Xwt
 		{
 			if (func == null)
 				throw new ArgumentNullException(nameof(func));
+			
 			var ts = new TaskCompletionSource<T>();
-			if (UIThread == Thread.CurrentThread)
-			{
+
+			Action funcCall = () => {
 				try {
 					toolkit.EnterUserCode();
 					ts.SetResult(func());
@@ -244,21 +236,12 @@ namespace Xwt
 				} finally {
 					toolkit.ExitUserCode(null);
 				}
-			}
+			};
+
+			if (UIThread == Thread.CurrentThread)
+				funcCall();
 			else
-			{
-				engine.InvokeAsync(delegate
-				{
-					try {
-						toolkit.EnterUserCode();
-						ts.SetResult(func());
-					} catch (Exception ex) {
-						ts.SetException(ex);
-					} finally {
-						toolkit.ExitUserCode(null);
-					}
-				});
-			}
+				engine.InvokeAsync(funcCall);
 			return ts.Task;
 		}
 		

--- a/Xwt/Xwt/Toolkit.cs
+++ b/Xwt/Xwt/Toolkit.cs
@@ -430,6 +430,19 @@ namespace Xwt
 				currentEngine = oldEngine;
 			}
 		}
+
+		internal void InvokeAndThrow (Action a)
+		{
+			var oldEngine = currentEngine;
+			try {
+				currentEngine = this;
+				EnterUserCode();
+				a();
+			} finally {
+				ExitUserCode(null);
+				currentEngine = oldEngine;
+			}
+		}
 		
 		/// <summary>
 		/// Invokes an action after the user code has been processed.

--- a/Xwt/Xwt/Toolkit.cs
+++ b/Xwt/Xwt/Toolkit.cs
@@ -411,9 +411,16 @@ namespace Xwt
 		}
 
 		/// <summary>
-		/// Invokes the specified action on the GUI Thread.
+		/// Invokes the specified action using this toolkit.
 		/// </summary>
-		/// <param name="a">The action to invoke on the main GUI thread.</param>
+		/// <param name="a">The action to invoke in the context of this toolkit.</param>
+		/// <remarks>
+		/// Invoke allows dynamic toolkit switching. It will set <see cref="CurrentEngine"/> to this toolkit and reset
+		/// it back to its original value after the action has been executed.
+		/// 
+		/// Invoke must be executed on the UI thread. The action will not be synchronized with the main UI thread automatically.
+		/// </remarks>
+		/// <returns><c>true</c> if the action has been executed sucessfully; otherwise, <c>false</c>.</returns>
 		public bool Invoke (Action a)
 		{
 			var oldEngine = currentEngine;

--- a/Xwt/Xwt/XwtComponent.cs
+++ b/Xwt/Xwt/XwtComponent.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Xwt.Backends;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Xwt
 {
@@ -109,11 +110,48 @@ namespace Xwt
 				throw new InvalidConstructorInvocation (typeof(T));
 		}
 
+
+		/// <summary>
+		/// Invokes an action in the GUI thread.
+		/// </summary>
+		public Task InvokeAsync(Action action)
+		{
+			if (action == null)
+				throw new ArgumentNullException(nameof(action));
+			var dispatcher = backendHost.Backend as IDispatcherBackend;
+			if (dispatcher != null)
+				return dispatcher.InvokeAsync(() => backendHost.ToolkitEngine.InvokeAndThrow(action));
+			return Application.InvokeAsync(() => backendHost.ToolkitEngine.InvokeAndThrow(action));
+		}
+
+		/// <summary>
+		/// Invokes a function in the GUI thread.
+		/// </summary>
+		public Task<T> InvokeAsync<T>(Func<T> func)
+		{
+			if (func == null)
+				throw new ArgumentNullException(nameof(func));
+			var dispatcher = backendHost.Backend as IDispatcherBackend;
+			if (dispatcher != null)
+				return dispatcher.InvokeAsync(() =>
+					{
+						T result = default(T);
+						backendHost.ToolkitEngine.InvokeAndThrow(() => result = func());
+						return result;
+					});
+			return Application.InvokeAsync(() =>
+					{
+						T result = default(T);
+						backendHost.ToolkitEngine.InvokeAndThrow(() => result = func());
+						return result;
+					});
+		}
+
 		#region ISynchronizeInvoke implementation
 
 		IAsyncResult ISynchronizeInvoke.BeginInvoke (Delegate method, object[] args)
 		{
-			var asyncResult = new AsyncInvokeResult ();
+			var asyncResult = new AsyncInvokeResult (backendHost.Backend);
 			asyncResult.Invoke (method, args);
 			return asyncResult;
 		}
@@ -149,24 +187,39 @@ namespace Xwt
 	class AsyncInvokeResult : IAsyncResult
 	{
 		ManualResetEventSlim asyncResetEvent = new ManualResetEventSlim (false);
+		IDispatcherBackend dispatcher;
 
-		public AsyncInvokeResult ()
+		public AsyncInvokeResult(IBackend backend)
 		{
-			this.asyncResetEvent = new ManualResetEventSlim ();
+			dispatcher = backend as IDispatcherBackend;
+			this.asyncResetEvent = new ManualResetEventSlim();
 		}
 
 		internal void Invoke (Delegate method, object[] args)
 		{
-			Application.Invoke (delegate {
-				try {
-					AsyncState = method.DynamicInvoke(args);
-				} catch (Exception ex){
-					Exception = ex;
-				} finally {
-					IsCompleted = true;
-					asyncResetEvent.Set ();
-				}
-			});
+			if (dispatcher != null) {
+				dispatcher.InvokeAsync (delegate {
+					try {
+						AsyncState = method.DynamicInvoke(args);
+					} catch (Exception ex) {
+						Exception = ex;
+					} finally {
+						IsCompleted = true;
+						asyncResetEvent.Set ();
+					}
+				});
+			} else {
+				Application.Invoke (delegate {
+					try {
+						AsyncState = method.DynamicInvoke(args);
+					} catch (Exception ex){
+						Exception = ex;
+					} finally {
+						IsCompleted = true;
+						asyncResetEvent.Set ();
+					}
+				});
+			}
 		}
 
 		#region IAsyncResult implementation


### PR DESCRIPTION
This PR includes the following optimizations/features:
* new `Application.InvokeAsync` functions which return an observable `Task`
* new `XwtComponent.InvokeAsync` functions to invoke code in the context of a specific Xwt Component/Widget (uses the Toolkit assigned to the component and optionally uses component specific UI sync logic)
* new `IDispatcherBackend` interface for backend specific UI synchronization logic. Inludes WPF support to `DispatcherObject.Dispatcher`.

Especially in Dialogs (and modal Windows in general) `Window.InvokeAsync` should be the preferred synchronization method, because WPF dialogs could run on a different (not the main UI) thread where `Application.Invoke` may block/fail silently.