### PR TITLE
Add PopupWindow

### DIFF
--- a/TestApps/Samples/MainWindow.cs
+++ b/TestApps/Samples/MainWindow.cs
@@ -135,6 +135,7 @@ namespace Samples
 
 			var windows = AddSample (null, "Windows", typeof(Windows));
 			AddSample (windows, "Message Dialogs", typeof(MessageDialogs));
+			AddSample (windows, "Popup Windows", typeof(PopupWindows));
 			
 			AddSample (null, "Screens", typeof (ScreensSample));
 

--- a/TestApps/Samples/Samples.csproj
+++ b/TestApps/Samples/Samples.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Samples\FileSelectorSample.cs" />
     <Compile Include="Samples\FolderSelectorSample.cs" />
     <Compile Include="Samples\ListViewCombos.cs" />
+    <Compile Include="Samples\PopupWindows.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/TestApps/Samples/Samples/PopupWindows.cs
+++ b/TestApps/Samples/Samples/PopupWindows.cs
@@ -1,0 +1,86 @@
+﻿//
+// PopupWindows.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2017 (c) Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using Xwt;
+using Xwt.Drawing;
+
+namespace Samples
+{
+	public class PopupWindows : VBox
+	{
+		public PopupWindows ()
+		{
+			var btn1 = new Button ("Show Utility Window");
+			PopupWindow popup1 = null;
+			btn1.Clicked += (sender, e) => {
+				if (popup1 == null) {
+					popup1 = new PopupWindow ();
+					popup1.TransientFor = ParentWindow;
+					popup1.InitialLocation = WindowLocation.CenterParent;
+					popup1.Title = "Utility";
+					var content = new VBox ();
+					content.PackStart (new Label ("Utility Window"));
+					var btn = new Button ("Close");
+					btn.Clicked += delegate { popup1.Close (); };
+					content.PackStart (btn);
+					popup1.Content = content;
+				}
+				popup1.Show ();
+			};
+
+			PackStart (btn1);
+
+
+			var btn2 = new Button ("Show custom Tooltip Window");
+			PopupWindow popup2 = null;
+			btn2.Clicked += (sender, e) => {
+				if (popup2 == null) {
+					popup2 = new PopupWindow (PopupWindow.PopupType.Tooltip);
+					popup2.TransientFor = ParentWindow;
+					popup2.Decorated = false;
+					popup2.Title = "Tooltip";
+					popup2.BackgroundColor = Colors.Blue.WithAlpha (0.7);
+					var l = new Label ("Tooltip Window");
+					l.Margin = 5;
+					l.TextColor = Colors.White;
+					l.MouseExited += (sl, el) => popup2.Hide ();
+					l.VerticalPlacement = l.HorizontalPlacement = WidgetPlacement.Center;
+					l.Margin = new WidgetSpacing (5, 4, 5, 4);
+
+					popup2.Content = l;
+				}
+				if (!popup2.Visible) {
+					btn2.Label = "Hide custom Tooltip Window";
+					popup2.Show ();
+				} else {
+					btn2.Label = "Show custom Tooltip Window";
+					popup2.Hide ();
+				}
+			};
+
+			PackStart (btn2);
+		}
+	}
+}

--- a/TestApps/Samples/Samples/PopupWindows.cs
+++ b/TestApps/Samples/Samples/PopupWindows.cs
@@ -33,21 +33,21 @@ namespace Samples
 		public PopupWindows ()
 		{
 			var btn1 = new Button ("Show Utility Window");
-			PopupWindow popup1 = null;
+			UtilityWindow utility = null;
 			btn1.Clicked += (sender, e) => {
-				if (popup1 == null) {
-					popup1 = new PopupWindow ();
-					popup1.TransientFor = ParentWindow;
-					popup1.InitialLocation = WindowLocation.CenterParent;
-					popup1.Title = "Utility";
+				if (utility == null) {
+					utility = new UtilityWindow ();
+					utility.TransientFor = ParentWindow;
+					utility.InitialLocation = WindowLocation.CenterParent;
+					utility.Title = "Utility";
 					var content = new VBox ();
 					content.PackStart (new Label ("Utility Window"));
 					var btn = new Button ("Close");
-					btn.Clicked += delegate { popup1.Close (); };
+					btn.Clicked += delegate { utility.Close (); };
 					content.PackStart (btn);
-					popup1.Content = content;
+					utility.Content = content;
 				}
-				popup1.Show ();
+				utility.Show ();
 			};
 
 			PackStart (btn1);

--- a/Xwt.Gtk/Xwt.Gtk.csproj
+++ b/Xwt.Gtk/Xwt.Gtk.csproj
@@ -157,6 +157,8 @@
     <Compile Include="Xwt.GtkBackend\FontSelectorBackend.cs" />
     <Compile Include="Xwt.GtkBackend\SelectFontDialogBackend.cs" />
     <Compile Include="Xwt.GtkBackend.CellViews\CustomCellRendererComboBox.cs" />
+    <Compile Include="Xwt.GtkBackend\PopupWindowBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\UtilityWindowBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Xwt.Gtk/Xwt.Gtk3.csproj
+++ b/Xwt.Gtk/Xwt.Gtk3.csproj
@@ -160,6 +160,8 @@
     <Compile Include="Xwt.GtkBackend\SelectFontDialogBackend.cs" />
     <Compile Include="Xwt.GtkBackend\Gtk3FontChooserDialog.cs" />
     <Compile Include="Xwt.GtkBackend\FontSelectorBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\PopupWindowBackend.cs" />
+    <Compile Include="Xwt.GtkBackend\UtilityWindowBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk2PopoverWindow.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk2PopoverWindow.cs
@@ -81,6 +81,7 @@ namespace Xwt.GtkBackend
 
 		protected override bool OnExposeEvent (Gdk.EventExpose evnt)
 		{
+			bool handled;
 			using (Context ctx = Gdk.CairoHelper.Create (this.GdkWindow)) {
 				if (BackgroundColor.HasValue) {
 					// We clear the surface with a transparent color if possible
@@ -91,11 +92,10 @@ namespace Xwt.GtkBackend
 					ctx.Operator = Operator.Source;
 					ctx.Paint ();
 				}
-				OnDraw (ctx);
+				handled = OnDraw (ctx);
 			}
 
-			base.OnExposeEvent (evnt);
-			return false;
+			return handled || base.OnExposeEvent (evnt);
 		}
 	}
 }

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk2PopoverWindow.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk2PopoverWindow.cs
@@ -52,6 +52,7 @@ namespace Xwt.GtkBackend
 
 		public GtkPopoverWindow (Gtk.WindowType type) : base (type)
 		{
+			AppPaintable = true;
 			UpdateColorMap ();
 		}
 
@@ -73,7 +74,7 @@ namespace Xwt.GtkBackend
 			base.OnScreenChanged (previous_screen);
 		}
 
-		protected virtual bool OnDrawn (Cairo.Context cr)
+		protected virtual bool OnDraw (Cairo.Context cr)
 		{
 			return false;
 		}
@@ -90,7 +91,7 @@ namespace Xwt.GtkBackend
 					ctx.Operator = Operator.Source;
 					ctx.Paint ();
 				}
-				OnDrawn (ctx);
+				OnDraw (ctx);
 			}
 
 			base.OnExposeEvent (evnt);

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk3PopoverWindow.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk3PopoverWindow.cs
@@ -28,30 +28,87 @@ using Cairo;
 
 namespace Xwt.GtkBackend
 {
-	public abstract class GtkPopoverWindow : Gtk.Window
+	public class GtkPopoverWindow : Gtk.Window
 	{
 		protected bool supportAlpha = true;
-
-		protected GtkPopoverWindow (Gtk.WindowType type) : base (type)
-		{}
-
-		protected override void OnScreenChanged (Gdk.Screen previous_screen)
+		protected bool SupportAlpha
 		{
-			// To check if the display supports alpha channels, get the colormap
-			var visual = this.Screen.RgbaVisual;
-			if (visual == null) {
-				visual = this.Screen.SystemVisual;
-				supportAlpha = false;
-			} else {
-				supportAlpha = true;
+			get
+			{
+				return supportAlpha;
 			}
-			this.Visual = visual;
-			base.OnScreenChanged (previous_screen);
+			private set
+			{
+				if (supportAlpha != value)
+				{
+					supportAlpha = value;
+					OnSupportAlphaChanged();
+				}
+			}
 		}
 
-		protected override bool OnDrawn (Context cr)
+		protected virtual void OnSupportAlphaChanged()
+		{
+			QueueDraw();
+		}
+
+		Color? backgroundColor;
+
+		public Color? BackgroundColor
+		{
+			get { return backgroundColor; }
+			set {
+				backgroundColor = value;
+				// HACK: with AppPaintable == false Gtk3 doesn't draw the default background.
+				//       Set AppPaintable = true only if a color is not null and is transparent.
+				AppPaintable = backgroundColor?.A < 1.0;
+			}
+		}
+
+		public GtkPopoverWindow (Gtk.WindowType type) : base (type)
+		{
+			UpdateColorMap();
+		}
+
+		void UpdateColorMap()
+		{
+			// To check if the display supports alpha channels, get the colormap
+			var visual = Screen.RgbaVisual;
+			if (visual == null)
+			{
+				visual = Screen.SystemVisual;
+				SupportAlpha = false;
+			}
+			else
+				SupportAlpha = true;
+			Visual = visual;
+		}
+
+		protected override void OnScreenChanged(Gdk.Screen previous_screen)
+		{
+			UpdateColorMap();
+			base.OnScreenChanged(previous_screen);
+		}
+
+		protected virtual bool OnDraw (Cairo.Context cr)
+		{
+			return false;
+		}
+
+		protected sealed override bool OnDrawn (Context cr)
 		{
 			cr.Restore ();
+			if (BackgroundColor.HasValue)
+			{
+				// We clear the surface with a transparent color if possible
+				if (SupportAlpha && BackgroundColor.Value.A < 1.0)
+					cr.SetSourceRGBA(BackgroundColor.Value.R, BackgroundColor.Value.G, BackgroundColor.Value.B, BackgroundColor.Value.A);
+				else
+					cr.SetSourceRGB(BackgroundColor.Value.R, BackgroundColor.Value.G, BackgroundColor.Value.B);
+				cr.Operator = Operator.Source;
+				cr.Paint();
+			}
+			OnDraw(cr);
 			return base.OnDrawn (cr);
 		}
 	}

--- a/Xwt.Gtk/Xwt.GtkBackend/Gtk3PopoverWindow.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Gtk3PopoverWindow.cs
@@ -97,7 +97,6 @@ namespace Xwt.GtkBackend
 
 		protected sealed override bool OnDrawn (Context cr)
 		{
-			cr.Restore ();
 			if (BackgroundColor.HasValue)
 			{
 				// We clear the surface with a transparent color if possible
@@ -108,8 +107,10 @@ namespace Xwt.GtkBackend
 				cr.Operator = Operator.Source;
 				cr.Paint();
 			}
-			OnDraw(cr);
-			return base.OnDrawn (cr);
+			var handled = OnDraw (cr);
+			cr.Restore();
+
+			return handled || base.OnDrawn (cr);
 		}
 	}
 }

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
@@ -114,6 +114,7 @@ namespace Xwt.GtkBackend
 			RegisterBackend<ICalendarBackend, CalendarBackend> ();
 			RegisterBackend<IFontSelectorBackend, FontSelectorBackend> ();
 			RegisterBackend<ISelectFontDialogBackend, SelectFontDialogBackend> ();
+			RegisterBackend<IPopupWindowBackend, WindowBackend> ();
 
 			string typeName = null;
 			string asmName = null;

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
@@ -114,7 +114,8 @@ namespace Xwt.GtkBackend
 			RegisterBackend<ICalendarBackend, CalendarBackend> ();
 			RegisterBackend<IFontSelectorBackend, FontSelectorBackend> ();
 			RegisterBackend<ISelectFontDialogBackend, SelectFontDialogBackend> ();
-			RegisterBackend<IPopupWindowBackend, WindowBackend> ();
+			RegisterBackend<IPopupWindowBackend, PopupWindowBackend> ();
+			RegisterBackend<IUtilityWindowBackend, UtilityWindowBackend> ();
 
 			string typeName = null;
 			string asmName = null;

--- a/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
@@ -145,7 +145,7 @@ namespace Xwt.GtkBackend
 			}
 
 
-			protected override bool OnDrawn (Context cr)
+			protected override bool OnDraw (Context cr)
 			{
 				int w, h;
 				this.GdkWindow.GetSize (out w, out h);
@@ -173,7 +173,7 @@ namespace Xwt.GtkBackend
 				cr.SetSourceRGBA (BackgroundColor.R, BackgroundColor.G, BackgroundColor.B, BackgroundColor.A);
 				cr.Fill ();
 
-				return base.OnDrawn (cr);
+				return base.OnDraw (cr);
 			}
 			
 			void DrawTriangle (Context ctx)

--- a/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
@@ -46,8 +46,17 @@ namespace Xwt.GtkBackend
 			WidgetSpacing padding;
 			Gtk.Alignment alignment;
 			int arrowDelta;
+			Color backgroundColor;
 
-			public Color BackgroundColor { get; set; }
+			public new Color BackgroundColor {
+				get {
+					return backgroundColor;
+				}
+				set {
+					backgroundColor = value;
+					UpdateBaseColor ();
+				}
+			}
 
 			public Xwt.Popover.Position ArrowPosition {
 				get {
@@ -114,8 +123,19 @@ namespace Xwt.GtkBackend
 				this.alignment = new Gtk.Alignment (0, 0, 1, 1);
 				this.alignment.Show ();
 				this.Add (alignment);
+			}
 
-				OnScreenChanged (null);
+			protected override void OnSupportAlphaChanged ()
+			{
+				UpdateBaseColor ();
+			}
+
+			void UpdateBaseColor ()
+			{
+				if (SupportAlpha)
+					base.BackgroundColor = Drawing.Colors.Transparent.ToCairoColor ();
+				else
+					base.BackgroundColor = BackgroundColor;
 			}
 
 			protected override void OnSizeAllocated (Gdk.Rectangle allocation)
@@ -129,14 +149,6 @@ namespace Xwt.GtkBackend
 			{
 				int w, h;
 				this.GdkWindow.GetSize (out w, out h);
-				
-				// We clear the surface with a transparent color if possible
-				if (supportAlpha)
-					cr.SetSourceRGBA (1.0, 1.0, 1.0, 0.0);
-				else
-					cr.SetSourceRGB (1.0, 1.0, 1.0);
-				cr.Operator = Operator.Source;
-				cr.Paint ();
 
 				cr.LineWidth = GtkWorkarounds.GetScaleFactor (Content) > 1 ? 2 : 1;
 				var bounds = new Xwt.Rectangle (cr.LineWidth / 2, cr.LineWidth / 2, w - cr.LineWidth, h - cr.LineWidth);
@@ -153,7 +165,7 @@ namespace Xwt.GtkBackend
 				DrawTriangle (cr);
 
 				// We use it
-				if (supportAlpha)
+				if (SupportAlpha)
 					cr.SetSourceRGBA (0.0, 0.0, 0.0, 0.2);
 				else
 					cr.SetSourceRGB (238d / 255d, 238d / 255d, 238d / 255d);

--- a/Xwt.Gtk/Xwt.GtkBackend/PopupWindowBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopupWindowBackend.cs
@@ -1,0 +1,63 @@
+﻿//
+// PopupWindowBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Xwt.Backends;
+
+namespace Xwt.GtkBackend
+{
+	public class PopupWindowBackend : WindowBackend, IPopupWindowBackend
+	{
+		PopupWindow.PopupType windowType;
+
+		public override void Initialize ()
+		{
+			Window = new GtkPopoverWindow (Gtk.WindowType.Toplevel);
+			Window.TypeHint = Gdk.WindowTypeHint.Utility;
+			Window = new GtkPopoverWindow (windowType == PopupWindow.PopupType.Tooltip ? Gtk.WindowType.Popup : Gtk.WindowType.Toplevel);
+
+			switch (windowType) {
+			case PopupWindow.PopupType.Tooltip:
+				Window.TypeHint = Gdk.WindowTypeHint.Tooltip;
+				Window.Decorated = false;
+				break;
+			case PopupWindow.PopupType.Menu:
+				Window.TypeHint = Gdk.WindowTypeHint.PopupMenu;
+				Window.Decorated = false;
+				break;
+			}
+
+			Window.SkipPagerHint = true;
+			Window.SkipTaskbarHint = true;
+			Window.Add (CreateMainLayout ());
+		}
+
+		void IPopupWindowBackend.Initialize (IWindowFrameEventSink sink, PopupWindow.PopupType type)
+		{
+			windowType = type;
+			((IWindowFrameBackend)this).Initialize (sink);
+		}
+	}
+}

--- a/Xwt.Gtk/Xwt.GtkBackend/UtilityWindowBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/UtilityWindowBackend.cs
@@ -1,0 +1,43 @@
+//
+// UtilityWindowBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using Xwt.Backends;
+
+namespace Xwt.GtkBackend
+{
+	public class UtilityWindowBackend : WindowBackend, IUtilityWindowBackend
+	{
+		public override void Initialize ()
+		{
+			Window = new GtkPopoverWindow (Gtk.WindowType.Toplevel);
+			Window.TypeHint = Gdk.WindowTypeHint.Utility;
+			Window.SkipPagerHint = true;
+			Window.SkipTaskbarHint = true;
+			Window.Add (CreateMainLayout ());
+		}
+	}
+	
+}

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowBackend.cs
@@ -45,7 +45,6 @@ namespace Xwt.GtkBackend
 				Window = new Gtk.Window ("");
 			else {
 				Window = new GtkPopoverWindow (windowType == PopupWindow.PopupType.Tooltip ? Gtk.WindowType.Popup : Gtk.WindowType.Toplevel);
-				Window.AppPaintable = true;
 				Window.SkipPagerHint = true;
 				Window.SkipTaskbarHint = true;
 				switch (windowType) {

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowBackend.cs
@@ -27,6 +27,7 @@
 
 using System;
 using Xwt.Backends;
+using Xwt.Drawing;
 
 namespace Xwt.GtkBackend
 {
@@ -120,6 +121,18 @@ namespace Xwt.GtkBackend
 		{
 			width = RequestedSize.Width;
 			height = RequestedSize.Height;
+		}
+
+		Color? backgroundColor;
+
+		Color IWindowBackend.BackgroundColor {
+			get {
+				return backgroundColor ?? Window.GetBackgroundColor ();
+			}
+			set {
+				backgroundColor = value;
+				Window.SetBackgroundColor (value);
+			}
 		}
 	}
 

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowBackend.cs
@@ -27,20 +27,48 @@
 
 using System;
 using Xwt.Backends;
+using Xwt.CairoBackend;
 using Xwt.Drawing;
 
 namespace Xwt.GtkBackend
 {
-	public class WindowBackend: WindowFrameBackend, IWindowBackend, IConstraintProvider
+	public class WindowBackend: WindowFrameBackend, IWindowBackend, IPopupWindowBackend, IConstraintProvider
 	{
 		Gtk.Alignment alignment;
 		Gtk.MenuBar mainMenu;
 		Gtk.VBox mainBox;
+		PopupWindow.PopupType? windowType;
 		
 		public override void Initialize ()
 		{
-			Window = new Gtk.Window ("");
+			if (!windowType.HasValue)
+				Window = new Gtk.Window ("");
+			else {
+				Window = new GtkPopoverWindow (windowType == PopupWindow.PopupType.Tooltip ? Gtk.WindowType.Popup : Gtk.WindowType.Toplevel);
+				Window.AppPaintable = true;
+				Window.SkipPagerHint = true;
+				Window.SkipTaskbarHint = true;
+				switch (windowType) {
+				case PopupWindow.PopupType.Utility:
+					Window.TypeHint = Gdk.WindowTypeHint.Utility;
+					break;
+				case PopupWindow.PopupType.Tooltip:
+					Window.TypeHint = Gdk.WindowTypeHint.Tooltip;
+					Window.Decorated = false;
+					break;
+				case PopupWindow.PopupType.Menu:
+					Window.TypeHint = Gdk.WindowTypeHint.PopupMenu;
+					Window.Decorated = false;
+					break;
+				}
+			}
 			Window.Add (CreateMainLayout ());
+		}
+
+		public void Initialize(IWindowFrameEventSink sink, PopupWindow.PopupType type)
+		{
+			windowType = type;
+			((IWindowFrameBackend)this).Initialize(sink);
 		}
 		
 		protected virtual Gtk.Widget CreateMainLayout ()
@@ -131,6 +159,8 @@ namespace Xwt.GtkBackend
 			}
 			set {
 				backgroundColor = value;
+				if (Window is GtkPopoverWindow)
+					((GtkPopoverWindow)Window).BackgroundColor = value.ToCairoColor ();
 				Window.SetBackgroundColor (value);
 			}
 		}

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowBackend.cs
@@ -32,42 +32,16 @@ using Xwt.Drawing;
 
 namespace Xwt.GtkBackend
 {
-	public class WindowBackend: WindowFrameBackend, IWindowBackend, IPopupWindowBackend, IConstraintProvider
+	public class WindowBackend: WindowFrameBackend, IWindowBackend, IConstraintProvider
 	{
 		Gtk.Alignment alignment;
 		Gtk.MenuBar mainMenu;
 		Gtk.VBox mainBox;
-		PopupWindow.PopupType? windowType;
 		
 		public override void Initialize ()
 		{
-			if (!windowType.HasValue)
-				Window = new Gtk.Window ("");
-			else {
-				Window = new GtkPopoverWindow (windowType == PopupWindow.PopupType.Tooltip ? Gtk.WindowType.Popup : Gtk.WindowType.Toplevel);
-				Window.SkipPagerHint = true;
-				Window.SkipTaskbarHint = true;
-				switch (windowType) {
-				case PopupWindow.PopupType.Utility:
-					Window.TypeHint = Gdk.WindowTypeHint.Utility;
-					break;
-				case PopupWindow.PopupType.Tooltip:
-					Window.TypeHint = Gdk.WindowTypeHint.Tooltip;
-					Window.Decorated = false;
-					break;
-				case PopupWindow.PopupType.Menu:
-					Window.TypeHint = Gdk.WindowTypeHint.PopupMenu;
-					Window.Decorated = false;
-					break;
-				}
-			}
+			Window = new Gtk.Window ("");
 			Window.Add (CreateMainLayout ());
-		}
-
-		public void Initialize(IWindowFrameEventSink sink, PopupWindow.PopupType type)
-		{
-			windowType = type;
-			((IWindowFrameBackend)this).Initialize(sink);
 		}
 		
 		protected virtual Gtk.Widget CreateMainLayout ()

--- a/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
@@ -121,6 +121,7 @@ namespace Xwt.WPFBackend
 			RegisterBackend<IWebViewBackend, WebViewBackend> ();
 			RegisterBackend<KeyboardHandler, WpfKeyboardHandler> ();
 			RegisterBackend<ICalendarBackend, CalendarBackend> ();
+			RegisterBackend<IPopupWindowBackend, WindowBackend> ();
 		}
 
 		public override void DispatchPendingEvents()

--- a/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
@@ -121,7 +121,8 @@ namespace Xwt.WPFBackend
 			RegisterBackend<IWebViewBackend, WebViewBackend> ();
 			RegisterBackend<KeyboardHandler, WpfKeyboardHandler> ();
 			RegisterBackend<ICalendarBackend, CalendarBackend> ();
-			RegisterBackend<IPopupWindowBackend, WindowBackend> ();
+			RegisterBackend<IPopupWindowBackend, WindowBackend>();
+			RegisterBackend<IUtilityWindowBackend, WindowBackend>();
 		}
 
 		public override void DispatchPendingEvents()

--- a/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
@@ -38,13 +38,14 @@ using Xwt.Backends;
 
 namespace Xwt.WPFBackend
 {
-	public class WindowBackend : WindowFrameBackend, IWindowBackend
+	public class WindowBackend : WindowFrameBackend, IWindowBackend, IPopupWindowBackend
 	{
 		protected Grid rootPanel;
 		public System.Windows.Controls.Menu mainMenu;
 		MenuBackend mainMenuBackend;
 		FrameworkElement widget;
 		DockPanel contentBox;
+		WindowStyle defaultWindowStyle = WindowStyle.SingleBorderWindow;
 
 		public WindowBackend ()
 		{
@@ -70,6 +71,13 @@ namespace Xwt.WPFBackend
 			Window.Frontend = (Window) Frontend;
 		}
 
+		public void Initialize(IWindowFrameEventSink sink, PopupWindow.PopupType type)
+		{
+			Initialize ();
+			defaultWindowStyle = WindowStyle.ToolWindow;
+			Decorated = type == PopupWindow.PopupType.Utility;
+		}
+
 		// A Grid with a single column, and two rows (menu and child control).
 		static Grid CreateMainGrid ()
 		{
@@ -84,6 +92,18 @@ namespace Xwt.WPFBackend
 			grid.RowDefinitions.Add (contentRow);
 
 			return grid;
+		}
+
+		public override bool Decorated
+		{
+			get { return base.Decorated; }
+			set
+			{
+				base.Decorated = value;
+				if (value)
+					Window.WindowStyle = defaultWindowStyle;
+				Window.AllowsTransparency = Window.WindowStyle == WindowStyle.None && BackgroundColor.Alpha < 1.0;
+			}
 		}
 
 		public override bool HasMenu {
@@ -191,7 +211,10 @@ namespace Xwt.WPFBackend
 
 		public Xwt.Drawing.Color BackgroundColor {
 			get { return Window.Background.ToXwtColor (); }
-			set { Window.Background = ResPool.GetSolidBrush (value); }
+			set {
+				Window.Background = ResPool.GetSolidBrush (value);
+				Window.AllowsTransparency = Window.WindowStyle == WindowStyle.None && value.Alpha < 1.0;
+			}
 		}
 	}
 

--- a/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
@@ -38,7 +38,7 @@ using Xwt.Backends;
 
 namespace Xwt.WPFBackend
 {
-	public class WindowBackend : WindowFrameBackend, IWindowBackend, IPopupWindowBackend
+	public class WindowBackend : WindowFrameBackend, IWindowBackend, IPopupWindowBackend, IUtilityWindowBackend
 	{
 		protected Grid rootPanel;
 		public System.Windows.Controls.Menu mainMenu;
@@ -69,13 +69,16 @@ namespace Xwt.WPFBackend
 		{
 			base.Initialize ();
 			Window.Frontend = (Window) Frontend;
+			if (Frontend is UtilityWindow)
+				defaultWindowStyle = WindowStyle.ToolWindow;
+			Decorated = true;
 		}
 
 		public void Initialize(IWindowFrameEventSink sink, PopupWindow.PopupType type)
 		{
 			Initialize ();
 			defaultWindowStyle = WindowStyle.ToolWindow;
-			Decorated = type == PopupWindow.PopupType.Utility;
+			Decorated = false;
 		}
 
 		// A Grid with a single column, and two rows (menu and child control).

--- a/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
@@ -188,6 +188,11 @@ namespace Xwt.WPFBackend
 		{
 			Window.ResetBorderSize ();
 		}
+
+		public Xwt.Drawing.Color BackgroundColor {
+			get { return Window.Background.ToXwtColor (); }
+			set { Window.Background = ResPool.GetSolidBrush (value); }
+		}
 	}
 
 	class WpfWindow : System.Windows.Window

--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -117,7 +117,7 @@ namespace Xwt.WPFBackend
 			get { return eventSink; }
 		}
 
-		bool IWindowFrameBackend.Decorated {
+		public virtual bool Decorated {
 			get { return window.WindowStyle != WindowStyle.None; }
 			set {
 				window.WindowStyle = value ? WindowStyle.SingleBorderWindow : WindowStyle.None;
@@ -141,7 +141,7 @@ namespace Xwt.WPFBackend
 				Window.Owner = null;
 		}
 
-		bool IWindowFrameBackend.Resizable {
+		public virtual bool Resizable {
 			get {
 				return resizable;
 			}
@@ -162,9 +162,9 @@ namespace Xwt.WPFBackend
 			}
 		}
 
-		void UpdateResizeMode ()
+		protected void UpdateResizeMode ()
 		{
-			var m = resizable && window.WindowStyle == WindowStyle.SingleBorderWindow ? ResizeMode.CanResize : ResizeMode.NoResize;
+			var m = resizable && window.WindowStyle != WindowStyle.None ? ResizeMode.CanResize : ResizeMode.NoResize;
 			if (m != window.ResizeMode) {
 				window.ResizeMode = m;
 				OnResizeModeChanged ();

--- a/Xwt.XamMac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacEngine.cs
@@ -126,6 +126,7 @@ namespace Xwt.Mac
 			RegisterBackend <Xwt.Backends.IColorPickerBackend, ColorPickerBackend> ();
 			RegisterBackend <Xwt.Backends.ICalendarBackend,CalendarBackend> ();
 			RegisterBackend <Xwt.Backends.ISelectFontDialogBackend, SelectFontDialogBackend> ();
+			RegisterBackend <Xwt.Backends.IPopupWindowBackend, PopupWindowBackend> ();
 		}
 
 		public override void RunApplication ()

--- a/Xwt.XamMac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacEngine.cs
@@ -127,6 +127,7 @@ namespace Xwt.Mac
 			RegisterBackend <Xwt.Backends.ICalendarBackend,CalendarBackend> ();
 			RegisterBackend <Xwt.Backends.ISelectFontDialogBackend, SelectFontDialogBackend> ();
 			RegisterBackend <Xwt.Backends.IPopupWindowBackend, PopupWindowBackend> ();
+			RegisterBackend <Xwt.Backends.IUtilityWindowBackend, PopupWindowBackend> ();
 		}
 
 		public override void RunApplication ()

--- a/Xwt.XamMac/Xwt.Mac/PopupWindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopupWindowBackend.cs
@@ -1,0 +1,617 @@
+﻿//
+// PopupWindowBackend.cs
+//
+// Author:
+//       Lluis Sanchez <lluis@xamarin.com>
+//       Andres G. Aragoneses <andres.aragoneses@7digital.com>
+//       Konrad M. Kruczynski <kkruczynski@antmicro.com>
+//       Vsevolod Kukol <sevoku@microsoft.com>
+// 
+// Copyright (c) 2011 Xamarin Inc
+// Copyright (c) 2012 7Digital Media Ltd
+// Copyright (c) 2016 Antmicro Ltd
+// Copyright (c) 2017 (c) Microsoft Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using AppKit;
+using CoreGraphics;
+using Foundation;
+using ObjCRuntime;
+using Xwt.Backends;
+using Xwt.Drawing;
+
+// TODO: Merge back with WindowBackend and reuse code
+
+namespace Xwt.Mac
+{
+	public class PopupWindowBackend : NSPanel, IPopupWindowBackend
+	{
+		WindowBackendController controller;
+		IWindowFrameEventSink eventSink;
+		Window frontend;
+		ViewBackend child;
+		NSView childView;
+		IWindowFrameBackend transientParent;
+		bool sensitive = true;
+		PopupWindow.PopupType windowType;
+
+		public PopupWindowBackend ()
+		{
+			AutorecalculatesKeyViewLoop = true;
+
+			ContentView.AutoresizesSubviews = true;
+			ContentView.Hidden = true;
+
+			// TODO: do it only if mouse move events are enabled in a widget
+			AcceptsMouseMovedEvents = true;
+
+			WillClose += delegate {
+				OnClosed ();
+			};
+
+		}
+
+		public override bool CanBecomeKeyWindow {
+			get {
+				return windowType != PopupWindow.PopupType.Tooltip;
+			}
+		}
+
+		object IWindowFrameBackend.Window {
+			get { return this; }
+		}
+
+		public IntPtr NativeHandle {
+			get { return Handle; }
+		}
+
+		public IWindowFrameEventSink EventSink {
+			get { return (IWindowFrameEventSink)eventSink; }
+		}
+
+		public virtual void InitializeBackend (object frontend, ApplicationContext context)
+		{
+			this.ApplicationContext = context;
+			this.frontend = (Window) frontend;
+		}
+		
+		public void Initialize (IWindowFrameEventSink eventSink)
+		{
+			this.eventSink = eventSink;
+		}
+
+		public void Initialize (IWindowFrameEventSink eventSink, PopupWindow.PopupType windowType)
+		{
+			this.windowType = windowType;
+			UpdateWindowStyle ();
+			Initialize (eventSink);
+		}
+
+		void UpdateWindowStyle ()
+		{
+			StyleMask |= NSWindowStyle.Closable | NSWindowStyle.Miniaturizable | NSWindowStyle.Utility;
+
+			switch (windowType) {
+			case PopupWindow.PopupType.Utility:
+				StyleMask |= NSWindowStyle.Resizable;
+				TitleVisibility = NSWindowTitleVisibility.Visible;
+				Level = NSWindowLevel.Floating;
+				FloatingPanel = true;
+				break;
+
+			case PopupWindow.PopupType.Tooltip:
+			case PopupWindow.PopupType.Menu:
+				StyleMask |= NSWindowStyle.FullSizeContentView;
+				MovableByWindowBackground = true;
+				TitlebarAppearsTransparent = true;
+				TitleVisibility = NSWindowTitleVisibility.Hidden;
+				this.StandardWindowButton (NSWindowButton.CloseButton).Hidden = true;
+				this.StandardWindowButton (NSWindowButton.MiniaturizeButton).Hidden = true;
+				this.StandardWindowButton (NSWindowButton.ZoomButton).Hidden = true;
+
+				if (windowType == PopupWindow.PopupType.Tooltip)
+					// NSWindowLevel.ScreenSaver overlaps menus, this allows showing tooltips above menus
+					Level = NSWindowLevel.ScreenSaver;
+				else
+					Level = NSWindowLevel.PopUpMenu;
+
+				break;
+			}
+		}
+
+		public override void MouseExited (NSEvent theEvent)
+		{
+			if (windowType == PopupWindow.PopupType.Tooltip)
+				Visible = false;
+			base.MouseExited (theEvent);
+		}
+
+		public ApplicationContext ApplicationContext {
+			get;
+			private set;
+		}
+
+		public object NativeWidget {
+			get {
+				return this;
+			}
+		}
+
+		public string Name { get; set; }
+
+		public void Present ()
+		{
+			Visible = true;
+			MakeKeyAndOrderFront (MacEngine.App);
+		}
+
+		public bool Visible {
+			get {
+				return IsVisible;
+			}
+			set {
+				ContentView.Hidden = !value; // handle shown/hidden events
+				IsVisible = value;
+
+				if (transientParent != null) {
+					var win = transientParent as NSWindow ?? ApplicationContext.Toolkit.GetNativeWindow (transientParent) as NSWindow;
+					if (win != null) {
+						if (value)
+							win.AddChildWindow (this, NSWindowOrderingMode.Above);
+						else
+							win.RemoveChildWindow (this);
+					}
+				}
+			}
+		}
+
+		public double Opacity {
+			get { return AlphaValue; }
+			set { AlphaValue = (float)value; }
+		}
+
+		Color? backgroundColor;
+		public new Color BackgroundColor {
+			get {
+				if (backgroundColor.HasValue)
+					return backgroundColor.Value;
+				return base.BackgroundColor.ToXwtColor ();
+			}
+			set {
+				backgroundColor = value;
+				base.BackgroundColor = value.ToNSColor ();
+				IsOpaque = false;
+			}
+		}
+
+		public bool Sensitive {
+			get {
+				return sensitive;
+			}
+			set {
+				sensitive = value;
+				if (child != null)
+					child.UpdateSensitiveStatus (child.Widget, sensitive);
+			}
+		}
+
+		public bool HasFocus {
+			get {
+				return IsKeyWindow;
+			}
+		}
+
+		public bool FullScreen {
+			get {
+				if (MacSystemInformation.OsVersion < MacSystemInformation.Lion)
+					return false;
+
+				return (StyleMask & NSWindowStyle.FullScreenWindow) != 0;
+
+			}
+			set {
+				if (MacSystemInformation.OsVersion < MacSystemInformation.Lion)
+					return;
+
+				if (value != ((StyleMask & NSWindowStyle.FullScreenWindow) != 0))
+					ToggleFullScreen (null);
+			}
+		}
+
+		object IWindowFrameBackend.Screen {
+			get {
+				return Screen;
+			}
+		}
+
+		#region IWindowBackend implementation
+		void IBackend.EnableEvent (object eventId)
+		{
+			if (eventId is WindowFrameEvent) {
+				var @event = (WindowFrameEvent)eventId;
+				switch (@event) {
+				case WindowFrameEvent.BoundsChanged:
+					DidResize += HandleDidResize;
+					DidMove += HandleDidResize;
+					break;
+				case WindowFrameEvent.Hidden:
+					EnableVisibilityEvent (@event);
+					this.WillClose += OnWillClose;
+					break;
+				case WindowFrameEvent.Shown:
+					EnableVisibilityEvent (@event);
+					break;
+				case WindowFrameEvent.CloseRequested:
+					WindowShouldClose = OnShouldClose;
+					break;
+				}
+			}
+		}
+		
+		void OnWillClose (object sender, EventArgs args) {
+			OnHidden ();
+		}
+
+		bool OnShouldClose (NSObject ob)
+		{
+			return closePerformed = RequestClose ();
+		}
+
+		internal bool RequestClose ()
+		{
+			bool res = true;
+			ApplicationContext.InvokeUserCode (() => res = eventSink.OnCloseRequested ());
+			return res;
+		}
+
+		protected virtual void OnClosed ()
+		{
+			if (!disposing)
+				ApplicationContext.InvokeUserCode (eventSink.OnClosed);
+		}
+
+		bool closePerformed;
+
+		bool IWindowFrameBackend.Close ()
+		{
+			closePerformed = true;
+			if ((StyleMask & NSWindowStyle.Titled) != 0 && (StyleMask & NSWindowStyle.Closable) != 0)
+				PerformClose(this);
+			else
+				Close ();
+			return closePerformed;
+		}
+		
+		bool VisibilityEventsEnabled ()
+		{
+			return eventsEnabled != WindowFrameEvent.BoundsChanged;
+		}
+		WindowFrameEvent eventsEnabled = WindowFrameEvent.BoundsChanged;
+
+		NSString HiddenProperty {
+			get { return new NSString ("hidden"); }
+		}
+		
+		void EnableVisibilityEvent (WindowFrameEvent ev)
+		{
+			if (!VisibilityEventsEnabled ()) {
+				ContentView.AddObserver (this, HiddenProperty, NSKeyValueObservingOptions.New, IntPtr.Zero);
+			}
+			if (!eventsEnabled.HasFlag (ev)) {
+				eventsEnabled |= ev;
+			}
+		}
+
+		public override void ObserveValue (NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
+		{
+			if (keyPath.ToString () == HiddenProperty.ToString () && ofObject.Equals (ContentView)) {
+				if (ContentView.Hidden) {
+					if (eventsEnabled.HasFlag (WindowFrameEvent.Hidden)) {
+						OnHidden ();
+					}
+				} else {
+					if (eventsEnabled.HasFlag (WindowFrameEvent.Shown)) {
+						OnShown ();
+					}
+				}
+			}
+		}
+
+		void OnHidden () {
+			ApplicationContext.InvokeUserCode (delegate ()
+			{
+				eventSink.OnHidden ();
+			});
+		}
+
+		void OnShown () {
+			ApplicationContext.InvokeUserCode (delegate ()
+			{
+				eventSink.OnShown ();
+			});
+		}
+
+		void DisableVisibilityEvent (WindowFrameEvent ev)
+		{
+			if (eventsEnabled.HasFlag (ev)) {
+				eventsEnabled ^= ev;
+				if (!VisibilityEventsEnabled ()) {
+					ContentView.RemoveObserver (this, HiddenProperty);
+				}
+			}
+		}
+
+		void IBackend.DisableEvent (object eventId)
+		{
+			if (eventId is WindowFrameEvent) {
+				var @event = (WindowFrameEvent)eventId;
+				switch (@event) {
+					case WindowFrameEvent.BoundsChanged:
+						DidResize -= HandleDidResize;
+						DidMove -= HandleDidResize;
+						break;
+					case WindowFrameEvent.Hidden:
+						this.WillClose -= OnWillClose;
+						DisableVisibilityEvent (@event);
+						break;
+					case WindowFrameEvent.Shown:
+						DisableVisibilityEvent (@event);
+						break;
+				}
+			}
+		}
+
+		void HandleDidResize (object sender, EventArgs e)
+		{
+			OnBoundsChanged ();
+		}
+
+		protected virtual void OnBoundsChanged ()
+		{
+			LayoutWindow ();
+			ApplicationContext.InvokeUserCode (delegate {
+				eventSink.OnBoundsChanged (((IWindowBackend)this).Bounds);
+			});
+		}
+
+		void IWindowBackend.SetChild (IWidgetBackend child)
+		{
+			if (this.child != null) {
+				ViewBackend.RemoveChildPlacement (this.child.Widget);
+				this.child.Widget.RemoveFromSuperview ();
+				childView = null;
+			}
+			this.child = (ViewBackend) child;
+			if (child != null) {
+				childView = ViewBackend.GetWidgetWithPlacement (child);
+				ContentView.AddSubview (childView);
+				LayoutWindow ();
+				childView.AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable;
+			}
+		}
+		
+		public virtual void UpdateChildPlacement (IWidgetBackend childBackend)
+		{
+			var w = ViewBackend.SetChildPlacement (childBackend);
+			LayoutWindow ();
+			w.AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable;
+		}
+
+		bool IWindowFrameBackend.Decorated {
+			get {
+				return (StyleMask & NSWindowStyle.Titled) != 0;
+			}
+			set {
+				if (value)
+					StyleMask |= NSWindowStyle.Titled;
+				else
+					StyleMask &= ~(NSWindowStyle.Titled | NSWindowStyle.Borderless);
+				HasShadow = value;
+			}
+		}
+		
+		bool IWindowFrameBackend.ShowInTaskbar {
+			get {
+				return false;
+			}
+			set {
+			}
+		}
+
+		void IWindowFrameBackend.SetTransientFor (IWindowFrameBackend window)
+		{
+			if (transientParent == window)
+				return;
+
+			transientParent = window;
+
+			if (windowType == PopupWindow.PopupType.Utility)
+				Level = window == null ? NSWindowLevel.Floating : NSWindowLevel.ModalPanel;
+
+			if (ParentWindow != null)
+				ParentWindow.RemoveChildWindow (this);
+
+			// add to parent now, only if already visible
+			if (window != null && IsVisible) {
+				var win = window as NSWindow ?? ApplicationContext.Toolkit.GetNativeWindow (window) as NSWindow;
+				if (win != null)
+					win.AddChildWindow (this, NSWindowOrderingMode.Above);
+			}
+		}
+
+		bool IWindowFrameBackend.Resizable {
+			get {
+				return (StyleMask & NSWindowStyle.Resizable) != 0;
+			}
+			set {
+				if (value)
+					StyleMask |= NSWindowStyle.Resizable;
+				else
+					StyleMask &= ~NSWindowStyle.Resizable;
+			}
+		}
+		
+		public void SetPadding (double left, double top, double right, double bottom)
+		{
+			LayoutWindow ();
+		}
+
+		void IWindowFrameBackend.Move (double x, double y)
+		{
+			var r = MacDesktopBackend.FromDesktopRect (new Rectangle (x, y, Frame.Width, Frame.Height));
+			r = FrameRectFor (r);
+			SetFrameOrigin (r.Location);
+		}
+		
+		void IWindowFrameBackend.SetSize (double width, double height)
+		{
+			var cr = ContentRectFor (Frame);
+			if (width == -1)
+				width = cr.Width;
+			if (height == -1)
+				height = cr.Height;
+			var r = FrameRectFor (new CGRect ((nfloat)cr.X, (nfloat)cr.Y, (nfloat)width, (nfloat)height));
+			SetFrame (r, true);
+			LayoutWindow ();
+		}
+		
+		Rectangle IWindowFrameBackend.Bounds {
+			get {
+				var b = ContentRectFor (Frame);
+				var r = MacDesktopBackend.ToDesktopRect (b);
+				return new Rectangle ((int)r.X, (int)r.Y, (int)r.Width, (int)r.Height);
+			}
+			set {
+				var r = MacDesktopBackend.FromDesktopRect (value);
+				var fr = FrameRectFor (r);
+				SetFrame (fr, true);
+			}
+		}
+		
+		public void SetMainMenu (IMenuBackend menu)
+		{
+			var m = (MenuBackend) menu;
+			m.SetMainMenuMode ();
+			NSApplication.SharedApplication.Menu = m;
+			
+//			base.Menu = m;
+		}
+		
+		#endregion
+
+		static Selector closeSel = new Selector ("close");
+		#if MONOMAC
+		static Selector retainSel = new Selector("retain");
+		#endif
+
+		bool disposing, disposed;
+
+		protected override void Dispose(bool disposing)
+		{
+			if (!disposed && disposing)
+			{
+				this.disposing = true;
+				try
+				{
+					if (VisibilityEventsEnabled() && ContentView != null)
+						ContentView.RemoveObserver(this, HiddenProperty);
+					
+					// HACK: Xamarin.Mac/MonoMac limitation: no direct way to release a window manually
+					// A NSWindow instance will be removed from NSApplication.SharedApplication.Windows
+					// only if it is being closed with ReleasedWhenClosed set to true but not on Dispose
+					// and there is no managed way to tell Cocoa to release the window manually (and to
+					// remove it from the active window list).
+					// see also: https://bugzilla.xamarin.com/show_bug.cgi?id=45298
+					// WORKAROUND:
+					// bump native reference count by calling DangerousRetain()
+					// base.Dispose will now unref the window correctly without crashing
+					DangerousRetain();
+					// tell Cocoa to release the window on Close
+					ReleasedWhenClosed = true;
+					// Close the window (Cocoa will do its job even if the window is already closed)
+					Messaging.void_objc_msgSend (this.Handle, closeSel.Handle);
+				} finally {
+					this.disposing = false;
+					this.disposed = true;
+				}
+			}
+			if (controller != null) {
+				controller.Dispose ();
+				controller = null;
+			}
+			base.Dispose (disposing);
+		}
+		
+		public void DragStart (TransferDataSource data, DragDropAction dragAction, object dragImage, double xhot, double yhot)
+		{
+			throw new NotImplementedException ();
+		}
+		
+		public void SetDragSource (string[] types, DragDropAction dragAction)
+		{
+		}
+		
+		public void SetDragTarget (string[] types, DragDropAction dragAction)
+		{
+		}
+		
+		public virtual void SetMinSize (Size s)
+		{
+			var b = ((IWindowBackend)this).Bounds;
+			if (b.Size.Width < s.Width)
+				b.Width = s.Width;
+			if (b.Size.Height < s.Height)
+				b.Height = s.Height;
+
+			if (b != ((IWindowBackend)this).Bounds)
+				((IWindowBackend)this).Bounds = b;
+
+			var r = FrameRectFor (new CGRect (0, 0, (nfloat)s.Width, (nfloat)s.Height));
+			MinSize = r.Size;
+		}
+
+		public void SetIcon (ImageDescription icon)
+		{
+		}
+		
+		public virtual void GetMetrics (out Size minSize, out Size decorationSize)
+		{
+			minSize = decorationSize = Size.Zero;
+		}
+
+		public virtual void LayoutWindow ()
+		{
+			LayoutContent (ContentView.Frame);
+		}
+		
+		public void LayoutContent (CGRect frame)
+		{
+			if (child != null) {
+				frame.X += (nfloat) frontend.Padding.Left;
+				frame.Width -= (nfloat) (frontend.Padding.HorizontalSpacing);
+				frame.Y += (nfloat) frontend.Padding.Top;
+				frame.Height -= (nfloat) (frontend.Padding.VerticalSpacing);
+				childView.Frame = frame;
+			}
+		}
+	}
+}
+

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -34,6 +34,7 @@ using CoreGraphics;
 using Foundation;
 using ObjCRuntime;
 using Xwt.Backends;
+using Xwt.Drawing;
 
 namespace Xwt.Mac
 {
@@ -131,6 +132,15 @@ namespace Xwt.Mac
 		public double Opacity {
 			get { return AlphaValue; }
 			set { AlphaValue = (float)value; }
+		}
+
+		Color IWindowBackend.BackgroundColor {
+			get {
+				return BackgroundColor.ToXwtColor ();
+			}
+			set {
+				BackgroundColor = value.ToNSColor ();
+			}
 		}
 
 		public bool Sensitive {

--- a/Xwt.XamMac/Xwt.XamMac.csproj
+++ b/Xwt.XamMac/Xwt.XamMac.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Xwt.Mac\SelectFontDialogBackend.cs" />
     <Compile Include="Xwt.Mac\NSApplicationInitializer.cs" />
     <Compile Include="Xwt.Mac\GtkQuartz.cs" />
+    <Compile Include="Xwt.Mac\PopupWindowBackend.cs" />
   </ItemGroup>
   <Import Project="..\BuildHelpers.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Xwt/Xwt.Backends/IPopupWindowBackend.cs
+++ b/Xwt/Xwt.Backends/IPopupWindowBackend.cs
@@ -1,0 +1,33 @@
+﻿//
+// IPopupWindowBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2017 (c) Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace Xwt.Backends
+{
+	public interface IPopupWindowBackend : IWindowBackend
+	{
+		void Initialize (IWindowFrameEventSink sink, PopupWindow.PopupType type);
+	}
+}

--- a/Xwt/Xwt.Backends/IUtilityWindowBackend.cs
+++ b/Xwt/Xwt.Backends/IUtilityWindowBackend.cs
@@ -1,0 +1,32 @@
+﻿//
+// IUtilityWindowBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2017 Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+namespace Xwt.Backends
+{
+	public interface IUtilityWindowBackend : IWindowBackend
+	{
+	}
+}

--- a/Xwt/Xwt.Backends/IWindowBackend.cs
+++ b/Xwt/Xwt.Backends/IWindowBackend.cs
@@ -26,11 +26,13 @@
 
 using System;
 using Xwt;
+using Xwt.Drawing;
 
 namespace Xwt.Backends
 {
 	public interface IWindowBackend: IWindowFrameBackend, IChildPlacementHandler
 	{
+		Color BackgroundColor { get; set; }
 		void SetChild (IWidgetBackend child);
 		void SetMainMenu (IMenuBackend menu);
 		void SetPadding (double left, double top, double right, double bottom);

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -346,6 +346,7 @@
     <Compile Include="Xwt.Backends\IComboBoxCellViewFrontend.cs" />
     <Compile Include="Xwt.Backends\IDispatcherBackend.cs" />
     <Compile Include="Xwt\ITranslationCatalog.cs" />
+    <Compile Include="Xwt.Backends\IPopupWindowBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -347,6 +347,8 @@
     <Compile Include="Xwt.Backends\IDispatcherBackend.cs" />
     <Compile Include="Xwt\ITranslationCatalog.cs" />
     <Compile Include="Xwt.Backends\IPopupWindowBackend.cs" />
+    <Compile Include="Xwt\UtilityWindow.cs" />
+    <Compile Include="Xwt.Backends\IUtilityWindowBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt/PopupWindow.cs
+++ b/Xwt/Xwt/PopupWindow.cs
@@ -3,6 +3,7 @@
 //  
 // Author:
 //       Lluis Sanchez <lluis@xamarin.com>
+//       Vsevolod Kukol <sevoku@microsoft.com>
 // 
 // Copyright (c) 2011 Xamarin Inc
 // 
@@ -23,14 +24,60 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
+
+using Xwt.Backends;
 
 namespace Xwt
 {
-	public class PopupWindow
+	[BackendType (typeof (IPopupWindowBackend))]
+	public class PopupWindow : Window
 	{
-		public PopupWindow ()
+		public enum PopupType
 		{
+			Utility,
+			Tooltip,
+			Menu
+		}
+
+		readonly PopupType type;
+
+		public PopupType Type { get { return type; } }
+
+		public PopupWindow () : this (PopupType.Utility)
+		{
+		}
+
+		public PopupWindow (PopupType type) : base (0)
+		{
+			this.type = type;
+			switch (type) {
+			case PopupType.Tooltip:
+			case PopupType.Menu:
+				ShowInTaskbar = false;
+				InitialLocation = WindowLocation.CenterParent;
+				Resizable = false;
+				break;
+			}
+		}
+
+		protected new class WindowBackendHost : WindowFrame.WindowBackendHost
+		{
+			new PopupWindow Parent { get { return (PopupWindow)base.Parent; } }
+
+			protected override void OnBackendCreated ()
+			{
+				base.OnBackendCreated ();
+				((IPopupWindowBackend)Backend).Initialize (this, Parent.Type);
+			}
+		}
+
+		protected override BackendHost CreateBackendHost ()
+		{
+			return new WindowBackendHost ();
+		}
+
+		IPopupWindowBackend Backend {
+			get { return (IPopupWindowBackend)BackendHost.Backend; }
 		}
 	}
 }

--- a/Xwt/Xwt/PopupWindow.cs
+++ b/Xwt/Xwt/PopupWindow.cs
@@ -78,6 +78,33 @@ namespace Xwt
 		IPopupWindowBackend Backend {
 			get { return (IPopupWindowBackend)BackendHost.Backend; }
 		}
+
+		bool shown;
+		internal override void AdjustSize ()
+		{
+			if (Resizable || !shown) {
+				base.AdjustSize ();
+				shown = true;
+				return;
+			}
+			Size mMinSize, mDecorationsSize;
+			Backend.GetMetrics (out mMinSize, out mDecorationsSize);
+
+			var ws = mDecorationsSize;
+			if (Content != null) {
+				IWidgetSurface s = Content.Surface;
+				ws += s.GetPreferredSize (true);
+			}
+			ws.Width += Padding.HorizontalSpacing;
+			ws.Height += Padding.VerticalSpacing;
+
+			if (ws.Width<mMinSize.Width)
+				ws.Width = mMinSize.Width;
+			if (ws.Height<mMinSize.Height)
+				ws.Height = mMinSize.Height;
+
+			Backend.SetSize (ws.Width, ws.Height);
+		}
 	}
 }
 

--- a/Xwt/Xwt/UtilityWindow.cs
+++ b/Xwt/Xwt/UtilityWindow.cs
@@ -1,22 +1,21 @@
-// 
-// PopupWindow.cs
-//  
+﻿//
+// UtilityWindow.cs
+//
 // Author:
-//       Lluis Sanchez <lluis@xamarin.com>
 //       Vsevolod Kukol <sevoku@microsoft.com>
-// 
-// Copyright (c) 2011 Xamarin Inc
-// 
+//
+// Copyright (c) 2017 Microsoft Corporation
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,47 +25,23 @@
 // THE SOFTWARE.
 
 using Xwt.Backends;
-
 namespace Xwt
 {
-	[BackendType (typeof (IPopupWindowBackend))]
-	public class PopupWindow : Window
+	[BackendType (typeof (IUtilityWindowBackend))]
+	public class UtilityWindow : Window
 	{
-		public enum PopupType
+		public UtilityWindow () : base (0)
 		{
-			Tooltip,
-			Menu
-		}
-
-		readonly PopupType type;
-
-		public PopupType Type { get { return type; } }
-
-		public PopupWindow () : this (PopupType.Tooltip)
-		{
-		}
-
-		public PopupWindow (PopupType type) : base (0)
-		{
-			this.type = type;
-			switch (type) {
-			case PopupType.Tooltip:
-			case PopupType.Menu:
-				ShowInTaskbar = false;
-				InitialLocation = WindowLocation.CenterParent;
-				Resizable = false;
-				break;
-			}
 		}
 
 		protected new class WindowBackendHost : Window.WindowBackendHost
 		{
-			new PopupWindow Parent { get { return (PopupWindow)base.Parent; } }
+			new UtilityWindow Parent { get { return (UtilityWindow)base.Parent; } }
 
 			protected override void OnBackendCreated ()
 			{
 				base.OnBackendCreated ();
-				((IPopupWindowBackend)Backend).Initialize (this, Parent.Type);
+				((IUtilityWindowBackend)Backend).Initialize (this);
 			}
 		}
 
@@ -75,9 +50,8 @@ namespace Xwt
 			return new WindowBackendHost ();
 		}
 
-		IPopupWindowBackend Backend {
-			get { return (IPopupWindowBackend)BackendHost.Backend; }
+		IUtilityWindowBackend Backend {
+			get { return (IUtilityWindowBackend)BackendHost.Backend; }
 		}
 	}
 }
-

--- a/Xwt/Xwt/WidgetSpacing.cs
+++ b/Xwt/Xwt/WidgetSpacing.cs
@@ -44,8 +44,10 @@ namespace Xwt
 	/// </summary>
 	[TypeConverter (typeof(WidgetSpacingValueConverter))]
 	[ValueSerializer (typeof(WidgetSpacingValueSerializer))]
-	public struct WidgetSpacing
+	public struct WidgetSpacing : IEquatable<WidgetSpacing>
 	{
+		public static WidgetSpacing Zero = new WidgetSpacing ();
+
 		static public implicit operator WidgetSpacing (double value)
 		{
 			return new WidgetSpacing (value, value, value, value);
@@ -99,6 +101,12 @@ namespace Xwt
 			get { return Top + Bottom; }
 		}
 
+		public bool IsZero {
+			get {
+				return ((Left == 0) && (Right == 0) && (Top == 0) && (Bottom == 0));
+			}
+		}
+
 		/// <summary>
 		/// Get the spacing of a widget for the specified orientation.
 		/// </summary>
@@ -110,6 +118,41 @@ namespace Xwt
 				return Top + Bottom;
 			else
 				return Left + Right;
+		}
+
+		// Equality
+		public override bool Equals (object o)
+		{
+			if (!(o is WidgetSpacing))
+				return false;
+
+			return (this == (WidgetSpacing)o);
+		}
+
+		public bool Equals (WidgetSpacing other)
+		{
+			return this == other;
+		}
+
+		public override int GetHashCode ()
+		{
+			unchecked {
+				var hash = Left.GetHashCode ();
+				hash = (hash * 397) ^ Right.GetHashCode ();
+				hash = (hash * 397) ^ Top.GetHashCode ();
+				hash = (hash * 397) ^ Bottom.GetHashCode ();
+				return hash;
+			}
+		}
+
+		public static bool operator == (WidgetSpacing s1, WidgetSpacing s2)
+		{
+			return ((s1.Left == s2.Left) && (s1.Right == s2.Right) && (s1.Top == s2.Top) && (s1.Bottom == s2.Bottom));
+		}
+
+		public static bool operator != (WidgetSpacing s1, WidgetSpacing s2)
+		{
+			return !(s1 == s2);
 		}
 	}
 

--- a/Xwt/Xwt/Window.cs
+++ b/Xwt/Xwt/Window.cs
@@ -26,7 +26,7 @@
 
 using System;
 using Xwt.Backends;
-
+using Xwt.Drawing;
 
 namespace Xwt
 {
@@ -59,6 +59,11 @@ namespace Xwt
 		public WindowLocation InitialLocation {
 			get { return initialLocation; }
 			set { initialLocation = value; }
+		}
+
+		public Color BackgroundColor {
+			get { return Backend.BackgroundColor; }
+			set { Backend.BackgroundColor = value; }
 		}
 
 		public WidgetSpacing Padding {

--- a/Xwt/Xwt/Window.cs
+++ b/Xwt/Xwt/Window.cs
@@ -46,10 +46,15 @@ namespace Xwt
 		{
 			return new WindowBackendHost ();
 		}
-		
-		public Window ()
+
+		public Window () : this (12)
 		{
-			Padding = 12;
+		}
+		
+		internal Window (WidgetSpacing initialPadding)
+		{
+			if (!initialPadding.IsZero)
+				Padding = initialPadding;
 		}
 		
 		IWindowBackend Backend {


### PR DESCRIPTION
This PR adds an `Xwt.PopupWindow` window (replacing the dummy Xwt.PopupWindow).
The PopupWindow is a special window type (based on `Xwt.Window`) which can be used to show custom Panels, custom Tooltips, custom Menus or highly customized windows.

By default a PopupWindow is a so called Utility Window, but it can also be created with an additional `PopupType` parameter to change the default behavior of the Popup:
* `PopupType.Utility`:
   Default Utility window (Cocoa: `NSPanel`, Gtk/Wpf: default window with utility style)
* `PopupType.Tooltip`:
   A special undecorated utility/popup window with support for background colors with alpha channel.
   Depending on the toolkit capabilities it may have a different pointer handling or animation.
* `PopupType.Menu`:
   In most cases same as `PopupType.Tooltip` but tells the WM to treat the window like a menu (depends on the WM to handle the hint).

**TODO:** `CanGetFocus` and `HasFocus` support, important for interactive tooltips.