### PR TITLE
Optimize Popover impl. + support Gtk based reference widgets

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ButtonBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ButtonBackend.cs
@@ -248,6 +248,36 @@ namespace Xwt.Mac
 			}
 		}
 
+		#if !MONOMAC
+		public override bool AllowsVibrancy {
+			get {
+				// we don't support vibrancy
+				if (EffectiveAppearance.AllowsVibrancy)
+					return false;
+				return base.AllowsVibrancy;
+			}
+		}
+
+		NSButtonType buttonType = NSButtonType.MomentaryPushIn;
+		public override void SetButtonType (NSButtonType aType)
+		{
+			buttonType = aType;
+			base.SetButtonType (aType);
+		}
+
+		public override NSAppearance EffectiveAppearance {
+			get {
+				// HACK: if vibrancy is enabled (inside popover) radios/checks don't handle background drawing correctly
+				// FIXME: this fix doesn't work for the vibrant light theme, the label background is wrong if
+				//        the window background is set to a custom color
+				if (base.EffectiveAppearance.AllowsVibrancy &&
+				    (buttonType == NSButtonType.Switch || buttonType == NSButtonType.Radio))
+					Cell.BackgroundStyle = base.EffectiveAppearance.Name.Contains ("Dark") ? NSBackgroundStyle.Dark : NSBackgroundStyle.Light;
+				return base.EffectiveAppearance;
+			}
+		}
+		#endif
+
 		class ColoredButtonCell : NSButtonCell
 		{
 			public Color? Color { get; set; }

--- a/Xwt.XamMac/Xwt.Mac/ComboBoxBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ComboBoxBackend.cs
@@ -202,6 +202,17 @@ namespace Xwt.Mac
 			if (Backend.Cursor != null)
 				AddCursorRect (Bounds, Backend.Cursor);
 		}
+
+		#if !MONOMAC
+		public override bool AllowsVibrancy {
+			get {
+				// we don't support vibrancy
+				if (EffectiveAppearance.AllowsVibrancy)
+					return false;
+				return base.AllowsVibrancy;
+			}
+		}
+		#endif
 	}
 }
 

--- a/Xwt.XamMac/Xwt.Mac/GtkQuartz.cs
+++ b/Xwt.XamMac/Xwt.Mac/GtkQuartz.cs
@@ -1,0 +1,82 @@
+﻿//
+// GtkQuartz.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Runtime.InteropServices;
+
+#if MONOMAC
+using MonoMac.AppKit;
+using MonoMac.ObjCRuntime;
+#else
+using AppKit;
+using ObjCRuntime;
+#endif
+
+namespace Xwt.Mac
+{
+	static class GtkQuartz
+	{
+		const string LIBQUARTZ = "libgtk-quartz-2.0";
+
+		static System.Reflection.PropertyInfo gdkWindowHandleProp;
+
+		public static NSView GetView (object widget)
+		{
+			if (widget == null)
+				throw new ArgumentNullException (nameof (widget));
+
+			var gdkWindowProp = widget.GetType ().GetProperty ("GdkWindow");
+			if (gdkWindowProp?.PropertyType.FullName != "Gdk.Window")
+				throw new ArgumentException ("Wigdet is not a valid Gtk.Windget", nameof (widget));
+
+			var gdkWindow = gdkWindowProp.GetValue (widget, null);
+
+			if (gdkWindow == null)
+				throw new InvalidOperationException ("Wigdet is not realized");
+
+			if (gdkWindowHandleProp == null)
+				gdkWindowHandleProp = gdkWindow.GetType ().GetProperty ("Handle");
+
+			if (gdkWindowHandleProp?.PropertyType != typeof (IntPtr))
+				throw new ArgumentException ("Wigdet is not a valid Gtk.Windget", nameof (widget));
+
+			var gdkPtr = gdkWindowHandleProp.GetValue (gdkWindow, null);
+
+			var ptr = IntPtr.Zero;
+			if (gdkPtr != null)
+				try {
+					ptr = gdk_quartz_window_get_nsview ((IntPtr)gdkPtr);
+				} catch (Exception ex) {
+					throw new InvalidOperationException ("Unsupported Gtk version", ex);
+				}
+			if (ptr == IntPtr.Zero)
+				return null;
+			return Runtime.GetNSObject (ptr) as NSView;
+		}
+
+		[DllImport (LIBQUARTZ)]
+		static extern IntPtr gdk_quartz_window_get_nsview (IntPtr window);
+	}
+}

--- a/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
@@ -245,6 +245,17 @@ namespace Xwt.Mac
 		{
 			return false;
 		}
+
+		#if !MONOMAC
+		public override bool AllowsVibrancy {
+			get {
+				// we don't support vibrancy
+				if (EffectiveAppearance.AllowsVibrancy)
+					return false;
+				return base.AllowsVibrancy;
+			}
+		}
+		#endif
 	}
 
 	class CustomTextFieldCell: NSTextFieldCell

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -274,28 +274,6 @@ namespace Xwt.Mac
 			}
 		}
 
-		public static NSPopover MakePopover (Widget child)
-		{
-			var popover = new NSPopover {
-				Behavior = NSPopoverBehavior.Transient
-			};
-			var controller = new FactoryViewController (null, child, popover);
-			popover.ContentViewController = controller;
-			popover.WeakDelegate = controller;
-			return popover;
-		}
-
-		public static NSPopover MakePopover (Widget child, Color backgroundColor)
-		{
-			var popover = new NSPopover {
-				Behavior = NSPopoverBehavior.Transient
-			};
-			var controller = new FactoryViewController (null, child, popover) { BackgroundColor = backgroundColor.ToCGColor () };
-			popover.ContentViewController = controller;
-			popover.WeakDelegate = controller;
-			return popover;
-		}
-
 		public static NSRectEdge ToRectEdge (Popover.Position pos)
 		{
 			switch (pos) {

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -37,70 +37,41 @@ namespace Xwt.Mac
 	public class PopoverBackend : IPopoverBackend
 	{
 		NSPopover popover;
-		public event EventHandler Closed;
 
 		class FactoryViewController : NSViewController
 		{
-			Xwt.Widget child;
-			NSView view;
+			readonly Widget child;
 			public CGColor BackgroundColor { get; set; }
 
-			public FactoryViewController (Xwt.Widget child) : base (null, null)
+			public FactoryViewController (Widget child) : base (null, null)
 			{
 				this.child = child;
 			}
 
-			// Called when created from unmanaged code
-			public FactoryViewController (IntPtr handle) : base (handle)
-			{
-			}
-			
-			// Called when created directly from a XIB file
-			[Export ("initWithCoder:")]
-			public FactoryViewController (NSCoder coder) : base (coder)
-			{
-			}
-			
 			public override void LoadView ()
 			{
 				var backend = (ViewBackend)Toolkit.GetBackend (child);
-				view = ((ViewBackend)backend).NativeWidget as NSView;
+				View = backend.Widget;
 
-				if (view.Layer == null)
-					view.WantsLayer = true;
+				if (View.Layer == null)
+					View.WantsLayer = true;
 				if (BackgroundColor != null)
-					view.Layer.BackgroundColor = BackgroundColor;
+					View.Layer.BackgroundColor = BackgroundColor;
 				backend.SetAutosizeMode (true);
 				ForceChildLayout ();
 				// FIXME: unset when the popover is closed
 			}
-			
+
 			void ForceChildLayout ()
 			{
 				((IWidgetSurface)child).Reallocate ();
-			}
-			
-			public override NSView View {
-				get {
-					if (view == null)
-						LoadView ();
-					return view;
-				}
-				set {
-					if (value == null)
-						return;
-					view = value;
-				}
 			}
 		}
 
 		public Color BackgroundColor { get; set; }
 
-		IPopoverEventSink sink;
-		
 		public void Initialize (IPopoverEventSink sink)
 		{
-			this.sink = sink;
 		}
 
 		public void InitializeBackend (object frontend, ApplicationContext context)
@@ -115,7 +86,7 @@ namespace Xwt.Mac
 		{
 		}
 
-		public void Show (Xwt.Popover.Position orientation, Xwt.Widget referenceWidget, Xwt.Rectangle positionRect, Xwt.Widget child)
+		public void Show (Popover.Position orientation, Widget referenceWidget, Rectangle positionRect, Widget child)
 		{
 			popover = MakePopover (child, BackgroundColor);
 			ViewBackend backend = (ViewBackend)Toolkit.GetBackend (referenceWidget);
@@ -129,8 +100,8 @@ namespace Xwt.Mac
 				positionRect.Height = 1;
 
 			popover.Show (positionRect.ToCGRect (),
-			              reference,
-			              ToRectEdge (orientation));
+				      reference,
+				      ToRectEdge (orientation));
 		}
 
 		public void Hide ()
@@ -143,7 +114,7 @@ namespace Xwt.Mac
 			popover.Close ();
 		}
 
-		public static NSPopover MakePopover (Xwt.Widget child)
+		public static NSPopover MakePopover (Widget child)
 		{
 			return new NSPopover {
 				Behavior = NSPopoverBehavior.Transient,
@@ -151,20 +122,19 @@ namespace Xwt.Mac
 			};
 		}
 
-		public static NSPopover MakePopover (Xwt.Widget child, Color backgroundColor)
+		public static NSPopover MakePopover (Widget child, Color backgroundColor)
 		{
 			return new NSPopover {
 				Behavior = NSPopoverBehavior.Transient,
 				ContentViewController = new FactoryViewController (child) { BackgroundColor = backgroundColor.ToCGColor () }
 			};
 		}
-		
-		public static NSRectEdge ToRectEdge (Xwt.Popover.Position pos)
+
+		public static NSRectEdge ToRectEdge (Popover.Position pos)
 		{
 			switch (pos) {
 			case Popover.Position.Top:
 				return NSRectEdge.MaxYEdge;
-			case Popover.Position.Bottom:
 			default:
 				return NSRectEdge.MinYEdge;
 			}

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -37,6 +37,7 @@ namespace Xwt.Mac
 {
 	public class PopoverBackend : IPopoverBackend
 	{
+		public Popover Frontend { get; private set; }
 		public ApplicationContext ApplicationContext { get; set; }
 		public IPopoverEventSink EventSink { get; set; }
 		internal bool EnableCloseEvent { get; private set; }
@@ -68,6 +69,8 @@ namespace Xwt.Mac
 					View.Layer.BackgroundColor = BackgroundColor;
 
 				WidgetSpacing padding = 0;
+				if (Backend != null)
+					padding = Backend.Frontend.Padding;
 				View.AddConstraints (new NSLayoutConstraint [] {
 					NSLayoutConstraint.Create (NativeChild, NSLayoutAttribute.Left, NSLayoutRelation.Equal, View, NSLayoutAttribute.Left, 1, (nfloat)padding.Left),
 					NSLayoutConstraint.Create (NativeChild, NSLayoutAttribute.Right, NSLayoutRelation.Equal, View, NSLayoutAttribute.Right, 1, -(nfloat)padding.Right),
@@ -82,6 +85,8 @@ namespace Xwt.Mac
 				ChildBackend.SetAutosizeMode (true);
 				Child.Surface.Reallocate ();
 				WidgetSpacing padding = 0;
+				if (Backend != null)
+					padding = Backend.Frontend.Padding;
 				NativeChild.SetFrameOrigin (new CGPoint ((nfloat)padding.Left, (nfloat)padding.Top));
 			}
 
@@ -106,6 +111,7 @@ namespace Xwt.Mac
 		public void InitializeBackend (object frontend, ApplicationContext context)
 		{
 			ApplicationContext = context;
+			Frontend = frontend as Popover;
 		}
 
 		public void EnableEvent (object eventId)

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -63,11 +63,6 @@ namespace Xwt.Mac
 				View = new NSView ();
 				View.AddSubview (NativeChild);
 
-				if (View.Layer == null)
-					View.WantsLayer = true;
-				if (BackgroundColor != null)
-					View.Layer.BackgroundColor = BackgroundColor;
-
 				WidgetSpacing padding = 0;
 				if (Backend != null)
 					padding = Backend.Frontend.Padding;
@@ -84,6 +79,11 @@ namespace Xwt.Mac
 			{
 				ChildBackend.SetAutosizeMode (true);
 				Child.Surface.Reallocate ();
+				if (BackgroundColor != null) {
+					if (View.Window.ContentView.Superview.Layer == null)
+						View.Window.ContentView.Superview.WantsLayer = true;
+					View.Window.ContentView.Superview.Layer.BackgroundColor = BackgroundColor;
+				}
 				WidgetSpacing padding = 0;
 				if (Backend != null)
 					padding = Backend.Frontend.Padding;
@@ -101,7 +101,16 @@ namespace Xwt.Mac
 			}
 		}
 
-		public Color BackgroundColor { get; set; }
+		CGColor backgroundColor;
+
+		public Color BackgroundColor {
+			get {
+				return (backgroundColor ?? NSColor.WindowBackground.CGColor).ToXwtColor ();
+			}
+			set {
+				backgroundColor = value.ToCGColor ();
+			}
+		}
 
 		public void Initialize (IPopoverEventSink sink)
 		{
@@ -153,7 +162,7 @@ namespace Xwt.Mac
 			popover = new NSPopover {
 				Behavior = NSPopoverBehavior.Transient
 			};
-			var controller = new FactoryViewController (this, child) { BackgroundColor = BackgroundColor.ToCGColor () };
+			var controller = new FactoryViewController (this, child) { BackgroundColor = backgroundColor };
 			popover.ContentViewController = controller;
 			popover.WeakDelegate = controller;
 

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -183,17 +183,22 @@ namespace Xwt.Mac
 
 		public static NSPopover MakePopover (Widget child)
 		{
+			var controller = new FactoryViewController (null, child);
 			return new NSPopover {
 				Behavior = NSPopoverBehavior.Transient,
-				ContentViewController = new FactoryViewController (null, child)
+				ContentViewController = controller,
+				WeakDelegate = controller
 			};
 		}
 
 		public static NSPopover MakePopover (Widget child, Color backgroundColor)
 		{
+
+			var controller = new FactoryViewController (null, child) { BackgroundColor = backgroundColor.ToCGColor () };
 			return new NSPopover {
 				Behavior = NSPopoverBehavior.Transient,
-				ContentViewController = new FactoryViewController (null, child) { BackgroundColor = backgroundColor.ToCGColor () }
+				ContentViewController = controller,
+				WeakDelegate = controller
 			};
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -3,6 +3,7 @@
 //
 // Author:
 //       Jérémie Laval <jeremie.laval@xamarin.com>
+//       Vsevolod Kukol <sevoku@microsoft.com>
 //
 // Copyright (c) 2012 Xamarin, Inc.
 //
@@ -88,7 +89,6 @@ namespace Xwt.Mac
 
 		public void Show (Popover.Position orientation, Widget referenceWidget, Rectangle positionRect, Widget child)
 		{
-			popover = MakePopover (child, BackgroundColor);
 			ViewBackend backend = (ViewBackend)Toolkit.GetBackend (referenceWidget);
 			var reference = backend.Widget;
 
@@ -99,6 +99,8 @@ namespace Xwt.Mac
 			if (Math.Abs (positionRect.Height) < double.Epsilon)
 				positionRect.Height = 1;
 
+			DestroyPopover ();
+			popover = MakePopover (child, BackgroundColor);
 			popover.Show (positionRect.ToCGRect (),
 				      reference,
 				      ToRectEdge (orientation));
@@ -106,12 +108,21 @@ namespace Xwt.Mac
 
 		public void Hide ()
 		{
-			popover.Close ();
+			DestroyPopover ();
 		}
 
 		public void Dispose ()
 		{
-			popover.Close ();
+			DestroyPopover ();
+		}
+
+		void DestroyPopover ()
+		{
+			if (popover != null) {
+				popover.Close ();
+				popover.Dispose ();
+				popover = null;
+			}
 		}
 
 		public static NSPopover MakePopover (Widget child)

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -168,12 +168,12 @@ namespace Xwt.Mac
 			ViewBackend backend = (ViewBackend)Toolkit.GetBackend (referenceWidget);
 			var reference = backend.Widget;
 
-			// If the position rect is empty, the coordinates of the rect will be ignored.
-			// Width and Height of the rect must be > Epsilon, for the positioning to function correctly.
+			// If the rect is empty, the coordinates of the rect will be ignored.
+			// Set the width and height, for the positioning to function correctly.
 			if (Math.Abs (positionRect.Width) < double.Epsilon)
-				positionRect.Width = 1;
+				positionRect.Width = referenceWidget.Size.Width;
 			if (Math.Abs (positionRect.Height) < double.Epsilon)
-				positionRect.Height = 1;
+				positionRect.Height = referenceWidget.Size.Height;
 
 			DestroyPopover ();
 

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -92,15 +92,13 @@ namespace Xwt.Mac
 				{
 					this.controller = controller;
 				}
-				
-				#if !MONOMAC
+
 				public override bool AllowsVibrancy {
 					get {
 						// disable vibrancy for custom background
 						return controller.BackgroundColor == null ? base.AllowsVibrancy : false;
 					}
 				}
-				#endif
 			}
 
 			[Export ("popoverWillShow:")]
@@ -237,13 +235,11 @@ namespace Xwt.Mac
 			};
 			var controller = new FactoryViewController (this, child, popover) { BackgroundColor = backgroundColor };
 			popover.ContentViewController = controller;
-			popover.WeakDelegate = controller;
+			popover.Delegate = controller;
 
-			#if !MONOMAC
 			// if the reference has a custom appearance, use it for the popover
 			if (popover is INSAppearanceCustomization && refView.EffectiveAppearance.Name != NSAppearance.NameAqua)
 				((INSAppearanceCustomization)popover).SetAppearance (refView.EffectiveAppearance);
-			#endif
 
 			popover.Show (positionRect.ToCGRect (),
 				      refView,
@@ -264,9 +260,9 @@ namespace Xwt.Mac
 		{
 			if (popover != null) {
 				popover.Close ();
-				var controller = popover.WeakDelegate as FactoryViewController;
+				var controller = popover.Delegate as FactoryViewController;
 				if (controller != null) {
-					popover.WeakDelegate = null;
+					popover.Delegate = null;
 					controller.Dispose ();
 				}
 				popover.Dispose ();
@@ -284,11 +280,7 @@ namespace Xwt.Mac
 			}
 		}
 
-		#if MONOMAC
-		public class NSAppearanceCustomizationPopover : NSPopover
-		#else
 		public class NSAppearanceCustomizationPopover : NSPopover, INSAppearanceCustomization
-		#endif
 		{
 		}
 	}

--- a/Xwt.XamMac/Xwt.Mac/SeparatorBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/SeparatorBackend.cs
@@ -54,6 +54,17 @@ namespace Xwt.Mac
 		public NSView View {
 			get { return this; }
 		}
+
+		#if !MONOMAC
+		public override bool AllowsVibrancy {
+			get {
+				// we don't support vibrancy
+				if (EffectiveAppearance.AllowsVibrancy)
+					return false;
+				return base.AllowsVibrancy;
+			}
+		}
+		#endif
 	}
 }
 

--- a/Xwt.XamMac/Xwt.Mac/SliderBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/SliderBackend.cs
@@ -202,6 +202,17 @@ namespace Xwt.Mac
 				((MacSliderCell)Cell).StepIncrement = value;
 			}
 		}
+
+		#if !MONOMAC
+		public override bool AllowsVibrancy {
+			get {
+				// we don't support vibrancy
+				if (EffectiveAppearance.AllowsVibrancy)
+					return false;
+				return base.AllowsVibrancy;
+			}
+		}
+		#endif
 	}
 
 	public class MacSliderCell : NSSliderCell

--- a/Xwt.XamMac/Xwt.Mac/SpinButtonBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/SpinButtonBackend.cs
@@ -118,7 +118,7 @@ namespace Xwt.Mac
 		{
 			this.eventSink = eventSink;
 			formater = new NSNumberFormatter ();
-			stepper = new NSStepper ();
+			stepper = new VibrancyStepper ();
 			input = new NSTextField ();
 			input.Formatter = formater;
 			input.DoubleValue = 0;
@@ -331,6 +331,20 @@ namespace Xwt.Mac
 				case SpinButtonEvent.ValueChanged: enableValueChangedEvent = false; break;
 				}
 			}
+		}
+
+		class VibrancyStepper : NSStepper
+		{
+			#if !MONOMAC
+			public override bool AllowsVibrancy {
+				get {
+					// we don't support vibrancy
+					if (EffectiveAppearance.AllowsVibrancy)
+						return false;
+					return base.AllowsVibrancy;
+				}
+			}
+			#endif
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.XamMac.csproj
+++ b/Xwt.XamMac/Xwt.XamMac.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Xwt.Mac\CalendarBackend.cs" />
     <Compile Include="Xwt.Mac\SelectFontDialogBackend.cs" />
     <Compile Include="Xwt.Mac\NSApplicationInitializer.cs" />
+    <Compile Include="Xwt.Mac\GtkQuartz.cs" />
   </ItemGroup>
   <Import Project="..\BuildHelpers.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This PR includes various PopoverBackend fixes:
* `Closed` event was missing
* Resizing fixed
* `Padding` was missing
* `BackgroundColor` fixed
* Support for custom NSAppearance
* Positioning fixed

The last commit 29c280388e0679b9514ddf60daa83e088a2e6539 allows to attach a Popover to a Gtk based Widget. 