### PR TITLE
[Gtk] Reset CellRendererText.Attributes when using mixed text and markup data fields

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererText.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererText.cs
@@ -32,6 +32,7 @@ namespace Xwt.GtkBackend
 	public class CustomCellRendererText: CellViewBackend
 	{
 		Gtk.CellRendererText cellRenderer;
+		bool mixedMarkupText;
 
 		public CustomCellRendererText ()
 		{
@@ -50,8 +51,11 @@ namespace Xwt.GtkBackend
 				atts.AddAttributes (new TextIndexer (tx.Text), tx.Attributes);
 				cellRenderer.Attributes = new Pango.AttrList (atts.Handle);
 				atts.Dispose ();
+				mixedMarkupText = true;
 			} else {
 				cellRenderer.Text = view.Text;
+				if (mixedMarkupText)
+					cellRenderer.Attributes = new Pango.AttrList ();
 			}
 			cellRenderer.Editable = view.Editable;
 			cellRenderer.Ellipsize = view.Ellipsize.ToGtkValue ();


### PR DESCRIPTION
It is not guaranteed that a cell has only a markup or a text data field. Sometimes it can be useful to have both (expandable trees). In such a mixed mode we need to reset the Pango attributes when setting the cell text.