### PR TITLE
[Mac] Fix invalid -apple-system-font warning Pt.2

### DIFF
--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -250,7 +250,7 @@ namespace Xwt.Drawing
 				installedFonts.Add("____FakeTestFont 72", "Arial");
 				installedFonts.Add ("____FakeTestFont Rounded MT Bold", "Arial");
 				// HACK: add font mapping for patched pango SF Font support
-				installedFonts.Add ("-apple-system-font", ".AppleSystemUIFont");
+				installedFonts ["-apple-system-font"] = ".AppleSystemUIFont";
 			}
 		}
 


### PR DESCRIPTION
The fix introduced in b9fc3ab78357c987fc43795f2197b6f75765c5e1
did not take into account that the "-apple-system-font"
may have been already detected. This can happen if the Xwt.Gtk
font backend is initialized first.