### PR TITLE
Fix PopupWindow initialization

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowBackend.cs
@@ -65,20 +65,29 @@ namespace Xwt.WPFBackend
 			get { return (WpfWindow)base.Window; }
 		}
 
+		bool initialized;
+
 		public override void Initialize ()
 		{
-			base.Initialize ();
-			Window.Frontend = (Window) Frontend;
-			if (Frontend is UtilityWindow)
-				defaultWindowStyle = WindowStyle.ToolWindow;
-			Decorated = true;
+			if (!initialized) {
+				base.Initialize();
+				Window.Frontend = (Window)Frontend;
+				if (Frontend is UtilityWindow)
+					defaultWindowStyle = WindowStyle.ToolWindow;
+				Decorated = true;
+				initialized = true;
+			}
 		}
 
 		public void Initialize(IWindowFrameEventSink sink, PopupWindow.PopupType type)
 		{
-			Initialize ();
-			defaultWindowStyle = WindowStyle.ToolWindow;
-			Decorated = false;
+			if (!initialized) {
+				base.Initialize();
+				Window.Frontend = (Window)Frontend;
+				defaultWindowStyle = WindowStyle.ToolWindow;
+				Decorated = false;
+				initialized = true;
+			}
 		}
 
 		// A Grid with a single column, and two rows (menu and child control).

--- a/Xwt.XamMac/Xwt.Mac/PopupWindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopupWindowBackend.cs
@@ -95,20 +95,28 @@ namespace Xwt.Mac
 			this.ApplicationContext = context;
 			this.frontend = (Window) frontend;
 		}
+
+		bool backendInitiaized;
 		
 		public void Initialize (IWindowFrameEventSink eventSink)
 		{
-			this.eventSink = eventSink;
-			this.isPopup = false;
-			UpdateWindowStyle ();
+			if (!backendInitiaized) {
+				this.eventSink = eventSink;
+				this.isPopup = false;
+				UpdateWindowStyle();
+				backendInitiaized = true;
+			}
 		}
 
 		public void Initialize (IWindowFrameEventSink eventSink, PopupWindow.PopupType windowType)
 		{
-			this.isPopup = true;
-			this.eventSink = eventSink;
-			this.windowType = windowType;
-			UpdateWindowStyle ();
+			if (!backendInitiaized) {
+				this.eventSink = eventSink;
+				this.isPopup = true;
+				this.windowType = windowType;
+				UpdateWindowStyle();
+				backendInitiaized = true;
+			}
 		}
 
 		void UpdateWindowStyle ()

--- a/Xwt/Xwt/PopupWindow.cs
+++ b/Xwt/Xwt/PopupWindow.cs
@@ -65,8 +65,8 @@ namespace Xwt
 
 			protected override void OnBackendCreated ()
 			{
-				base.OnBackendCreated ();
 				((IPopupWindowBackend)Backend).Initialize (this, Parent.Type);
+				base.OnBackendCreated ();
 			}
 		}
 

--- a/Xwt/Xwt/UtilityWindow.cs
+++ b/Xwt/Xwt/UtilityWindow.cs
@@ -37,12 +37,6 @@ namespace Xwt
 		protected new class WindowBackendHost : Window.WindowBackendHost
 		{
 			new UtilityWindow Parent { get { return (UtilityWindow)base.Parent; } }
-
-			protected override void OnBackendCreated ()
-			{
-				base.OnBackendCreated ();
-				((IUtilityWindowBackend)Backend).Initialize (this);
-			}
 		}
 
 		protected override BackendHost CreateBackendHost ()


### PR DESCRIPTION
This fixes the `PopupWindow`initialization by calling `IPopupWindowBackend.Initialize` before `IWindowFrameBackend.Initialize` and the backends should take care of the rest.