### PR TITLE
[Mac] Fix RichTextView wrapping inside ScrollView

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
@@ -84,7 +84,9 @@ namespace Xwt.Mac
 
 		public override Size GetPreferredSize (SizeConstraint widthConstraint, SizeConstraint heightConstraint)
 		{
-			var width = (double) Widget.TextStorage.Size.Width;
+			// set initial width to 0 to force text wrapping if inside ScrollView with disabled horizontal scrolling
+			var enclosingScrolView = (Widget.Superview as NSClipView)?.EnclosingScrollView;
+			var width = (enclosingScrolView?.HasHorizontalScroller == false) ? 0 : (double)Widget.TextStorage.Size.Width;
 			if (widthConstraint.IsConstrained)
 				width = widthConstraint.AvailableSize;
 			if (minWidth != -1 && minWidth > width)


### PR DESCRIPTION
If the enclosing ScrollViews horizontal scrolling
is disabled, GetPreferredSize should not use the initial
text width in order to allow the text view to wrap
the text.