### PR TITLE
[Gtk] Don't leak popup windows

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/PopupWindowBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopupWindowBackend.cs
@@ -34,8 +34,6 @@ namespace Xwt.GtkBackend
 
 		public override void Initialize ()
 		{
-			Window = new GtkPopoverWindow (Gtk.WindowType.Toplevel);
-			Window.TypeHint = Gdk.WindowTypeHint.Utility;
 			Window = new GtkPopoverWindow (windowType == PopupWindow.PopupType.Tooltip ? Gtk.WindowType.Popup : Gtk.WindowType.Toplevel);
 
 			switch (windowType) {

--- a/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WindowFrameBackend.cs
@@ -100,25 +100,33 @@ namespace Xwt.GtkBackend
 			Initialize ();
 
 			#if !XWT_GTK3
-			Window.SizeRequested += delegate(object o, Gtk.SizeRequestedArgs args) {
-				if (!Window.Resizable) {
-					int w = args.Requisition.Width, h = args.Requisition.Height;
-					if (w < (int) requestedSize.Width)
-						w = (int) requestedSize.Width;
-					if (h < (int) requestedSize.Height)
-						h = (int) requestedSize.Height;
-					args.Requisition = new Gtk.Requisition () { Width = w, Height = h };
-				}
-			};
+			Window.SizeRequested += OnSizeRequested;
 			#endif
 		}
-		
+
+		#if !XWT_GTK3
+		void OnSizeRequested (object o, Gtk.SizeRequestedArgs args)
+		{
+			if (!Window.Resizable) {
+				int w = args.Requisition.Width, h = args.Requisition.Height;
+				if (w < (int)requestedSize.Width)
+					w = (int)requestedSize.Width;
+				if (h < (int)requestedSize.Height)
+					h = (int)requestedSize.Height;
+				args.Requisition = new Gtk.Requisition () { Width = w, Height = h };
+			}
+		}
+		#endif
+
 		public virtual void Initialize ()
 		{
 		}
 		
 		public virtual void Dispose ()
 		{
+			#if !XWT_GTK3
+			Window.SizeRequested -= OnSizeRequested;
+			#endif
 			Window.Destroy ();
 		}
 		


### PR DESCRIPTION
The popup was being attached. The Gtk window was being set, but there was no destroy done on it, thus it was esentially leaked forever.