### PR TITLE
Add ParentBounds and WindowBounds

### DIFF
--- a/Testing/Tests/WidgetTests.cs
+++ b/Testing/Tests/WidgetTests.cs
@@ -300,6 +300,7 @@ namespace Xwt
 				Assert.AreEqual (defh, w.Size.Height, "fw2");
 			}
 		}
+
 		[Test]
 		public void Coordinates ()
 		{
@@ -315,6 +316,7 @@ namespace Xwt
 				ShowWindow (win);
 
 				Assert.AreEqual (win.ScreenBounds.Inflate (-padding,-padding), w.ScreenBounds);
+				Assert.AreEqual (w.ParentBounds.Location, new Point (padding, padding));
 			}
 		}
 

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -306,6 +306,22 @@ namespace Xwt.GtkBackend
 				return dragDropInfo;
 			}
 		}
+
+		public Point ConvertToParentCoordinates (Point widgetCoordinates)
+		{
+			int x = 0, y = 0;
+			if (RootWidget?.Parent != null)
+				Widget.TranslateCoordinates (RootWidget.Parent, x, y, out x, out y);
+			return new Point (x, y);
+		}
+
+		public Point ConvertToWindowCoordinates (Point widgetCoordinates)
+		{
+			int x = 0, y = 0;
+			if (RootWidget?.Toplevel != null)
+				Widget.TranslateCoordinates (RootWidget.Toplevel, x, y, out x, out y);
+			return new Point (x, y);
+		}
 		
 		public Point ConvertToScreenCoordinates (Point widgetCoordinates)
 		{

--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -266,6 +266,18 @@ namespace Xwt.WPFBackend
 			return backend == null ? null : (FrameworkElement)backend.NativeWidget;
 		}
 
+		public Point ConvertToParentCoordinates (Point widgetCoordinates)
+		{
+			var p = Widget.TranslatePoint (widgetCoordinates.ToWpfPoint (), Frontend.Parent.Surface.NativeWidget as UIElement);
+			return p.ToXwtPoint ();
+		}
+
+		public Point ConvertToWindowCoordinates (Point widgetCoordinates)
+		{
+			var p = Widget.TranslatePoint (widgetCoordinates.ToWpfPoint (), GetParentWindow ());
+			return p.ToXwtPoint ();
+		}
+
 		public Point ConvertToScreenCoordinates (Point widgetCoordinates)
 		{
 			var p = Widget.PointToScreenDpiAware (new System.Windows.Point (

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -98,6 +98,11 @@ namespace Xwt.Mac
 		{
 			return new Rectangle (v.WidgetX(), v.WidgetY(), v.WidgetWidth(), v.WidgetHeight());
 		}
+
+		public static Point WidgetLocation (this NSView v)
+		{
+			return new Point (v.WidgetX (), v.WidgetY ());
+		}
 		
 		public static void SetWidgetBounds (this NSView v, Rectangle rect)
 		{
@@ -159,6 +164,21 @@ namespace Xwt.Mac
 		public static CGRect ToCGRect (this Rectangle r)
 		{
 			return new CGRect ((nfloat)r.X, (nfloat)r.Y, (nfloat)r.Width, (nfloat)r.Height);
+		}
+
+		public static Rectangle ToXwtRect (this CGRect r)
+		{
+			return new Rectangle (r.X, r.Y, r.Width, r.Height);
+		}
+
+		public static CGPoint ToCGPoint (this Point r)
+		{
+			return new CGPoint ((nfloat)r.X, (nfloat)r.Y);
+		}
+
+		public static Point ToXwtPoint (this CGPoint p)
+		{
+			return new Point (p.X, p.Y);
 		}
 
 		// /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Headers/IconsCore.h

--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -415,7 +415,20 @@ namespace Xwt.Mac
 		}
 		
 		#region IWidgetBackend implementation
-		
+
+		public Point ConvertToParentCoordinates (Point widgetCoordinates)
+		{
+			var location =  Widget.WidgetLocation ();
+			location.X += widgetCoordinates.X;
+			location.Y += widgetCoordinates.Y;
+			return location;
+		}
+
+		public Point ConvertToWindowCoordinates (Point widgetCoordinates)
+		{
+			return Widget.ConvertPointToView (widgetCoordinates.ToCGPoint (), null).ToXwtPoint ();
+		}
+
 		public Point ConvertToScreenCoordinates (Point widgetCoordinates)
 		{
 			var lo = Widget.ConvertPointToView (new CGPoint ((nfloat)widgetCoordinates.X, (nfloat)widgetCoordinates.Y), null);

--- a/Xwt/Xwt.Backends/IWidgetBackend.cs
+++ b/Xwt/Xwt.Backends/IWidgetBackend.cs
@@ -93,6 +93,20 @@ namespace Xwt.Backends
 		Size Size { get; }
 
 		/// <summary>
+		/// Converts widget relative coordinates to its parents coordinates.
+		/// </summary>
+		/// <returns>The parent coordinates.</returns>
+		/// <param name="widgetCoordinates">The relative widget coordinates.</param>
+		Point ConvertToParentCoordinates (Point widgetCoordinates);
+
+		/// <summary>
+		/// Converts widget relative coordinates to its parent window coordinates.
+		/// </summary>
+		/// <returns>The window coordinates.</returns>
+		/// <param name="widgetCoordinates">The relative widget coordinates.</param>
+		Point ConvertToWindowCoordinates (Point widgetCoordinates);
+
+		/// <summary>
 		/// Converts widget relative coordinates to screen coordinates.
 		/// </summary>
 		/// <returns>The screen coordinates.</returns>

--- a/Xwt/Xwt/Widget.cs
+++ b/Xwt/Xwt/Widget.cs
@@ -790,6 +790,42 @@ namespace Xwt
 		}
 
 		/// <summary>
+		/// Converts widget relative coordinates to its parent widget coordinates.
+		/// </summary>
+		/// <returns>The parent widget coordinates.</returns>
+		/// <param name="widgetCoordinates">The relative widget coordinates.</param>
+		public Point ConvertToParentCoordinates (Point widgetCoordinates)
+		{
+			return Backend.ConvertToParentCoordinates (widgetCoordinates);
+		}
+
+		/// <summary>
+		/// Gets the bounds of the widget in its parent window coordinates
+		/// </summary>
+		/// <value>The widget bounds.</value>
+		public Rectangle ParentBounds {
+			get { return new Rectangle (ConvertToParentCoordinates (new Point (0, 0)), Size); }
+		}
+
+		/// <summary>
+		/// Converts widget relative coordinates to its parent window coordinates.
+		/// </summary>
+		/// <returns>The window coordinates.</returns>
+		/// <param name="widgetCoordinates">The relative widget coordinates.</param>
+		public Point ConvertToWindowCoordinates (Point widgetCoordinates)
+		{
+			return Backend.ConvertToWindowCoordinates (widgetCoordinates);
+		}
+
+		/// <summary>
+		/// Gets the bounds of the widget in its parent widgets coordinates
+		/// </summary>
+		/// <value>The widget bounds.</value>
+		public Rectangle WindowBounds {
+			get { return new Rectangle (ConvertToWindowCoordinates (new Point (0, 0)), Size); }
+		}
+
+		/// <summary>
 		/// Converts widget relative coordinates to screen coordinates.
 		/// </summary>
 		/// <returns>The screen coordinates.</returns>


### PR DESCRIPTION
The new ParentBounds and WindowBounds properties and point conversion methods make it possible to retrieve bounds and coordinates relative to a parent widget or the root window of a widget.
New:
* `Widget.ParentBounds`: bounds of a widget relative to its parent widget
* `Widget.WindowBounds`: bounds of a widget relative to its parent window
* `Widget.ConvertToParentCoordinates(Point p)`: convert widget coordinates to parent coordinates
* `Widget.ConvertToWindowCoordinates(Point p)`: convert widget coordinates to window coordinates