### PR TITLE
[Mac] fix Label alignment with Label.Markup

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
@@ -27,6 +27,7 @@
 using System;
 using AppKit;
 using CoreGraphics;
+using Foundation;
 using ObjCRuntime;
 using Xwt.Backends;
 
@@ -96,6 +97,10 @@ namespace Xwt.Mac
 				Wrap = WrapMode.Character;
 			Widget.AllowsEditingTextAttributes = true;
 			Widget.AttributedStringValue = text.ToAttributedString ();
+
+			if (TextAlignment != Alignment.Start)
+				SetAlignmentAttribute ();
+
 			ResetFittingSize ();
 		}
 
@@ -110,7 +115,23 @@ namespace Xwt.Mac
 			}
 			set {
 				Widget.Alignment = value.ToNSTextAlignment ();
+				SetAlignmentAttribute ();
 			}
+		}
+
+		void SetAlignmentAttribute ()
+		{
+			if (Widget.AttributedStringValue == null)
+				return;
+			var ns = new NSMutableAttributedString (Widget.AttributedStringValue);
+			ns.BeginEditing ();
+			var r = new NSRange (0, ns.Length);
+			ns.RemoveAttribute (NSStringAttributeKey.ParagraphStyle, r);
+			var pstyle = NSParagraphStyle.DefaultParagraphStyle.MutableCopy () as NSMutableParagraphStyle;
+			pstyle.Alignment = Widget.Alignment;
+			ns.AddAttribute (NSStringAttributeKey.ParagraphStyle, pstyle, r);
+			ns.EndEditing ();
+			Widget.AttributedStringValue = ns;
 		}
 		
 		public EllipsizeMode Ellipsize {

--- a/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
@@ -96,10 +96,10 @@ namespace Xwt.Mac
 			if (Wrap == WrapMode.None)
 				Wrap = WrapMode.Character;
 			Widget.AllowsEditingTextAttributes = true;
-			Widget.AttributedStringValue = text.ToAttributedString ();
-
-			if (TextAlignment != Alignment.Start)
-				SetAlignmentAttribute ();
+			if (TextAlignment == Alignment.Start)
+				Widget.AttributedStringValue = text.ToAttributedString ();
+			else
+				Widget.AttributedStringValue = text.ToAttributedString ().WithAlignment (Widget.Alignment);
 
 			ResetFittingSize ();
 		}
@@ -115,23 +115,9 @@ namespace Xwt.Mac
 			}
 			set {
 				Widget.Alignment = value.ToNSTextAlignment ();
-				SetAlignmentAttribute ();
+				if (Widget.AttributedStringValue != null)
+					Widget.AttributedStringValue = (Widget.AttributedStringValue.MutableCopy () as NSMutableAttributedString).WithAlignment (Widget.Alignment);
 			}
-		}
-
-		void SetAlignmentAttribute ()
-		{
-			if (Widget.AttributedStringValue == null)
-				return;
-			var ns = new NSMutableAttributedString (Widget.AttributedStringValue);
-			ns.BeginEditing ();
-			var r = new NSRange (0, ns.Length);
-			ns.RemoveAttribute (NSStringAttributeKey.ParagraphStyle, r);
-			var pstyle = NSParagraphStyle.DefaultParagraphStyle.MutableCopy () as NSMutableParagraphStyle;
-			pstyle.Alignment = Widget.Alignment;
-			ns.AddAttribute (NSStringAttributeKey.ParagraphStyle, pstyle, r);
-			ns.EndEditing ();
-			Widget.AttributedStringValue = ns;
 		}
 		
 		public EllipsizeMode Ellipsize {

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -302,7 +302,7 @@ namespace Xwt.Mac
 
 		static Selector applyFontTraits = new Selector ("applyFontTraits:range:");
 
-		public static NSAttributedString ToAttributedString (this FormattedText ft)
+		public static NSMutableAttributedString ToAttributedString (this FormattedText ft)
 		{
 			NSMutableAttributedString ns = new NSMutableAttributedString (ft.Text);
 			ns.BeginEditing ();
@@ -355,6 +355,22 @@ namespace Xwt.Mac
 					ns.AddAttribute (NSStringAttributeKey.Font, nf, r);
 				}
 			}
+			ns.EndEditing ();
+			return ns;
+		}
+
+
+		public static NSMutableAttributedString WithAlignment (this NSMutableAttributedString ns, NSTextAlignment alignment)
+		{
+			if (ns == null)
+				return null;
+			
+			ns.BeginEditing ();
+			var r = new NSRange (0, ns.Length);
+			ns.RemoveAttribute (NSStringAttributeKey.ParagraphStyle, r);
+			var pstyle = NSParagraphStyle.DefaultParagraphStyle.MutableCopy () as NSMutableParagraphStyle;
+			pstyle.Alignment = alignment;
+			ns.AddAttribute (NSStringAttributeKey.ParagraphStyle, pstyle, r);
 			ns.EndEditing ();
 			return ns;
 		}


### PR DESCRIPTION
NSTextField.Alignment has no effect if
NSTextField.AttributedString is being used
for Markup. Alignment needs to be added to
the NSAttributedString with an appropriate
NSParagraphStyle.