### PR TITLE
Remove old warnings in Xwt and Xwt.Gtk

### DIFF
--- a/Xwt.Gtk/Xwt.Gtk.csproj
+++ b/Xwt.Gtk/Xwt.Gtk.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -22,6 +22,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ConsolePause>False</ConsolePause>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DebugSymbols>true</DebugSymbols>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -174,9 +176,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="icons\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <EmbeddedResource Include="icons\searchbox-clear-16.png">
       <LogicalName>searchbox-clear-16.png</LogicalName>

--- a/Xwt.Gtk/Xwt.GtkBackend/ListStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListStoreBackend.cs
@@ -50,9 +50,9 @@ namespace Xwt.GtkBackend
 				if (RowChanged != null)
 					RowChanged (this, new ListRowEventArgs (args.Path.Indices[0]));
 			};
-            store.RowsReordered += (o, args) => {
-                if (RowsReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(RowsReordered)} events from {nameof(ListStoreBackend)}, sorry.");
-            };
+			store.RowsReordered += (o, args) => {
+				if (RowsReordered != null) System.Diagnostics.Debug.WriteLine ($"No support for {nameof (RowsReordered)} events from {nameof (ListStoreBackend)}, sorry.");
+			};
 			return store;
 		}
 		

--- a/Xwt.Gtk/Xwt.GtkBackend/ListStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ListStoreBackend.cs
@@ -50,6 +50,9 @@ namespace Xwt.GtkBackend
 				if (RowChanged != null)
 					RowChanged (this, new ListRowEventArgs (args.Path.Indices[0]));
 			};
+            store.RowsReordered += (o, args) => {
+                if (RowsReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(RowsReordered)} events from {nameof(ListStoreBackend)}, sorry.");
+            };
 			return store;
 		}
 		

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
@@ -258,6 +258,11 @@ namespace Xwt.GtkBackend
 		public void DisableEvent (object eventId)
 		{
 		}
+		
+        protected virtual void OnNodesReordered(ListRowOrderEventArgs e)
+        {
+            if (NodesReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(NodesReordered)} events from {nameof(TreeStoreBackend)}, sorry.");
+        }		
 	}
 }
 

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
@@ -258,11 +258,11 @@ namespace Xwt.GtkBackend
 		public void DisableEvent (object eventId)
 		{
 		}
-		
-        protected virtual void OnNodesReordered(ListRowOrderEventArgs e)
-        {
-            if (NodesReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(NodesReordered)} events from {nameof(TreeStoreBackend)}, sorry.");
-        }		
+
+		protected virtual void OnNodesReordered(ListRowOrderEventArgs e)
+		{
+			if (NodesReordered != null) System.Diagnostics.Debug.WriteLine ($"No support for {nameof (NodesReordered)} events from {nameof (TreeStoreBackend)}, sorry.");
+		}
 	}
 }
 

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
     <DebugSymbols>true</DebugSymbols>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -370,7 +372,5 @@
   </ProjectExtensions>
   <ItemGroup />
   <ItemGroup />
-  <ItemGroup>
-    <Folder Include="Xwt.Accessibility\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/Xwt/Xwt/ListStore.cs
+++ b/Xwt/Xwt/ListStore.cs
@@ -392,6 +392,11 @@ namespace Xwt
 					RowDeleted (this, new ListRowEventArgs (n));
 			}
 		}
+		
+        protected virtual void OnRowsReordered(ListRowOrderEventArgs e)
+        {
+            if (RowsReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(RowsReordered)} events from {nameof(DefaultListStoreBackend)}, sorry.");
+        }	
 	}
 }
 

--- a/Xwt/Xwt/ListStore.cs
+++ b/Xwt/Xwt/ListStore.cs
@@ -392,11 +392,11 @@ namespace Xwt
 					RowDeleted (this, new ListRowEventArgs (n));
 			}
 		}
-		
-        protected virtual void OnRowsReordered(ListRowOrderEventArgs e)
-        {
-            if (RowsReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(RowsReordered)} events from {nameof(DefaultListStoreBackend)}, sorry.");
-        }	
+
+		protected virtual void OnRowsReordered(ListRowOrderEventArgs e)
+		{
+			if (RowsReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(RowsReordered)} events from {nameof(DefaultListStoreBackend)}, sorry.");
+		}	
 	}
 }
 

--- a/Xwt/Xwt/TreeNavigator.cs
+++ b/Xwt/Xwt/TreeNavigator.cs
@@ -33,12 +33,6 @@ using Xwt.Backends;
 
 namespace Xwt
 {
-	public struct NodePosition
-	{
-		internal TreePosition ParentPos;
-		internal int Index;
-	}
-	
 	public class TreeNavigator
 	{
 		ITreeStoreBackend backend;

--- a/Xwt/Xwt/TreeStore.cs
+++ b/Xwt/Xwt/TreeStore.cs
@@ -447,5 +447,10 @@ namespace Xwt
 		public void DisableEvent (object eventId)
 		{
 		}
+		
+        protected virtual void OnNodesReordered(ListRowOrderEventArgs e)
+        {
+            if (NodesReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(NodesReordered)} events from {nameof(DefaultTreeStoreBackend)}, sorry.");
+        }
 	}
 }

--- a/Xwt/Xwt/TreeStore.cs
+++ b/Xwt/Xwt/TreeStore.cs
@@ -447,10 +447,10 @@ namespace Xwt
 		public void DisableEvent (object eventId)
 		{
 		}
-		
-        protected virtual void OnNodesReordered(ListRowOrderEventArgs e)
-        {
-            if (NodesReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(NodesReordered)} events from {nameof(DefaultTreeStoreBackend)}, sorry.");
-        }
+
+		protected virtual void OnNodesReordered(ListRowOrderEventArgs e)
+		{
+			if (NodesReordered != null) System.Diagnostics.Debug.WriteLine($"No support for {nameof(NodesReordered)} events from {nameof(DefaultTreeStoreBackend)}, sorry.");
+		}
 	}
 }


### PR DESCRIPTION
There are a few unnecessary warnings in Xwt and Xwt.Gtk which are just annoying. We're using Xwt from source currently and all of our other projects have zero warnings and will fail if any warnings are issued. It just seems like it's time to get rid of these few warnings.