### PR TITLE
Don't raise UnhandledException on toolkit loading failure

### DIFF
--- a/Xwt/Xwt/Toolkit.cs
+++ b/Xwt/Xwt/Toolkit.cs
@@ -282,7 +282,6 @@ namespace Xwt
 			catch (Exception ex) {
 				if (throwIfFails)
 					throw new Exception ("Toolkit could not be loaded", ex);
-				Application.NotifyException (ex);
 			}
 			if (throwIfFails)
 				throw new Exception ("Toolkit could not be loaded");


### PR DESCRIPTION
If throwIfFails is false, exceptions should be ignored
as requested by the caller. Otherwise Toolkit.TryLoad
raises UnhandledException without need.