### PR TITLE
Fix label markup sizing

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
@@ -91,8 +91,12 @@ namespace Xwt.Mac
 
 		public void SetFormattedText (FormattedText text)
 		{
+			// HACK: wrapping needs to be enabled in order to display Attributed string correctly on Mac
+			if (Wrap == WrapMode.None)
+				Wrap = WrapMode.Character;
 			Widget.AllowsEditingTextAttributes = true;
 			Widget.AttributedStringValue = text.ToAttributedString ();
+			ResetFittingSize ();
 		}
 
 		public Xwt.Drawing.Color TextColor {

--- a/Xwt/Xwt/Label.cs
+++ b/Xwt/Xwt/Label.cs
@@ -82,6 +82,7 @@ namespace Xwt
 				markup = value;
 				var t = FormattedText.FromMarkup (markup);
 				Backend.SetFormattedText (t);
+				OnPreferredSizeChanged ();
 			}
 		}
 


### PR DESCRIPTION
Fixes wrong label size after updating `Label.Markup` and rendering/sizing issues with formatted text inside labels on Mac.