### PR TITLE
Fix special font name parsing and font unit tests

### DIFF
--- a/Testing/Tests/FontTests.cs
+++ b/Testing/Tests/FontTests.cs
@@ -230,6 +230,40 @@ namespace Xwt
 		}
 
 		[Test]
+		public void FontNameWithNumber()
+		{
+			var font = Font.FromName("____FakeTestFont 72");
+			Assert.AreEqual("Arial", font.Family);
+			Assert.AreNotEqual(72d, font.Size); // 72 is part of the font name and not the size
+		}
+
+		[Test]
+		public void FontNameWithNumberAndStyles()
+		{
+			var font = Font.FromName("____FakeTestFont 72 18 Bold");
+			Assert.AreEqual("Arial", font.Family);
+			Assert.AreEqual(18d, font.Size);
+			Assert.AreEqual(FontWeight.Bold, font.Weight);
+		}
+
+		[Test]
+		public void FontNameWithWeight()
+		{
+			var font = Font.FromName("____FakeTestFont Rounded MT Bold");
+			Assert.AreEqual("Arial", font.Family);
+			Assert.AreNotEqual(FontWeight.Bold, font.Weight); // Bold is part of the name and not the weight
+		}
+
+		[Test]
+		public void FontNameWithWeightAndStyles()
+		{
+			var font = Font.FromName("____FakeTestFont Rounded MT Bold Bold 18");
+			Assert.AreEqual("Arial", font.Family);
+			Assert.AreEqual(18d, font.Size);
+			Assert.AreEqual(FontWeight.Bold, font.Weight); // Bold is part of the name and the weight
+		}
+
+		//[Test]
 		public void RenderWeight ()
 		{
 			var font = "Avenir Next";

--- a/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/FontBackendHandler.cs
@@ -70,8 +70,6 @@ namespace Xwt.GtkBackend
 
 		public override object Create (string fontName, double size, FontStyle style, FontWeight weight, FontStretch stretch)
 		{
-			if (Platform.IsMac && fontName == ".AppleSystemUIFont")
-				fontName = "-apple-system-font";
 			return FontDescription.FromString (fontName + ", " + style + " " + weight + " " + stretch + " " + size.ToString (CultureInfo.InvariantCulture));
 		}
 

--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -241,6 +241,10 @@ namespace Xwt.Drawing
 				foreach (var f in Toolkit.CurrentEngine.FontBackendHandler.GetInstalledFonts ())
 					installedFonts [f] = f;
 				installedFontsArray = new ReadOnlyCollection<string> (installedFonts.Values.ToArray ());
+				// add dummy font names for unit tests, the names are not exposed to users
+				// see the FontNameWith* tests (Testing/Tests/FontTests.cs) for details
+				installedFonts.Add("____FakeTestFont 72", "Arial");
+				installedFonts.Add("____FakeTestFont Rounded MT Bold", "Arial");
 			}
 		}
 

--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -186,15 +186,16 @@ namespace Xwt.Drawing
 				return Font.SystemFont;
 		}
 
-		static bool IsFontSupported (string fontNames)
+		static bool IsFontSupported (string fontName)
 		{
-			LoadInstalledFonts ();
-
-			string[] names = fontNames.Split (new [] {','}, StringSplitOptions.RemoveEmptyEntries);
-			if (names.Length == 0)
-				throw new ArgumentException ("Font family name not provided");
+			if (fontName == null)
+				throw new ArgumentNullException(nameof (fontName), "Font family name not provided");
+			if (fontName == string.Empty)
+				return false;
 			
-			return names.Any (name => installedFonts.ContainsKey (name.Trim ()));
+			LoadInstalledFonts ();
+			
+			return installedFonts.ContainsKey (fontName.Trim ());
 		}
 
 		static string GetSupportedFont (string fontNames)


### PR DESCRIPTION
This PR fixes some issues and failing font tests introduced in #544. Additionally it includes new tests for special font names.