### PR TITLE
[Mac] Optimize image drawing context.

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ContextBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ContextBackendHandler.cs
@@ -296,8 +296,6 @@ namespace Xwt.Mac
 
 			// Add the styles that have been globaly set to the context
 			img.Styles = img.Styles.AddRange (cb.Styles);
-			
-			NSImage image = img.ToNSImage ();
 
 			ctx.SaveState ();
 			ctx.SetAlpha ((float)img.Alpha);
@@ -309,12 +307,14 @@ namespace Xwt.Mac
 			ctx.TranslateCTM ((float)(destRect.X - (srcRect.X * rx)), (float)(destRect.Y - (srcRect.Y * ry)));
 			ctx.ScaleCTM ((float)rx, (float)ry);
 
+			NSImage image = (NSImage)img.Backend;
 			if (image is CustomImage) {
-				((CustomImage)image).DrawInContext ((CGContextBackend)backend);
+				((CustomImage)image).DrawInContext ((CGContextBackend)backend, img);
 			} else {
-				var rr = new CGRect (0, 0, image.Size.Width, image.Size.Height);
+				var size = new CGSize ((nfloat)img.Size.Width, (nfloat)img.Size.Height);
+				var rr = new CGRect (0, 0, size.Width, size.Height);
 				ctx.ScaleCTM (1f, -1f);
-				ctx.DrawImage (new CGRect (0, -image.Size.Height, image.Size.Width, image.Size.Height), image.AsCGImage (ref rr, NSGraphicsContext.CurrentContext, null));
+				ctx.DrawImage (new CGRect (0, -size.Height, size.Width, size.Height), image.AsCGImage (ref rr, NSGraphicsContext.CurrentContext, null));
 			}
 
 			ctx.RestoreState ();

--- a/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
@@ -333,7 +333,7 @@ namespace Xwt.Mac
 
 		internal void DrawInContext (CGContextBackend ctx, ImageDescription idesc)
 		{
-			var s = ctx.Size != CGSize.Empty ? ctx.Size : Size;
+			var s = ctx.Size != CGSize.Empty ? ctx.Size : new CGSize (idesc.Size.Width, idesc.Size.Height);
 			actx.InvokeUserCode (delegate {
 				drawCallback (ctx, new Rectangle (0, 0, s.Width, s.Height), idesc, actx.Toolkit);
 			});


### PR DESCRIPTION
This commit works around code that reflects a lot. NSObject.Copy() does
reflection to find the intptr constructor of an object, then uses
ConstructorInfo.Invoke to construct the NSImage.

Since we don't operate with the actual NSImage in the case we don't
have a custom image, do not create a copy, as we only need to pass in
the CGImage we get. The AsCGImage does not do any reflection, so this
should turn into faster code.