### PR TITLE
[Gtk] TableViewBackend: custom HeaderView is not visible

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/TableViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TableViewBackend.cs
@@ -163,8 +163,10 @@ namespace Xwt.GtkBackend
 		{
 			if (col.HeaderView == null)
 				tc.Title = col.Title;
-			else
+			else {
 				tc.Widget = CellUtil.CreateCellRenderer (ApplicationContext, col.HeaderView);
+				tc.Widget?.Show ();
+			}
 		}
 		
 		void MapColumn (ListViewColumn col, Gtk.TreeViewColumn tc)


### PR DESCRIPTION
setting an custom HeaderView results in an invisible Header

Solution:
Show() has to be called 
(see: http://stackoverflow.com/questions/24698901/header-widget-in-gtk-treeviewcolumn)