### PR TITLE
[Mac] Fix some missing TextLayout.Markup features

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
@@ -72,7 +72,7 @@ namespace Xwt.Mac
 			var names = fontName.Split (new char[] {','}, StringSplitOptions.RemoveEmptyEntries);
 			NSFont f = null;
 			foreach (var name in names) {
-				f = NSFontManager.SharedFontManager.FontWithFamily (name.Trim (), t, GetWeightValue (weight), (float)size);
+				f = NSFontManager.SharedFontManager.FontWithFamily (name.Trim (), t, weight.ToMacValue (), (float)size);
 				if (f != null) break;
 			}
 			if (f == null) return null;
@@ -222,11 +222,7 @@ namespace Xwt.Mac
 		{
 			FontData f = (FontData) handle;
 			f = f.Copy ();
-			int w = GetWeightValue (weight);
-			var traits = NSFontManager.SharedFontManager.TraitsOfFont (f.Font);
-			traits |= weight >= FontWeight.Bold ? NSFontTraitMask.Bold : NSFontTraitMask.Unbold;
-			traits &= weight >= FontWeight.Bold ? ~NSFontTraitMask.Unbold : ~NSFontTraitMask.Bold;
-			f.Font = NSFontManager.SharedFontManager.FontWithFamily (f.Font.FamilyName, traits, w, f.Font.PointSize);
+			f.Font = f.Font.WithWeight (weight);
 			f.Weight = weight;
 			return f;
 		}

--- a/Xwt.XamMac/Xwt.Mac/TextLayoutBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextLayoutBackendHandler.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using AppKit;
 using CoreGraphics;
 using CoreText;
@@ -42,11 +43,18 @@ namespace Xwt.Mac
 			public NSFont Font;
 			public float? Width, Height;
 			public TextTrimming TextTrimming;
+			readonly public List<TextAttribute> Attributes = new List<TextAttribute> ();
+			readonly public ApplicationContext ApplicationContext;
+
+			public LayoutInfo (ApplicationContext actx)
+			{
+				ApplicationContext = actx;
+			}
 		}
 		
 		public override object Create ()
 		{
-			return new LayoutInfo ();
+			return new LayoutInfo (ApplicationContext);
 		}
 		
 		public override void SetText (object backend, string text)
@@ -153,19 +161,77 @@ namespace Xwt.Mac
 
 		static NSAttributedString CreateAttributedString (LayoutInfo li, string overrideText = null)
 		{
+			if (overrideText != null || li.Attributes.Count == 0)
+				return CreateAttributedString (overrideText ?? li.Text, li.Font);
+
+			var ns = new NSMutableAttributedString (li.Text);
+			ns.BeginEditing ();
+			var r = new NSRange (0, li.Text.Length);
+			if (li.Font != null)
+				ns.AddAttribute (CTStringAttributeKey.Font, li.Font, r);
+			ns.AddAttribute (CTStringAttributeKey.ForegroundColorFromContext, new NSNumber (true), r);
+
+			foreach (var att in li.Attributes) {
+				r = new NSRange (att.StartIndex, att.Count);
+				if (att is BackgroundTextAttribute) {
+					var xa = (BackgroundTextAttribute)att;
+					ns.AddAttribute (CTStringAttributeKey.BackgroundColor, xa.Color.ToNSColor (), r);
+				} else if (att is ColorTextAttribute) {
+					var xa = (ColorTextAttribute)att;
+					// FIXME: CTStringAttributeKey.ForegroundColor has no effect
+					ns.AddAttribute (CTStringAttributeKey.ForegroundColor, xa.Color.ToNSColor (), r);
+				} else if (att is UnderlineTextAttribute) {
+					var xa = (UnderlineTextAttribute)att;
+					var style = xa.Underline ? CTUnderlineStyle.Single : CTUnderlineStyle.None;
+					ns.AddAttribute (CTStringAttributeKey.UnderlineStyle, NSNumber.FromInt32 ((int)style), r);
+				} else if (att is FontStyleTextAttribute) {
+					var xa = (FontStyleTextAttribute)att;
+					if (xa.Style == FontStyle.Italic) {
+						ns.ApplyFontTraits (NSFontTraitMask.Italic, r);
+					} else if (xa.Style == FontStyle.Oblique) {
+						// FIXME: CoreText has no Obliqueness support
+					} else {
+						// FIXME: CoreText has no Obliqueness support
+						ns.ApplyFontTraits (NSFontTraitMask.Unitalic, r);
+					}
+				} else if (att is FontWeightTextAttribute) {
+					var xa = (FontWeightTextAttribute)att;
+					NSRange er;
+					// get the effective font to modify for the given range
+					var ft = ns.GetAttribute (CTStringAttributeKey.Font, att.StartIndex, out er, r) as NSFont;
+					ft = ft.WithWeight (xa.Weight);
+					ns.AddAttribute (CTStringAttributeKey.Font, ft, r);
+				} else if (att is LinkTextAttribute) {
+					ns.AddAttribute (CTStringAttributeKey.ForegroundColor, Toolkit.CurrentEngine.Defaults.FallbackLinkColor.ToNSColor (), r);
+					ns.AddAttribute (CTStringAttributeKey.UnderlineStyle, NSNumber.FromInt32 ((int)CTUnderlineStyle.Single), r);
+				} else if (att is StrikethroughTextAttribute) {
+					//FIXME: CoreText has no Strikethrough support
+				} else if (att is FontTextAttribute) {
+					var xa = (FontTextAttribute)att;
+					var nf = ((FontData)li.ApplicationContext.Toolkit.GetSafeBackend (xa.Font)).Font;
+					ns.AddAttribute (CTStringAttributeKey.Font, nf, r);
+				}
+			}
+
+			ns.EndEditing ();
+			return ns;
+		}
+
+		static NSAttributedString CreateAttributedString (string text, NSFont font)
+		{
 			NSDictionary dict;
-			if (li.Font != null) {
+			if (font != null) {
 				dict = NSDictionary.FromObjectsAndKeys (
-					new object[] { li.Font, new NSNumber (true) },
-					new object[] { CTStringAttributeKey.Font, CTStringAttributeKey.ForegroundColorFromContext }
+					new object [] { font, new NSNumber (true) },
+					new object [] { CTStringAttributeKey.Font, CTStringAttributeKey.ForegroundColorFromContext }
 				);
 			} else {
 				dict = NSDictionary.FromObjectsAndKeys (
-					new object[] { new NSNumber (true) },
-					new object[] { CTStringAttributeKey.ForegroundColorFromContext }
+					new object [] { new NSNumber (true) },
+					new object [] { CTStringAttributeKey.ForegroundColorFromContext }
 				);
 			}
-			return new NSAttributedString (overrideText ?? li.Text, dict);
+			return new NSAttributedString (text, dict);
 		}
 		
 		internal static void Draw (CGContext ctx, object layout, double x, double y)
@@ -200,10 +266,14 @@ namespace Xwt.Mac
 
 		public override void AddAttribute (object backend, TextAttribute attribute)
 		{
+			LayoutInfo li = (LayoutInfo)backend;
+			li.Attributes.Add (attribute);
 		}
 
 		public override void ClearAttributes (object backend)
 		{
+			LayoutInfo li = (LayoutInfo)backend;
+			li.Attributes.Clear ();
 		}
 		
 		public override int GetIndexFromCoordinates (object backend, double x, double y)

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -261,6 +261,45 @@ namespace Xwt.Mac
 			return 1;
 		}
 
+		public static int ToMacValue (this FontWeight weight)
+		{
+			switch (weight) {
+			case FontWeight.Thin:
+				return 1;
+			case FontWeight.Ultralight:
+				return 2;
+			case FontWeight.Light:
+				return 3;
+			case FontWeight.Book:
+				return 4;
+			case FontWeight.Normal:
+				return 5;
+			case FontWeight.Medium:
+				return 6;
+			case FontWeight.Semibold:
+				return 8;
+			case FontWeight.Bold:
+				return 9;
+			case FontWeight.Ultrabold:
+				return 10;
+			case FontWeight.Heavy:
+				return 11;
+			case FontWeight.Ultraheavy:
+				return 12;
+			default:
+				return 13;
+			}
+		}
+
+		public static NSFont WithWeight (this NSFont font, FontWeight weight)
+		{
+			int w = weight.ToMacValue ();
+			var traits = NSFontManager.SharedFontManager.TraitsOfFont (font);
+			traits |= weight >= FontWeight.Bold? NSFontTraitMask.Bold : NSFontTraitMask.Unbold;
+			traits &= weight >= FontWeight.Bold? ~NSFontTraitMask.Unbold : ~NSFontTraitMask.Bold;
+			return NSFontManager.SharedFontManager.FontWithFamily (font.FamilyName, traits, w, font.PointSize);
+		}
+
 		static Selector applyFontTraits = new Selector ("applyFontTraits:range:");
 
 		public static NSAttributedString ToAttributedString (this FormattedText ft)


### PR DESCRIPTION
* AddAttribute/ClearAttributes support
* Apply TextAttributes supported by CoreText