### PR TITLE
[WPF] Fix CheckBoxCell Toggle and Mixed state handling

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -142,14 +142,21 @@ namespace Xwt.WPFBackend.Utilities
 			
 			CheckBoxCellView cellView = view as CheckBoxCellView;
 			if (cellView != null) {
-				FrameworkElementFactory factory = new FrameworkElementFactory (typeof(SWC.CheckBox));
+				FrameworkElementFactory factory = new FrameworkElementFactory (typeof(CheckBoxCell));
 				if (cellView.EditableField == null)
 					factory.SetValue (FrameworkElement.IsEnabledProperty, cellView.Editable);
 				else
 					factory.SetBinding (SWC.CheckBox.IsEnabledProperty, new Binding (dataPath + "[" + cellView.EditableField.Index + "]"));
 
-				factory.SetValue (SWC.CheckBox.IsThreeStateProperty, cellView.AllowMixed);
-				if (cellView.ActiveField != null)
+				if (cellView.AllowMixedField == null)
+					factory.SetValue(SWC.CheckBox.IsThreeStateProperty, cellView.AllowMixed);
+				else
+					factory.SetBinding(SWC.CheckBox.IsThreeStateProperty, new Binding(dataPath + "[" + cellView.AllowMixedField.Index + "]"));
+
+				if (cellView.StateField != null)
+					factory.SetBinding(SWC.CheckBox.IsCheckedProperty,
+						new Binding(dataPath + "[" + cellView.StateField.Index + "]") { Converter = new CheckBoxStateToBoolConverter() });
+				else if (cellView.ActiveField != null)
 					factory.SetBinding (SWC.CheckBox.IsCheckedProperty, new Binding (dataPath + "[" + cellView.ActiveField.Index + "]"));
 
 				var cb = new CheckBoxCellViewBackend ();


### PR DESCRIPTION
The `Checked` and `Unchecked` events are bound to the dependency properties and occur after the CheckBox has been toggled and the bound field set to the new state. This makes it impossible to implement own `Toggled` logic in the `CheckBoxCellView.Toggled` handler.

This patch introduces a new `CheckBox.Toggle` routed event which is raised before the default `OnToggle ()` logic, which can be stopped by setting `RoutedEventArgs.Handled`. The `CheckBoxCellViewBackend` uses the new logic to allow custom toggle logic on the Frontend side.

Additionally this patch fixes the `AllowMixedField` and `StateField` bindings using a custom `CheckBoxState` converter, which play together with the fixed Toggle implementation.