### PR TITLE
[a11y] Set the role of the ImageBox to an Image

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/ImageHandler.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ImageHandler.cs
@@ -502,6 +502,7 @@ namespace Xwt.GtkBackend
 			this.SetHasWindow (false);
 			this.SetAppPaintable (true);
 			this.actx = actx;
+			Accessible.Role = Atk.Role.Image;
 		}
 
 		public ImageDescription Image {


### PR DESCRIPTION
On Gtk the ImageBox is a custom Gtk.DrawingArea so it needs to have an image role set for accessibility