### PR TITLE
Fix custom image drawing issues

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
@@ -343,7 +343,7 @@ namespace Xwt.Mac
 		{
 			var s = ctx.Size != CGSize.Empty ? ctx.Size : Size;
 			actx.InvokeUserCode (delegate {
-				drawCallback (ctx, new Rectangle (0, 0, s.Width, s.Height), Image, actx.Toolkit);
+				drawCallback (ctx, new Rectangle (0, 0, s.Width, s.Height), idesc, actx.Toolkit);
 			});
 		}
 

--- a/Xwt/Xwt.Drawing/DrawingImage.cs
+++ b/Xwt/Xwt.Drawing/DrawingImage.cs
@@ -40,10 +40,10 @@ namespace Xwt.Drawing
 		void Draw (object ctx, Rectangle bounds, ImageDescription idesc, Toolkit toolkit)
 		{
 			var c = new Context (ctx, toolkit);
-			if (idesc.Styles != StyleSet.Empty)
-				c.SetStyles (idesc.Styles);
 			c.Reset (null);
 			c.Save ();
+			if (idesc.Styles != StyleSet.Empty)
+				c.SetStyles (idesc.Styles);
 			c.GlobalAlpha = idesc.Alpha;
 			OnDraw (c, bounds);
 			c.Restore ();


### PR DESCRIPTION
This fixes two issues:
1. When drawing more than one custom image with different styles using the same drawing context, the context styles need to be reset each time.
2. `ImageBackendHandler.ConvertToBitmap` may be called with a slightly modified `ImageDescription` which is being passed into the `CustomImage.DrawInContext` call and needs to be used instead the original `CustomImage.Image`. The issue can be reproduced in the ColorSelector example.