### PR TITLE
[Mac] Fix invalid -apple-system-font warning

### DIFF
--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -248,7 +248,9 @@ namespace Xwt.Drawing
 				// add dummy font names for unit tests, the names are not exposed to users
 				// see the FontNameWith* tests (Testing/Tests/FontTests.cs) for details
 				installedFonts.Add("____FakeTestFont 72", "Arial");
-				installedFonts.Add("____FakeTestFont Rounded MT Bold", "Arial");
+				installedFonts.Add ("____FakeTestFont Rounded MT Bold", "Arial");
+				// HACK: add font mapping for patched pango SF Font support
+				installedFonts.Add ("-apple-system-font", ".AppleSystemUIFont");
 			}
 		}
 


### PR DESCRIPTION
This fixes a croner case on Mac where Gtkrc must define
an invalid font name, because GTK can not handle
the special .AppleSystemUIFont name.

This fixes the warning:
`Font '-apple-system-font' not available in the system. Using '.AppleSystemUIFont' instead`