### PR TITLE
[Mac] Fixed crash using Popover with `NSView`.

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/EmbeddedWidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/EmbeddedWidgetBackend.cs
@@ -34,7 +34,7 @@ namespace Xwt.GtkBackend
 		{
 		}
 
-		public void SetContent (object nativeWidget)
+		public void SetContent (object nativeWidget, bool reparent)
 		{
 			if (nativeWidget is Gtk.Widget) {
 				Widget = (Gtk.Widget)nativeWidget;

--- a/Xwt.WPF/Xwt.WPFBackend/EmbedNativeWidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/EmbedNativeWidgetBackend.cs
@@ -12,7 +12,7 @@ namespace Xwt.WPFBackend
 {
 	class EmbedNativeWidgetBackend: WidgetBackend, IEmbeddedWidgetBackend
 	{
-		public void SetContent(object nativeWidget)
+		public void SetContent(object nativeWidget, bool reparent)
 		{
 			if (nativeWidget is FrameworkElement)
 				Widget = (FrameworkElement)nativeWidget;

--- a/Xwt.XamMac/Xwt.Mac/EmbedNativeWidgetBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/EmbedNativeWidgetBackend.cs
@@ -1,4 +1,4 @@
-using AppKit;
+﻿using AppKit;
 using Xwt.Backends;
 
 namespace Xwt.Mac
@@ -6,10 +6,15 @@ namespace Xwt.Mac
 	public class EmbedNativeWidgetBackend : ViewBackend, IEmbeddedWidgetBackend
 	{
 		NSView innerView;
+		bool reparent;
 
 		public EmbedNativeWidgetBackend ()
 		{
 
+		}
+
+		public NSView InnerView {
+			get { return innerView; }
 		}
 
 		public override void Initialize ()
@@ -18,13 +23,15 @@ namespace Xwt.Mac
 			if (innerView != null) {
 				var aView = innerView;
 				innerView = null;
+
 				SetNativeView (aView);
 			}
 		}
 
-		public void SetContent (object nativeWidget)
+		public void SetContent (object nativeWidget, bool reparent)
 		{
 			if (nativeWidget is NSView) {
+				this.reparent = reparent;
 				if (ViewObject == null)
 					innerView = (NSView)nativeWidget;
 				else
@@ -34,9 +41,13 @@ namespace Xwt.Mac
 
 		void SetNativeView (NSView aView)
 		{
-			if (innerView != null)
+			if (innerView != null && reparent)
 				innerView.RemoveFromSuperview ();
+			
 			innerView = aView;
+			if (!reparent)
+				return;
+			
 			innerView.Frame = Widget.Bounds;
 
 			innerView.AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;

--- a/Xwt.XamMac/Xwt.Mac/EmbedNativeWidgetBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/EmbedNativeWidgetBackend.cs
@@ -13,7 +13,7 @@ namespace Xwt.Mac
 
 		}
 
-		public NSView InnerView {
+		public NSView EmbeddedView {
 			get { return innerView; }
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -203,7 +203,11 @@ namespace Xwt.Mac
 		public void Show (Popover.Position orientation, Widget referenceWidget, Rectangle positionRect, Widget child)
 		{
 			var refBackend = Toolkit.GetBackend (referenceWidget) as IWidgetBackend;
-			NSView refView = (refBackend as ViewBackend)?.Widget;
+
+			NSView refView = (refBackend as EmbedNativeWidgetBackend)?.InnerView;
+
+			if (refView == null)
+				refView = (refBackend as ViewBackend)?.Widget;
 
 			if (refView == null) {
 				if (referenceWidget.Surface.ToolkitEngine.Type == ToolkitType.Gtk) {

--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -204,7 +204,7 @@ namespace Xwt.Mac
 		{
 			var refBackend = Toolkit.GetBackend (referenceWidget) as IWidgetBackend;
 
-			NSView refView = (refBackend as EmbedNativeWidgetBackend)?.InnerView;
+			NSView refView = (refBackend as EmbedNativeWidgetBackend)?.EmbeddedView;
 
 			if (refView == null)
 				refView = (refBackend as ViewBackend)?.Widget;

--- a/Xwt/Xwt.Backends/IEmbeddedWidgetBackend.cs
+++ b/Xwt/Xwt.Backends/IEmbeddedWidgetBackend.cs
@@ -48,12 +48,13 @@ namespace Xwt.Backends
 {
 	public interface IEmbeddedWidgetBackend: IWidgetBackend
 	{
-		void SetContent (object nativeWidget);
+		void SetContent (object nativeWidget, bool reparent);
 	}
 
 	[BackendType (typeof(IEmbeddedWidgetBackend))]
 	internal class EmbeddedNativeWidget: Widget
 	{
+		bool reparent;
 		object nativeWidget;
 		Widget sourceWidget;
 		NativeWidgetSizing sizing;
@@ -62,7 +63,7 @@ namespace Xwt.Backends
 		{
 			protected override void OnBackendCreated ()
 			{
-				Backend.SetContent (Parent.nativeWidget);
+				Backend.SetContent (Parent.nativeWidget, Parent.reparent);
 				base.OnBackendCreated ();
 			}
 		}
@@ -72,11 +73,12 @@ namespace Xwt.Backends
 			return new EmbeddedNativeWidgetBackendHost ();
 		}
 
-		public void Initialize (object nativeWidget, Widget sourceWidget, NativeWidgetSizing preferredSizing)
+		public void Initialize (object nativeWidget, Widget sourceWidget, NativeWidgetSizing preferredSizing, bool reparent)
 		{
 			this.nativeWidget = nativeWidget;
 			this.sourceWidget = sourceWidget;
 			this.sizing = preferredSizing;
+			this.reparent = reparent;
 		}
 		
 		protected override Size OnGetPreferredSize (SizeConstraint widthConstraint, SizeConstraint heightConstraint)

--- a/Xwt/Xwt/Toolkit.cs
+++ b/Xwt/Xwt/Toolkit.cs
@@ -554,7 +554,7 @@ namespace Xwt
 		/// </summary>
 		/// <returns>An Xwt widget with the specified native widget backend.</returns>
 		/// <param name="nativeWidget">The native widget.</param>
-		public Widget WrapWidget (object nativeWidget, NativeWidgetSizing preferredSizing = NativeWidgetSizing.External)
+		public Widget WrapWidget (object nativeWidget, NativeWidgetSizing preferredSizing = NativeWidgetSizing.External, bool reparent = true)
 		{
 			var externalWidget = nativeWidget as Widget;
 			if (externalWidget != null) {
@@ -563,7 +563,7 @@ namespace Xwt
 				nativeWidget = externalWidget.Surface.ToolkitEngine.GetNativeWidget (externalWidget);
 			}
 			var embedded = CreateObject<EmbeddedNativeWidget> ();
-			embedded.Initialize (nativeWidget, externalWidget, preferredSizing);
+			embedded.Initialize (nativeWidget, externalWidget, preferredSizing, reparent);
 			return embedded;
 		}
 


### PR DESCRIPTION
* Added a parameter to `WrapWidget` to do not reparent the nativeView.
We can’t wrap and unwrap the NSView to be used with the Popover, because this will change the parent of the window when we unwrap it, invalidating the `NSView.Window`, making NSPopover throw a NSException, due the missing NSWindow inside the NSView.
* This add a option to do not reparent the native view when Wrap/Unwrap, and get the (untouched) native view back on `Show`.

Previous related PR: https://github.com/mono/xwt/pull/668