### PR TITLE
Cross toolkit system dialogs

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/FileDialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/FileDialogBackend.cs
@@ -38,6 +38,8 @@ namespace Xwt.GtkBackend
 		List<Gtk.FileFilter> gtkFilters;
 		List<FileDialogFilter> filters;
 
+		public ApplicationContext ApplicationContext { get; private set; }
+
 		public FileDialogBackend (Gtk.FileChooserAction action)
 		{
 			this.action = action;
@@ -45,6 +47,7 @@ namespace Xwt.GtkBackend
 
 		public void InitializeBackend (object frontend, ApplicationContext context)
 		{
+			ApplicationContext = context;
 		}
 		
 		public void EnableEvent (object eventId)
@@ -127,8 +130,8 @@ namespace Xwt.GtkBackend
 		
 		public bool Run (IWindowFrameBackend parent)
 		{
-			var p = (WindowFrameBackend) parent;
-			int result = MessageService.RunCustomDialog (dialog, p != null ? p.Window : null);
+			var p = parent != null ? ApplicationContext.Toolkit.GetNativeWindow (parent) as Gtk.Window : null;
+			int result = MessageService.RunCustomDialog (dialog, p);
 			return result == (int) Gtk.ResponseType.Ok;
 		}
 		

--- a/Xwt.Gtk/Xwt.GtkBackend/SelectColorDialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/SelectColorDialogBackend.cs
@@ -55,8 +55,8 @@ namespace Xwt.GtkBackend
 			if (supportsAlpha)
 				dlg.ColorSelection.CurrentAlpha = (ushort) (((double)ushort.MaxValue) * color.Alpha);
 		
-			var p = (WindowFrameBackend) parent;
-			int result = MessageService.RunCustomDialog (dlg, p != null ? p.Window : null);
+			var p = parent != null ? Toolkit.CurrentEngine.GetNativeWindow (parent) as Gtk.Window : null;
+			int result = MessageService.RunCustomDialog (dlg, p);
 			
 			if (result == (int) Gtk.ResponseType.Ok) {
 				color = dlg.ColorSelection.CurrentColor.ToXwtValue ();

--- a/Xwt.Gtk/Xwt.GtkBackend/SelectFontDialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/SelectFontDialogBackend.cs
@@ -78,8 +78,8 @@ namespace Xwt.GtkBackend
 			if (SelectedFont != null)
 				dlg.SetFontName (SelectedFont.ToString ());
 
-			var p = (WindowFrameBackend)parent;
-			int result = MessageService.RunCustomDialog (dlg, p != null ? p.Window : null);
+			var p = parent != null ? Toolkit.CurrentEngine.GetNativeWindow (parent) as Gtk.Window : null;
+			int result = MessageService.RunCustomDialog (dlg, p);
 
 			if (result == (int)Gtk.ResponseType.Ok) {
 				SelectedFont = Font.FromName (dlg.FontName);

--- a/Xwt.WPF/Xwt.WPFBackend/SelectColorDialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/SelectColorDialogBackend.cs
@@ -50,7 +50,7 @@ namespace Xwt.WPFBackend
 			//TODO: Support alpha + create custom WPF solution?
 			dialog.Title = title;
 			if (parent != null)
-				return (this.dialog.ShowDialog(new WpfWin32Window(((WindowFrameBackend)parent).Window)) == DialogResult.OK);
+				return (this.dialog.ShowDialog(new XwtWin32Window(parent)) == DialogResult.OK);
 			else
 				return (this.dialog.ShowDialog() == DialogResult.OK);
 		}
@@ -87,22 +87,6 @@ namespace Xwt.WPFBackend
 				}
 				return hookProc;
 			}
-		}
-
-		private class WpfWin32Window
-			: IWin32Window
-		{
-			public WpfWin32Window(System.Windows.Window window)
-			{
-				this.helper = new WindowInteropHelper(window);
-			}
-
-			public IntPtr Handle
-			{
-				get { return this.helper.Handle; }
-			}
-
-			private readonly WindowInteropHelper helper;
 		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/SelectFolderDialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/SelectFolderDialogBackend.cs
@@ -88,7 +88,7 @@ namespace Xwt.WPFBackend
 		public bool Run (IWindowFrameBackend parent)
 		{
 			if (parent != null)
-				return (this.dialog.ShowDialog (new WpfWin32Window (((WindowFrameBackend) parent).Window)) == DialogResult.OK);
+				return (this.dialog.ShowDialog (new XwtWin32Window (parent)) == DialogResult.OK);
 			else
 				return (this.dialog.ShowDialog () == DialogResult.OK);
 		}
@@ -99,21 +99,5 @@ namespace Xwt.WPFBackend
 		}
 
 		private WindowsFolderBrowserDialog dialog;
-
-		private class WpfWin32Window
-			: IWin32Window
-		{
-			public WpfWin32Window (System.Windows.Window window)
-			{
-				this.helper = new WindowInteropHelper (window);
-			}
-
-			public IntPtr Handle
-			{
-				get { return this.helper.Handle; }
-			}
-
-			private readonly WindowInteropHelper helper;
-		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/Util.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/Util.cs
@@ -26,6 +26,7 @@
 using System.Windows;
 using System.Windows.Media;
 using System;
+using Xwt.Backends;
 
 namespace Xwt.WPFBackend
 {
@@ -89,5 +90,19 @@ namespace Xwt.WPFBackend
 
 			return null;
 		}
-    }
+	}
+
+	class XwtWin32Window : System.Windows.Forms.IWin32Window
+	{
+		public XwtWin32Window (IWindowFrameBackend window)
+		{
+			this.window = window;
+		}
+
+		public IntPtr Handle {
+			get { return window.NativeHandle; }
+		}
+
+		readonly IWindowFrameBackend window;
+	}
 }

--- a/Xwt/Xwt/FileDialog.cs
+++ b/Xwt/Xwt/FileDialog.cs
@@ -182,7 +182,7 @@ namespace Xwt
 					Backend.ActiveFilter = activeFilter;
 				if (!string.IsNullOrEmpty (title))
 					Backend.Title = title;
-				return Backend.Run ((IWindowFrameBackend)BackendHost.ToolkitEngine.GetSafeBackend (parentWindow));
+				return Backend.Run ((IWindowFrameBackend)Toolkit.GetBackend (parentWindow));
 			} finally {
 				currentFolder = Backend.CurrentFolder;
 				activeFilter = Backend.ActiveFilter;

--- a/Xwt/Xwt/SelectColorDialog.cs
+++ b/Xwt/Xwt/SelectColorDialog.cs
@@ -89,7 +89,7 @@ namespace Xwt
 			try {
 				if (color != Colors.Transparent)
 					backend.Color = color;
-				return backend.Run ((IWindowFrameBackend)Toolkit.CurrentEngine.GetSafeBackend (parentWindow), title, supportsAlpha);
+				return backend.Run ((IWindowFrameBackend)Toolkit.GetBackend (parentWindow), title, supportsAlpha);
 			} finally {
 				color = backend.Color;
 				backend.Dispose ();

--- a/Xwt/Xwt/SelectFolderDialog.cs
+++ b/Xwt/Xwt/SelectFolderDialog.cs
@@ -156,7 +156,7 @@ namespace Xwt
 				if (!string.IsNullOrEmpty (title))
 					Backend.Title = title;
 				Backend.CanCreateFolders = canCreateFolders;
-				return Backend.Run ((IWindowFrameBackend)BackendHost.ToolkitEngine.GetSafeBackend (parentWindow));
+				return Backend.Run ((IWindowFrameBackend)Toolkit.GetBackend (parentWindow));
 			} finally {
 				currentFolder = Backend.CurrentFolder;
 				folder = Backend.Folder;

--- a/Xwt/Xwt/SelectFontDialog.cs
+++ b/Xwt/Xwt/SelectFontDialog.cs
@@ -95,7 +95,7 @@ namespace Xwt
 				backend.SelectedFont = SelectedFont;
 				backend.Title = Title;
 				backend.PreviewText = PreviewText;
-				return backend.Run ((IWindowFrameBackend)Toolkit.CurrentEngine.GetSafeBackend (parentWindow));
+				return backend.Run ((IWindowFrameBackend)Toolkit.GetBackend (parentWindow));
 			} catch (Exception ex) {
 				Console.WriteLine (ex);
 				return false;


### PR DESCRIPTION
This does the same what we did in #596 for (Alert-)Dialogs, but this time for the most system dialogs (file, folder, color and font selectors).

GTK: full support
MAC: TBD, parenting not implemented at all
WPF: File dialogs missing, because we use the `Microsoft.Win32.FileDialog` wrapper (instead of the underlying `System.Windows.Forms.FileDialog` implementation) which does not allow native window owners.