### PR TITLE
Use ApplicationContext.Toolkit where appropriate

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/AlertDialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AlertDialogBackend.cs
@@ -76,7 +76,7 @@ namespace Xwt.GtkBackend
 		{			
 			GtkAlertDialog alertDialog = new GtkAlertDialog (context, message);
 			alertDialog.FocusButton (message.DefaultButton);
-			var win = Toolkit.CurrentEngine.GetNativeWindow (transientFor) as Gtk.Window;
+			var win = context.Toolkit.GetNativeWindow (transientFor) as Gtk.Window;
 			MessageService.ShowCustomDialog (alertDialog, win);
 			if (alertDialog.ApplyToAll)
 				ApplyToAll = true;

--- a/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
@@ -39,6 +39,7 @@ namespace Xwt.WPFBackend
 		MessageBoxImage icon;
 		MessageBoxOptions options;
 		MessageBoxResult defaultResult;
+		ApplicationContext context;
 
 		public AlertDialogBackend()
 		{
@@ -50,6 +51,7 @@ namespace Xwt.WPFBackend
 
 		public void Initialize (ApplicationContext actx)
 		{
+			context = actx;
 		}
 
 		public Command Run (WindowFrame transientFor, MessageDescription message)
@@ -63,7 +65,7 @@ namespace Xwt.WPFBackend
 					message.Text = message.Text + "\r\n\r\n" + message.SecondaryText;
 					message.SecondaryText = String.Empty;
 				}
-				var parent =  Toolkit.CurrentEngine.GetNativeWindow(transientFor) as System.Windows.Window;
+				var parent =  context.Toolkit.GetNativeWindow(transientFor) as System.Windows.Window;
 				if (parent != null) {
 					this.dialogResult = MessageBox.Show (parent, message.Text, message.SecondaryText,
 														this.buttons, this.icon, this.defaultResult, this.options);

--- a/Xwt.XamMac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AlertDialogBackend.cs
@@ -118,7 +118,7 @@ namespace Xwt.Mac
 				AccessoryView.SetFrameSize (optionsSize);
 			}
 
-			var win = Toolkit.CurrentEngine.GetNativeWindow (transientFor) as NSWindow;
+			var win = Context.Toolkit.GetNativeWindow (transientFor) as NSWindow;
 			if (win != null)
 				return sortedButtons [(int)this.RunSheetModal (win) - 1000];
 			return sortedButtons [(int)this.RunModal () - 1000];

--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -187,7 +187,7 @@ namespace Xwt.Mac
 				StyleMask |= NSWindowStyle.Miniaturizable;
 			Visible = true;
 			modalSessionRunning = true;
-			var win = parent as NSWindow ?? Toolkit.CurrentEngine.GetNativeWindow (parent) as NSWindow;
+			var win = parent as NSWindow ?? ApplicationContext.Toolkit.GetNativeWindow (parent) as NSWindow;
 			if (win != null) {
 				win.AddChildWindow (this, NSWindowOrderingMode.Above);
 				// always use NSWindow for alignment when running in guest mode and

--- a/Xwt/Xwt/CanvasCellView.cs
+++ b/Xwt/Xwt/CanvasCellView.cs
@@ -64,7 +64,7 @@ namespace Xwt
 
 		void ICanvasCellViewFrontend.Draw (object ctxBackend, Rectangle cellArea)
 		{
-			using (var ctx = new Context (ctxBackend, Toolkit.CurrentEngine)) {
+			using (var ctx = new Context (ctxBackend, BackendHost.ToolkitEngine)) {
 				ctx.Reset (null);
 				OnDraw (ctx, cellArea);
 			}
@@ -81,7 +81,7 @@ namespace Xwt
 		}
 
 		ApplicationContext ICanvasCellViewFrontend.ApplicationContext {
-			get { return new ApplicationContext (Toolkit.CurrentEngine); }
+			get { return new ApplicationContext (BackendHost.ToolkitEngine); }
 		}
 
 		#endregion


### PR DESCRIPTION
`Toolkit.CurrentEngine` should only be used if no `ApplicationContext` an no direct backend ref is available.

This fixes usage of a wrong toolkit in some cross-toolkit scenarios.