### PR TITLE
Add translation support

### DIFF
--- a/Xwt.Gtk.Mac/GtkMacOpenFileDialogBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacOpenFileDialogBackend.cs
@@ -46,7 +46,7 @@ namespace Xwt.Gtk.Mac
 			if (!string.IsNullOrEmpty (initialFileName))
 				this.DirectoryUrl = new NSUrl (initialFileName, true);
 
-			this.Prompt = "Select File" + (multiselect ? "s" : "");
+			this.Prompt = Application.TranslationCatalog.GetPluralString("Select File", "Select Files", multiselect ? 2 : 1);
 		}
 
 		public bool Run (IWindowFrameBackend parent)

--- a/Xwt.Gtk.Mac/GtkMacSaveFileDialogBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacSaveFileDialogBackend.cs
@@ -42,7 +42,7 @@ namespace Xwt.Gtk.Mac
 			if (!string.IsNullOrEmpty (initialFileName))
 				this.DirectoryUrl = new NSUrl (initialFileName, true);
 
-			this.Prompt = "Select File";
+			this.Prompt = Application.TranslationCatalog.GetString("Select File");
 		}
 
 		public bool Run (IWindowFrameBackend parent)

--- a/Xwt.Gtk.Mac/GtkMacSelectFolderBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacSelectFolderBackend.cs
@@ -44,7 +44,7 @@ namespace Xwt.Gtk.Mac
 			this.CanChooseFiles = false;
 			this.CanChooseDirectories = true;
 
-			this.Prompt = "Select Folder" + (multiselect ? "s" : "");
+			this.Prompt = Application.TranslationCatalog.GetPluralString("Select Folder", "Select Folders", multiselect ? 2 : 1);
 		}
 
 		public bool Run (IWindowFrameBackend parent)

--- a/Xwt.Gtk/Xwt.GtkBackend/FileDialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/FileDialogBackend.cs
@@ -70,7 +70,7 @@ namespace Xwt.GtkBackend
 				case Gtk.FileChooserAction.SelectFolder:
 				case Gtk.FileChooserAction.CreateFolder:
 					dialog.AddButton (Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
-					dialog.AddButton (Application.TranslationCatalog.GetString("Select Folder"), Gtk.ResponseType.Ok);
+					dialog.AddButton (Application.TranslationCatalog.GetString("Select"), Gtk.ResponseType.Ok);
 					break;
 				case Gtk.FileChooserAction.Save:
 					dialog.AddButton (Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);

--- a/Xwt.Gtk/Xwt.GtkBackend/FileDialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/FileDialogBackend.cs
@@ -70,7 +70,7 @@ namespace Xwt.GtkBackend
 				case Gtk.FileChooserAction.SelectFolder:
 				case Gtk.FileChooserAction.CreateFolder:
 					dialog.AddButton (Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
-					dialog.AddButton ("Select Folder", Gtk.ResponseType.Ok);
+					dialog.AddButton (Application.TranslationCatalog.GetString("Select Folder"), Gtk.ResponseType.Ok);
 					break;
 				case Gtk.FileChooserAction.Save:
 					dialog.AddButton (Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkAlertDialog.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkAlertDialog.cs
@@ -123,7 +123,7 @@ namespace Xwt.GtkBackend
 			}
 			
 			if (message.AllowApplyToAll) {
-				Gtk.CheckButton check = new Gtk.CheckButton ("Apply to all");
+				Gtk.CheckButton check = new Gtk.CheckButton (Application.TranslationCatalog.GetString("Apply to all"));
 				this.AddContent (check, false, false, 0);
 				check.Toggled += delegate {
 					ApplyToAll = check.Active;

--- a/Xwt.XamMac/Xwt.Mac/FileDialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/FileDialogBackend.cs
@@ -55,7 +55,7 @@ namespace Xwt.Mac
 			if (!string.IsNullOrEmpty (initialFileName))
 				this.DirectoryUrl = new NSUrl (initialFileName,true);
 			
-			this.Prompt = "Select File" + (multiselect ? "s" : "");
+			this.Prompt = Application.TranslationCatalog.GetPluralString ("Select File", "Select Files", multiselect ? 2 : 1);
 		}
 
 		public bool Run (IWindowFrameBackend parent)

--- a/Xwt.XamMac/Xwt.Mac/SaveFileDialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/SaveFileDialogBackend.cs
@@ -50,7 +50,7 @@ namespace Xwt.Mac
 			if (!string.IsNullOrEmpty (initialFileName))
 				this.DirectoryUrl = new NSUrl (initialFileName,true);
 
-			this.Prompt = "Select File";
+			this.Prompt = Application.TranslationCatalog.GetString("Select File");
 		}
 
 		public bool Run (IWindowFrameBackend parent)

--- a/Xwt.XamMac/Xwt.Mac/SelectFolderDialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/SelectFolderDialogBackend.cs
@@ -52,7 +52,7 @@ namespace Xwt.Mac
 			this.CanChooseDirectories = true;
 			this.CanCreateDirectories = false;
 			
-			this.Prompt = "Select " + (multiselect ? "Directories" : "Directory" );
+			this.Prompt = Application.TranslationCatalog.GetPluralString("Select Directory", "Select Directories", multiselect ? 2 : 1);
 			
 		}
 

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -345,6 +345,7 @@
     <Compile Include="Xwt\ToolkitDefaults.cs" />
     <Compile Include="Xwt.Backends\IComboBoxCellViewFrontend.cs" />
     <Compile Include="Xwt.Backends\IDispatcherBackend.cs" />
+    <Compile Include="Xwt\ITranslationCatalog.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt/Application.cs
+++ b/Xwt/Xwt/Application.cs
@@ -37,6 +37,7 @@ namespace Xwt
 		static Toolkit toolkit;
 		static ToolkitEngineBackend engine;
 		static UILoop mainLoop;
+		static ITranslationCatalog translationCatalog;
 
 		/// <summary>
 		/// Gets the task scheduler of the current engine.
@@ -60,6 +61,17 @@ namespace Xwt
 		internal static System.Threading.Thread UIThread {
 			get;
 			private set;
+		}
+
+		public static ITranslationCatalog TranslationCatalog {
+			get {
+				if (translationCatalog == null)
+					translationCatalog = new DefaultTranslationCatalog();
+				return translationCatalog;
+			}
+			set {
+				translationCatalog = value;
+			}
 		}
 
 		/// <summary>

--- a/Xwt/Xwt/ColorSelector.cs
+++ b/Xwt/Xwt/ColorSelector.cs
@@ -138,39 +138,39 @@ namespace Xwt
 			VBox entryBox = new VBox ();
 			Table entryTable = new Table ();
 			
-			entryTable.Add (new Label ("Color:"), 0, 0);
+			entryTable.Add (new Label (Application.TranslationCatalog.GetString("Color:")), 0, 0);
 			entryTable.Add (colorBox, 1, 0, colspan:4);
 			entryTable.Add (new HSeparator (), 0, 1, colspan:5);
 			
 			int r = 2;
-			entryTable.Add (new Label ("Hue:"), 0, r);
+			entryTable.Add (new Label (Application.TranslationCatalog.GetString("Hue:")), 0, r);
 			entryTable.Add (hueEntry = new SpinButton () { 
 				MinWidth = entryWidth, MinimumValue = 0, MaximumValue = 360, Digits = 0, IncrementValue = 1 }, 1, r++);
 			
-			entryTable.Add (new Label ("Saturation:"), 0, r);
+			entryTable.Add (new Label (Application.TranslationCatalog.GetString("Saturation:")), 0, r);
 			entryTable.Add (satEntry = new SpinButton () { 
 				MinWidth = entryWidth, MinimumValue = 0, MaximumValue = 100, Digits = 0, IncrementValue = 1 }, 1, r++);
 			
-			entryTable.Add (new Label ("Light:"), 0, r);
+			entryTable.Add (new Label (Application.TranslationCatalog.GetString("Light:")), 0, r);
 			entryTable.Add (lightEntry = new SpinButton () { 
 				MinWidth = entryWidth, MinimumValue = 0, MaximumValue = 100, Digits = 0, IncrementValue = 1 }, 1, r++);
 			
 			r = 2;
-			entryTable.Add (new Label ("Red:"), 3, r);
+			entryTable.Add (new Label (Application.TranslationCatalog.GetString("Red:")), 3, r);
 			entryTable.Add (redEntry = new SpinButton () { 
 				MinWidth = entryWidth, MinimumValue = 0, MaximumValue = 255, Digits = 0, IncrementValue = 1 }, 4, r++);
 			
-			entryTable.Add (new Label ("Green:"), 3, r);
+			entryTable.Add (new Label (Application.TranslationCatalog.GetString("Green:")), 3, r);
 			entryTable.Add (greenEntry = new SpinButton () { 
 				MinWidth = entryWidth, MinimumValue = 0, MaximumValue = 255, Digits = 0, IncrementValue = 1 }, 4, r++);
 			
-			entryTable.Add (new Label ("Blue:"), 3, r);
+			entryTable.Add (new Label (Application.TranslationCatalog.GetString("Blue:")), 3, r);
 			entryTable.Add (blueEntry = new SpinButton () { 
 				MinWidth = entryWidth, MinimumValue = 0, MaximumValue = 255, Digits = 0, IncrementValue = 1 }, 4, r++);
 			
 			Label label;
 			entryTable.Add (alphaSeparator = new HSeparator (), 0, r++, colspan:5);
-			entryTable.Add (label = new Label ("Opacity:"), 0, r);
+			entryTable.Add (label = new Label (Application.TranslationCatalog.GetString("Opacity:")), 0, r);
 			entryTable.Add (alphaSlider = new HSlider () {
 				MinimumValue = 0, MaximumValue = 255,  }, 1, r, colspan: 3);
 			entryTable.Add (alphaEntry = new SpinButton () { 

--- a/Xwt/Xwt/Command.cs
+++ b/Xwt/Xwt/Command.cs
@@ -57,22 +57,22 @@ namespace Xwt
 		
 		public bool IsStockButton { get; private set; }
 		
-		public static Command Ok = new Command ("Ok");
-		public static Command Cancel = new Command ("Cancel");
-		public static Command Yes = new Command ("Yes");
-		public static Command No = new Command ("No");
-		public static Command Close = new Command ("Close");
-		public static Command Delete = new Command ("Delete");
-		public static Command Add = new Command ("Add");
-		public static Command Remove = new Command ("Remove");
-		public static Command Clear = new Command ("Clear");
-		public static Command Copy = new Command ("Copy");
-		public static Command Cut = new Command ("Cut");
-		public static Command Paste = new Command ("Paste");
-		public static Command Save = new Command ("Save");
-		public static Command SaveAs = new Command ("SaveAs");
-		public static Command Stop = new Command ("Stop");
-		public static Command Apply = new Command ("Apply");
+		public static Command Ok = new Command ("Ok", Application.TranslationCatalog.GetString("Ok"));
+		public static Command Cancel = new Command ("Cancel", Application.TranslationCatalog.GetString("Cancel"));
+		public static Command Yes = new Command ("Yes", Application.TranslationCatalog.GetString("Yes"));
+		public static Command No = new Command ("No", Application.TranslationCatalog.GetString("No"));
+		public static Command Close = new Command ("Close", Application.TranslationCatalog.GetString("Close"));
+		public static Command Delete = new Command ("Delete", Application.TranslationCatalog.GetString("Delete"));
+		public static Command Add = new Command ("Add", Application.TranslationCatalog.GetString("Add"));
+		public static Command Remove = new Command ("Remove", Application.TranslationCatalog.GetString("Remove"));
+		public static Command Clear = new Command ("Clear", Application.TranslationCatalog.GetString("Clear"));
+		public static Command Copy = new Command ("Copy", Application.TranslationCatalog.GetString("Copy"));
+		public static Command Cut = new Command ("Cut", Application.TranslationCatalog.GetString("Cut"));
+		public static Command Paste = new Command ("Paste", Application.TranslationCatalog.GetString("Paste"));
+		public static Command Save = new Command ("Save", Application.TranslationCatalog.GetString("Save"));
+		public static Command SaveAs = new Command ("SaveAs", Application.TranslationCatalog.GetString("Save As"));
+		public static Command Stop = new Command ("Stop", Application.TranslationCatalog.GetString("Stop"));
+		public static Command Apply = new Command ("Apply", Application.TranslationCatalog.GetString("Apply"));
 
 		public override string ToString ()
 		{

--- a/Xwt/Xwt/FontSelector.cs
+++ b/Xwt/Xwt/FontSelector.cs
@@ -175,7 +175,7 @@ namespace Xwt
 			spnSize.MinimumValue = 1;
 			spnSize.MaximumValue = 800;
 			spnSize.IncrementValue = 1;
-			PreviewText = "The quick brown fox jumps over the lazy dog.";
+			PreviewText = Application.TranslationCatalog.GetString("The quick brown fox jumps over the lazy dog.");
 
 			spnSize.ValueChanged += (sender, e) => {
 				if (DefaultFontSizes.Contains (spnSize.Value)) {
@@ -211,15 +211,15 @@ namespace Xwt
 			};
 
 			VBox familyBox = new VBox ();
-			familyBox.PackStart (new Label ("Font:"));
+			familyBox.PackStart (new Label (Application.TranslationCatalog.GetString("Font:")));
 			familyBox.PackStart (listFonts, true);
 
 			VBox styleBox = new VBox ();
-			styleBox.PackStart (new Label ("Style:"));
+			styleBox.PackStart (new Label (Application.TranslationCatalog.GetString("Style:")));
 			styleBox.PackStart (listFace, true);
 
 			VBox sizeBox = new VBox ();
-			sizeBox.PackStart (new Label ("Size:"));
+			sizeBox.PackStart (new Label (Application.TranslationCatalog.GetString("Size:")));
 			sizeBox.PackStart (spnSize);
 			sizeBox.PackStart (listSize, true);
 
@@ -232,7 +232,7 @@ namespace Xwt
 			mainBox.MinWidth = 350;
 			mainBox.MinHeight = 300;
 			mainBox.PackStart (fontBox, true);
-			mainBox.PackStart (new Label ("Preview:"));
+			mainBox.PackStart (new Label (Application.TranslationCatalog.GetString("Preview:")));
 			mainBox.PackStart (previewText);
 
 			Content = mainBox;

--- a/Xwt/Xwt/ITranslationCatalog.cs
+++ b/Xwt/Xwt/ITranslationCatalog.cs
@@ -1,0 +1,47 @@
+﻿//
+// ITranslationCatalog.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2016 (c) Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+namespace Xwt
+{
+	public interface ITranslationCatalog
+	{
+		string GetString(string str);
+		string GetPluralString(string singular, string plural, int number);
+	}
+
+	class DefaultTranslationCatalog : ITranslationCatalog
+	{
+		public string GetString(string str)
+		{
+			return str;
+		}
+
+		public string GetPluralString(string singular, string plural, int number)
+		{
+			return number == 1 ? singular : plural;
+		}
+	}
+}

--- a/Xwt/Xwt/SelectFontDialog.cs
+++ b/Xwt/Xwt/SelectFontDialog.cs
@@ -32,8 +32,8 @@ namespace Xwt
 	public sealed class SelectFontDialog
 	{
 		Font font = Font.SystemFont;
-		string title = "Select a font";
-		string previewText = "The quick brown fox jumps over the lazy dog.";
+		string title = Application.TranslationCatalog.GetString("Select a font");
+		string previewText = Application.TranslationCatalog.GetString("The quick brown fox jumps over the lazy dog.");
 
 		public SelectFontDialog ()
 		{


### PR DESCRIPTION
This PR makes internal Xwt strings translatable though a custom `Xwt.ITranslationCatalog` implementation in `Application.TranslationCatalog`. The default implementation simply returns the same unteranslated string.

(closes #627)