### PR TITLE
Optimize XamMac ScrollView

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ScrollViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ScrollViewBackend.cs
@@ -123,7 +123,9 @@ namespace Xwt.Mac
 
 		public Rectangle VisibleRect {
 			get {
-				return Rectangle.Zero;
+				if (Widget.ContentView == null)
+					return Rectangle.Zero;
+				return Widget.ContentView.DocumentVisibleRect ().ToXwtRect ();
 			}
 		}
 		

--- a/Xwt.XamMac/Xwt.Mac/ScrollViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ScrollViewBackend.cs
@@ -59,6 +59,7 @@ namespace Xwt.Mac
 				var vs = new ScrollAdjustmentBackend (Widget, true);
 				var hs = new ScrollAdjustmentBackend (Widget, false);
 				CustomClipView clipView = new CustomClipView (hs, vs);
+				clipView.Scrolled += OnScrolled;
 				Widget.ContentView = clipView;
 				var dummy = new DummyClipView ();
 				dummy.AddSubview (backend.Widget);
@@ -119,6 +120,7 @@ namespace Xwt.Mac
 				((ScrollControlBackend)vertScroll).NotifyValueChanged ();
 			if (horScroll is ScrollControlBackend)
 				((ScrollControlBackend)horScroll).NotifyValueChanged ();
+			ApplicationContext.InvokeUserCode (EventSink.OnVisibleRectChanged);
 		}
 
 		public Rectangle VisibleRect {
@@ -210,6 +212,7 @@ namespace Xwt.Mac
 	
 	class CustomClipView: NSClipView
 	{
+		public event EventHandler Scrolled;
 		ScrollAdjustmentBackend hScroll;
 		ScrollAdjustmentBackend vScroll;
 		double currentX;
@@ -270,6 +273,8 @@ namespace Xwt.Mac
 
 			hScroll.NotifyValueChanged ();
 			vScroll.NotifyValueChanged ();
+			if (Scrolled != null)
+				Scrolled (this, EventArgs.Empty);
 		}
 
 		public void UpdateDocumentSize ()

--- a/Xwt.XamMac/Xwt.Mac/ScrollViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ScrollViewBackend.cs
@@ -129,9 +129,13 @@ namespace Xwt.Mac
 		
 		public bool BorderVisible {
 			get {
-				return false;
+				return Widget.BorderType != NSBorderType.NoBorder;
 			}
 			set {
+				if (value)
+					Widget.BorderType = NSBorderType.BezelBorder;
+				else
+					Widget.BorderType = NSBorderType.NoBorder;
 			}
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -139,6 +139,11 @@ namespace Xwt.Mac
 			return new Color (cs[0], cs[1], cs[2], col.Alpha);
 		}
 
+		public static CGSize ToCGSize (this Size s)
+		{
+			return new CGSize ((nfloat)s.Width, (nfloat)s.Height);
+		}
+
 		public static Size ToXwtSize (this CGSize s)
 		{
 			return new Size (s.Width, s.Height);


### PR DESCRIPTION
This PR fixes issues with ScrollView sizing and adds some missing backend features.

Fixed Sizing:
* Support `Margin` and `WidgetPlacement` of the child using `WidgetPlacementWrapper`
* Calculate preferred size based on child size (incl. placement request) and the current scrolling policies.
* Reallocate based on new preferred size calculation and take own size requisition into account.

Missing Features:
* `BorderVisible` property
* `VisibleRect` property
* `VisibleRectChanged` event