### PR TITLE
Always use native backend for Clipboard

### DIFF
--- a/Xwt/Xwt/Clipboard.cs
+++ b/Xwt/Xwt/Clipboard.cs
@@ -33,10 +33,18 @@ namespace Xwt
 {
 	public static class Clipboard
 	{
+		// Cache the toolkit the first time we access the Clipboard and then always use
+		//  the same one, otherwise we will get inconsistent results from APIs like ContainsData<T>().
+		static Toolkit toolkit;
+
 		static ClipboardBackend Backend {
-			get { return Toolkit.CurrentEngine.ClipboardBackend; }
+			get {
+				if (toolkit == null)
+					toolkit = Toolkit.CurrentEngine;
+				return toolkit.ClipboardBackend;
+			}
 		}
-		
+
 		public static void Clear ()
 		{
 			Backend.Clear ();


### PR DESCRIPTION
Without this, `Clipboard.ContainsData` can return different results depending on which backend it is invoked with.

The only caveat I see with this approach is that any `Image` object returned from the Clipboard API will now have the native backend, which might be different than where it will be consumed. But since we have multi-toolkit support for images, I don't think this should be an issue.