### PR TITLE
[Mac] Fix build with XamMac older than 3.4

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
@@ -35,7 +35,12 @@ namespace Xwt.Mac
 			var ds = System.Threading.Thread.GetNamedDataSlot ("NSApplication.Initialized");
 			if (System.Threading.Thread.GetData (ds) == null) {
 				System.Threading.Thread.SetData (ds, true);
-				NSApplication.IgnoreMissingAssembliesDuringRegistration = true;
+
+				// IgnoreMissingAssembliesDuringRegistration is only avalilable in Xamarin.Mac 3.4+
+				// Use reflection to not break builds with older Xamarin.Mac
+				var ignoreMissingAssemblies = typeof (NSApplication).GetField ("IgnoreMissingAssembliesDuringRegistration",
+				                                                               System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+				ignoreMissingAssemblies?.SetValue (null, true);
 				NSApplication.Init ();
 			}
 		}


### PR DESCRIPTION
4a4476f5192438e64a5643b8ee9731b7fc0e678f broke the build with older Xamarin.Mac versions (any before https://github.com/xamarin/xamarin-macios/commit/0963ba1e755c0f2a75bae6a387ad3f0ad8eba650, which is included in XM 3.4+ only)