### PR TITLE
[Mac] Force NSTableView to autoresize columns

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
@@ -27,6 +27,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using AppKit;
 using CoreGraphics;
 using Foundation;
@@ -70,8 +71,11 @@ namespace Xwt.Mac
 
 		internal void AutosizeColumns ()
 		{
-			foreach (var col in TableColumns ())
+			var columns = TableColumns ();
+			foreach (var col in columns)
 				AutosizeColumn (col);
+			if (columns.Any (c => c.ResizingMask.HasFlag (NSTableColumnResizing.Autoresizing)))
+				SizeToFit ();
 		}
 
 		void AutosizeColumn (NSTableColumn tableColumn)
@@ -85,6 +89,8 @@ namespace Xwt.Mac
 					var cell = base.GetCell (column, i);
 					s.Width = (nfloat)Math.Max (s.Width, cell.CellSize.Width);
 				}
+				if (!tableColumn.ResizingMask.HasFlag (NSTableColumnResizing.Autoresizing))
+					tableColumn.Width = s.Width;
 			}
 			tableColumn.MinWidth = s.Width;
 		}

--- a/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
@@ -27,6 +27,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
 using AppKit;
 using Foundation;
 using Xwt.Backends;
@@ -66,8 +67,11 @@ namespace Xwt.Mac
 
 		internal void AutosizeColumns ()
 		{
-			foreach (var col in TableColumns ())
+			var columns = TableColumns ();
+			foreach (var col in columns)
 				AutosizeColumn (col);
+			if (columns.Any (c => c.ResizingMask.HasFlag (NSTableColumnResizing.Autoresizing)))
+				SizeToFit ();
 		}
 
 		void AutosizeColumn (NSTableColumn tableColumn)
@@ -86,6 +90,8 @@ namespace Xwt.Mac
 					else
 						s.Width = (nfloat)Math.Max (s.Width, cell.CellSize.Width);
 				}
+				if (!tableColumn.ResizingMask.HasFlag (NSTableColumnResizing.Autoresizing))
+					tableColumn.Width = s.Width;
 			}
 			tableColumn.MinWidth = s.Width;
 		}


### PR DESCRIPTION
NSTableView autosizes its colums with enabled
Autoresizing only on initialization but not on
data changes. This patch forces the view to
recalculate column sizes of expanding columns,
and additionally enforces a fitting width for
not resizable columns.