### PR TITLE
[Mac] Fix stack overflow in ViewBackend.ParentIsSensitive

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -141,20 +141,22 @@ namespace Xwt.Mac
 			get { return sensitive; }
 			set {
 				sensitive = value;
-				UpdateSensitiveStatus (Widget, sensitive && ParentIsSensitive ());
+				UpdateSensitiveStatus (Widget, sensitive && ParentIsSensitive (Widget));
 			}
 		}
 
-		bool ParentIsSensitive ()
+		static bool ParentIsSensitive (NSView view)
 		{
-			IViewObject parent = Widget.Superview as IViewObject;
+			var parent = view.Superview;
+			if ((parent as NSControl)?.Enabled == false)
+				return false;
 			if (parent == null) {
-				var wb = Widget.Window as WindowBackend;
+				var wb = view.Window as WindowBackend;
 				return wb == null || wb.Sensitive;
 			}
-			if (!parent.Backend.Sensitive)
+			if ((parent as IViewObject)?.Backend.Sensitive == false)
 				return false;
-			return parent.Backend.ParentIsSensitive ();
+			return ParentIsSensitive (parent);
 		}
 
 		internal void UpdateSensitiveStatus (NSView view, bool parentIsSensitive)


### PR DESCRIPTION
In some rare cases a view and its superview both implement IViewObject
and additionally share the same Backend (for eaxmple a custom widget
inside an alignement container), which results in an infite loop when
Backend.ParentIsSensitive is called.

The workaround is to not rely on Superview being a IViewObject
and its Backend.Widget to be the real parent, but to use
Widget.Superview only to walk up the widget hierarchy.