### PR TITLE
[Xwt] Fix leak in DatePicker

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/DatePickerBackend.cs
@@ -235,7 +235,13 @@ namespace Xwt.GtkBackend
 				else if (Adjustment.Value < currentValue.Ticks)
 					DateTime = currentValue.AddComponent (selectedComponent, -1);
 			}
-			
+
+			protected override void OnDestroyed()
+			{
+				Adjustment.ValueChanged -= HandleValueChanged;
+				base.OnDestroyed();
+			}
+
 			protected override int OnOutput ()
 			{
 				DateTime dateTime = new DateTime ((long)Adjustment.Value);


### PR DESCRIPTION
The adjustment is held on the SpinButton as a property, not parented, so there is no destroy event happening for the adjustment.