### PR TITLE
[Mac] NSView based tables

### DIFF
--- a/Xwt.XamMac/Xwt.Mac.CellViews/CanvasTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CanvasTableCell.cs
@@ -32,9 +32,13 @@ namespace Xwt.Mac
 {
 	class CanvasTableCell: NSView, ICellRenderer
 	{
+		NSTrackingArea trackingArea;
+
 		public CompositeCell CellContainer { get; set; }
 
 		public CellViewBackend Backend { get; set; }
+
+		public NSView CellView { get { return this; } }
 
 		public void CopyFrom (object other)
 		{
@@ -77,6 +81,89 @@ namespace Xwt.Mac
 				backend.Context.TranslateCTM ((nfloat)(-bounds.X), (nfloat)(-bounds.Y));
 				Frontend.Draw (backend, new Rectangle (bounds.X, bounds.Y, bounds.Width, bounds.Height));
 			});
+		}
+
+		public override void UpdateTrackingAreas ()
+		{
+			if (trackingArea != null) {
+				RemoveTrackingArea (trackingArea);
+				trackingArea.Dispose ();
+			}
+			var options = NSTrackingAreaOptions.MouseMoved | NSTrackingAreaOptions.ActiveInKeyWindow | NSTrackingAreaOptions.MouseEnteredAndExited;
+			trackingArea = new NSTrackingArea (Bounds, options, this, null);
+			AddTrackingArea (trackingArea);
+		}
+
+		public override void RightMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.RightMouseDown (theEvent); 
+		}
+
+		public override void RightMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.RightMouseUp (theEvent); 
+		}
+
+		public override void MouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.MouseDown (theEvent); 
+		}
+
+		public override void MouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.MouseUp (theEvent); 
+		}
+
+		public override void OtherMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.OtherMouseDown (theEvent);
+		}
+
+		public override void OtherMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.OtherMouseUp (theEvent);
+		}
+
+		public override void MouseEntered (NSEvent theEvent)
+		{
+			this.HandleMouseEntered (theEvent);
+				base.MouseEntered (theEvent);
+		}
+
+		public override void MouseExited (NSEvent theEvent)
+		{
+			this.HandleMouseExited (theEvent);
+				base.MouseExited (theEvent);
+		}
+
+		public override void MouseMoved (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseMoved (theEvent);
+		}
+
+		public override void MouseDragged (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseDragged (theEvent);
+		}
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			if (!this.HandleKeyDown (theEvent))
+				base.KeyDown (theEvent);
+		}
+
+		public override void KeyUp (NSEvent theEvent)
+		{
+			if (!this.HandleKeyUp (theEvent))
+				base.KeyUp (theEvent);
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CellViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CellViewBackend.cs
@@ -30,6 +30,8 @@ namespace Xwt.Mac
 {
 	public class CellViewBackend: ICellViewBackend, ICanvasCellViewBackend
 	{
+		WidgetEvent enabledEvents;
+
 		public CellViewBackend (NSTableView table, int column)
 		{
 			Table = table;
@@ -65,10 +67,19 @@ namespace Xwt.Mac
 		
 		public virtual void EnableEvent (object eventId)
 		{
+			if (eventId is WidgetEvent)
+				enabledEvents |= (WidgetEvent)eventId;
 		}
 		
 		public virtual void DisableEvent (object eventId)
 		{
+			if (eventId is WidgetEvent)
+				enabledEvents &= ~(WidgetEvent)eventId;
+		}
+
+		public bool GetIsEventEnabled (WidgetEvent eventId)
+		{
+			return enabledEvents.HasFlag (eventId);
 		}
 
 		public void QueueDraw ()

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CheckBoxTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CheckBoxTableCell.cs
@@ -32,6 +32,8 @@ namespace Xwt.Mac
 {
 	class CheckBoxTableCell: NSButton, ICellRenderer
 	{
+		NSTrackingArea trackingArea;
+
 		public CheckBoxTableCell ()
 		{
 			SetButtonType (NSButtonType.Switch);
@@ -91,6 +93,8 @@ namespace Xwt.Mac
 
 		public CompositeCell CellContainer { get; set; }
 
+		public NSView CellView { get { return this; } }
+
 		public void Fill ()
 		{
 			var cellView = Frontend;
@@ -115,6 +119,89 @@ namespace Xwt.Mac
 		{
 			var ob = (CheckBoxTableCell)other;
 			Backend = ob.Backend;
+		}
+
+		public override void UpdateTrackingAreas ()
+		{
+			if (trackingArea != null) {
+				RemoveTrackingArea (trackingArea);
+				trackingArea.Dispose ();
+			}
+			var options = NSTrackingAreaOptions.MouseMoved | NSTrackingAreaOptions.ActiveInKeyWindow | NSTrackingAreaOptions.MouseEnteredAndExited;
+			trackingArea = new NSTrackingArea (Bounds, options, this, null);
+			AddTrackingArea (trackingArea);
+		}
+
+		public override void RightMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.RightMouseDown (theEvent); 
+		}
+
+		public override void RightMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.RightMouseUp (theEvent); 
+		}
+
+		public override void MouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.MouseDown (theEvent); 
+		}
+
+		public override void MouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.MouseUp (theEvent); 
+		}
+
+		public override void OtherMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.OtherMouseDown (theEvent);
+		}
+
+		public override void OtherMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.OtherMouseUp (theEvent);
+		}
+
+		public override void MouseEntered (NSEvent theEvent)
+		{
+			this.HandleMouseEntered (theEvent);
+				base.MouseEntered (theEvent);
+		}
+
+		public override void MouseExited (NSEvent theEvent)
+		{
+			this.HandleMouseExited (theEvent);
+				base.MouseExited (theEvent);
+		}
+
+		public override void MouseMoved (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseMoved (theEvent);
+		}
+
+		public override void MouseDragged (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseDragged (theEvent);
+		}
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			if (!this.HandleKeyDown (theEvent))
+				base.KeyDown (theEvent);
+		}
+
+		public override void KeyUp (NSEvent theEvent)
+		{
+			if (!this.HandleKeyUp (theEvent))
+				base.KeyUp (theEvent);
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -181,7 +181,7 @@ namespace Xwt.Mac
 				c.Fill ();
 			}
 
-			foreach (var c in GetCells (new CGRect (new CGPoint (0, 0), Frame.Size))) {
+			foreach (var c in GetCells (new CGRect (CGPoint.Empty, Frame.Size))) {
 				c.Cell.Frame = c.Frame;
 				c.Cell.NeedsDisplay = true;
 			}

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -257,36 +257,37 @@ namespace Xwt.Mac
 			double requiredSize = 0;
 			double availableSize = cellFrame.Width;
 
-			var sizes = new Dictionary<ICellRenderer, double> ();
+			var visibleCells = VisibleCells.ToArray ();
+			var sizes = new double [visibleCells.Length];
 
 			// Get the natural size of each child
-			foreach (var bp in VisibleCells) {
-				var v = bp as NSView;
+			for (int i = 0; i < visibleCells.Length; i++) {
+				var v = visibleCells[i] as NSView;
 				var s = v.FittingSize;
 				if (s.IsEmpty && SizeToFit (v))
 					s = v.Frame.Size;
-				sizes [bp] = s.Width;
+				sizes [i] = s.Width;
 				requiredSize += s.Width;
-				if (bp.Backend.Frontend.Expands)
+				if (visibleCells [i].Backend.Frontend.Expands)
 					nexpands++;
 			}
 
 			double remaining = availableSize - requiredSize;
 			if (remaining > 0) {
 				var expandRemaining = new SizeSplitter (remaining, nexpands);
-				foreach (var bp in VisibleCells) {
-					if (bp.Backend.Frontend.Expands)
-						sizes [bp] += (nfloat)expandRemaining.NextSizePart ();
+				for (int i = 0; i < visibleCells.Length; i++) {
+					if (visibleCells [i].Backend.Frontend.Expands)
+						sizes [i] += (nfloat)expandRemaining.NextSizePart ();
 				}
 			}
 
 			double x = cellFrame.X;
-			foreach (var s in sizes) {
-				var cell = (NSView)s.Key;
+			for (int i = 0; i < visibleCells.Length; i++) {
+				var cell = (NSView)visibleCells [i];
 				var height = cell.FittingSize.Height;
 				var y = (cellFrame.Height - height) / 2;
-				yield return new CellPos () { Cell = cell, Frame = new CGRect (x, y, s.Value, height) };
-				x += s.Value;
+				yield return new CellPos { Cell = cell, Frame = new CGRect (x, y, sizes [i], height) };
+				x += sizes [i];
 			}
 		}
 

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -24,24 +24,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using AppKit;
 using CoreGraphics;
 using Foundation;
+using ObjCRuntime;
 using Xwt.Backends;
 
 namespace Xwt.Mac
 {
-	class CompositeCell: NSCell, ICopiableObject, ICellDataSource
+	class CompositeCell : NSView, ICopiableObject, ICellDataSource, INSCopying
 	{
 		ICellSource source;
 		NSObject val;
 		List<ICellRenderer> cells = new List<ICellRenderer> ();
-		Orientation direction;
-		NSCell trackingCell;
 		ITablePosition tablePosition;
 		ApplicationContext context;
 
@@ -51,16 +49,19 @@ namespace Xwt.Mac
 			}
 		}
 
-		public CompositeCell (ApplicationContext context, Orientation dir, ICellSource source)
+		public CompositeCell (ApplicationContext context, ICellSource source)
 		{
 			if (source == null)
-				throw new ArgumentNullException ("source");
-			direction = dir;
+				throw new ArgumentNullException (nameof (source));
 			this.context = context;
 			this.source = source;
 		}
-		
-		public CompositeCell (IntPtr p): base (p)
+
+		public CompositeCell (IntPtr p) : base (p)
+		{
+		}
+
+		CompositeCell ()
 		{
 		}
 
@@ -87,11 +88,18 @@ namespace Xwt.Mac
 			source.SetCurrentEventRow (tablePosition.Position);
 		}
 
-		public override NSObject Copy (NSZone zone)
+		public override NSObject Copy ()
 		{
-			var ob = (ICopiableObject) base.Copy (zone);
+			var ob = (ICopiableObject)base.Copy ();
 			ob.CopyFrom (this);
-			return (NSObject) ob;
+			return (NSObject)ob;
+		}
+
+		NSObject INSCopying.Copy (NSZone zone)
+		{
+			var ob = (ICopiableObject)new CompositeCell ();
+			ob.CopyFrom (this);
+			return (NSObject)ob;
 		}
 
 		void ICopiableObject.CopyFrom (object other)
@@ -99,33 +107,31 @@ namespace Xwt.Mac
 			var ob = (CompositeCell)other;
 			if (ob.source == null)
 				throw new ArgumentException ("Cannot copy from a CompositeCell with a null `source`");
+			Identifier = ob.Identifier;
 			context = ob.context;
 			source = ob.source;
-			val = ob.val;
-			tablePosition = ob.tablePosition;
-			direction = ob.direction;
-			trackingCell = ob.trackingCell;
 			cells = new List<ICellRenderer> ();
 			foreach (var c in ob.cells) {
-				var copy = (ICellRenderer) Activator.CreateInstance (c.GetType ());
+				var copy = (ICellRenderer)Activator.CreateInstance (c.GetType ());
 				copy.CopyFrom (c);
 				AddCell (copy);
 			}
 			if (tablePosition != null)
 				Fill ();
 		}
-		
-		public override NSObject ObjectValue {
+
+		public virtual NSObject ObjectValue {
+			[Export ("objectValue")]
 			get {
 				return val;
 			}
+			[Export ("setObjectValue:")]
 			set {
 				val = value;
 				if (val is ITablePosition) {
-					tablePosition = (ITablePosition) val;
+					tablePosition = (ITablePosition)val;
 					Fill ();
-				}
-				else if (val is NSNumber) {
+				} else if (val is NSNumber) {
 					tablePosition = new TableRow () {
 						Row = ((NSNumber)val).Int32Value
 					};
@@ -135,202 +141,158 @@ namespace Xwt.Mac
 			}
 		}
 
-		public override bool IsOpaque {
-			get {
-				var b = base.IsOpaque;
-				return true;
-			}
+		internal ITablePosition TablePosition {
+			get { return tablePosition; }
 		}
-		
+
 		public void AddCell (ICellRenderer cell)
 		{
 			cell.CellContainer = this;
 			cells.Add (cell);
+			AddSubview ((NSView)cell);
 		}
-		
+
+		public void ClearCells ()
+		{
+			foreach (NSView cell in cells) {
+				cell.RemoveFromSuperview ();
+			}
+			cells.Clear ();
+		}
+
+		public override CGRect Frame {
+			get { return base.Frame; }
+			set {
+				var oldSize = base.Frame.Size;
+				base.Frame = value;
+				if (oldSize != value.Size && tablePosition != null) {
+					foreach (var c in GetCells (new CGRect (CGPoint.Empty, value.Size))) {
+						c.Cell.Frame = c.Frame;
+						c.Cell.NeedsDisplay = true;
+					}
+				}
+			}
+		}
+
 		public void Fill ()
 		{
 			foreach (var c in cells) {
-				c.Backend.CurrentCell = (NSCell) c;
-				c.Backend.CurrentPosition = tablePosition;
-				c.Backend.Frontend.Load (this);
+				c.Backend.Load (c);
 				c.Fill ();
 			}
 
-			var s = CellSize;
+			foreach (var c in GetCells (new CGRect (new CGPoint (0, 0), Frame.Size))) {
+				c.Cell.Frame = c.Frame;
+				c.Cell.NeedsDisplay = true;
+			}
 		}
 
 		IEnumerable<ICellRenderer> VisibleCells {
 			get { return cells.Where (c => c.Backend.Frontend.Visible); }
 		}
 
+		public NSView GetCellViewForBackend (ICellViewBackend backend)
+		{
+			return cells.FirstOrDefault (c => c.Backend == backend) as NSView;
+		}
+
 		CGSize CalcSize ()
 		{
 			nfloat w = 0;
 			nfloat h = 0;
-			foreach (NSCell c in VisibleCells) {
-				var s = c.CellSize;
-				if (direction == Orientation.Horizontal) {
-					w += s.Width;
-					if (s.Height > h)
-						h = s.Height;
-				} else {
-					h += s.Height;
-					if (s.Width > w)
-						w = s.Width;
-				}
+			foreach (NSView c in VisibleCells) {
+				var s = c.FittingSize;
+				if (s.IsEmpty && SizeToFit (c))
+					s = c.Frame.Size;
+				w += s.Width;
+				if (s.Height > h)
+					h = s.Height;
 			}
 			return new CGSize (w, h);
 		}
 
-		public override CGSize CellSizeForBounds (CGRect bounds)
-		{
-			return CalcSize ();
-		}
-
-		public override NSBackgroundStyle BackgroundStyle {
+		public override CGSize FittingSize {
 			get {
-				return base.BackgroundStyle;
-			}
-			set {
-				base.BackgroundStyle = value;
-				foreach (NSCell c in cells)
-					c.BackgroundStyle = value;
+				return CalcSize ();
 			}
 		}
-		
-		public override NSCellStateValue State {
+
+		static readonly Selector selSetBackgroundStyle = new Selector ("setBackgroundStyle:");
+
+		NSBackgroundStyle backgroundStyle;
+
+		public virtual NSBackgroundStyle BackgroundStyle {
+			[Export ("backgroundStyle")]
 			get {
-				return base.State;
+				return backgroundStyle;
 			}
+			[Export ("setBackgroundStyle:")]
 			set {
-				base.State = value;
-				foreach (NSCell c in cells)
-					c.State = value;
+				backgroundStyle = value;
+				foreach (NSView cell in cells)
+					if (cell.RespondsToSelector (selSetBackgroundStyle)) {
+						if (IntPtr.Size == 8)
+							Messaging.void_objc_msgSend_Int64 (cell.Handle, selSetBackgroundStyle.Handle, (long)value);
+						else
+							Messaging.void_objc_msgSend_int (cell.Handle, selSetBackgroundStyle.Handle, (int)value);
+					} else
+						cell.NeedsDisplay = true;
 			}
-		}
-		
-		public override bool Highlighted {
-			get {
-				return base.Highlighted;
-			}
-			set {
-				base.Highlighted = value;
-				foreach (NSCell c in cells)
-					c.Highlighted = value;
-			}
-		}
-		
-		public override void DrawInteriorWithFrame (CGRect cellFrame, NSView inView)
-		{
-			// FIXME: although ObjectValue seems to be set and Fill called correctly,
-			//        the table flickers without an additional Fill call, especially
-			//        on expansion/collapsing with partially hidden cells (row wise).
-			//        Cocoa seems to be resetting some NSCell bits, which may be
-			//        related to the deprecated NSCell mode.
-			if (tablePosition != null)
-				Fill ();
-			CGContext ctx = NSGraphicsContext.CurrentContext.GraphicsPort;
-			ctx.SaveState ();
-			ctx.AddRect (cellFrame);
-			ctx.Clip ();
-			foreach (CellPos cp in GetCells(cellFrame))
-				cp.Cell.DrawInteriorWithFrame (cp.Frame, inView);
-			ctx.RestoreState ();
-		}
-		
-		public override void Highlight (bool flag, CGRect withFrame, NSView inView)
-		{
-			foreach (CellPos cp in GetCells(withFrame)) {
-				cp.Cell.Highlight (flag, cp.Frame, inView);
-			}
-		}
-		
-		public override NSCellHit HitTest (NSEvent forEvent, CGRect inRect, NSView ofView)
-		{
-			foreach (CellPos cp in GetCells(inRect)) {
-				var h = cp.Cell.HitTest (forEvent, cp.Frame, ofView);
-				if (h != NSCellHit.None)
-					return h;
-			}
-			return NSCellHit.None;
 		}
 
-		public override bool TrackMouse (NSEvent theEvent, CGRect cellFrame, NSView controlView, bool untilMouseUp)
-		{
-			var c = GetHitCell (theEvent, cellFrame, controlView);
-			if (c != null)
-				return c.Cell.TrackMouse (theEvent, c.Frame, controlView, untilMouseUp);
-			else
-				return base.TrackMouse (theEvent, cellFrame, controlView, untilMouseUp);
-		}
+		static readonly Selector sizeToFitSel = new Selector ("sizeToFit");
 
-		public CGRect GetCellRect (CGRect cellFrame, NSCell cell)
+		protected virtual bool SizeToFit (NSView view)
 		{
-			foreach (var c in GetCells (cellFrame)) {
-				if (c.Cell == cell)
-					return c.Frame;
+			if (view.RespondsToSelector (sizeToFitSel)) {
+				Messaging.void_objc_msgSend (view.Handle, sizeToFitSel.Handle);
+				return true;
 			}
-			return CGRect.Empty;
-		}
-
-		CellPos GetHitCell (NSEvent theEvent, CGRect cellFrame, NSView controlView)
-		{
-			foreach (CellPos cp in GetCells(cellFrame)) {
-				var h = cp.Cell.HitTest (theEvent, cp.Frame, controlView);
-				if (h != NSCellHit.None)
-					return cp;
-			}
-			return null;
+			return false;
 		}
 		
 		IEnumerable<CellPos> GetCells (CGRect cellFrame)
 		{
-			if (direction == Orientation.Horizontal) {
+			int nexpands = 0;
+			double requiredSize = 0;
+			double availableSize = cellFrame.Width;
 
-				int nexpands = 0;
-				double requiredSize = 0;
-				double availableSize = cellFrame.Width;
+			var sizes = new Dictionary<ICellRenderer, double> ();
 
-				var sizes = new Dictionary<ICellRenderer, double> ();
+			// Get the natural size of each child
+			foreach (var bp in VisibleCells) {
+				var v = bp as NSView;
+				var s = v.FittingSize;
+				if (s.IsEmpty && SizeToFit (v))
+					s = v.Frame.Size;
+				sizes [bp] = s.Width;
+				requiredSize += s.Width;
+				if (bp.Backend.Frontend.Expands)
+					nexpands++;
+			}
 
-				// Get the natural size of each child
+			double remaining = availableSize - requiredSize;
+			if (remaining > 0) {
+				var expandRemaining = new SizeSplitter (remaining, nexpands);
 				foreach (var bp in VisibleCells) {
-					var s = ((NSCell)bp).CellSize;
-					sizes [bp] = s.Width;
-					requiredSize += s.Width;
 					if (bp.Backend.Frontend.Expands)
-						nexpands++;
-				}
-
-				double remaining = availableSize - requiredSize;
-				if (remaining > 0) {
-					var expandRemaining = new SizeSplitter (remaining, nexpands);
-					foreach (var bp in VisibleCells) {
-						if (bp.Backend.Frontend.Expands)
-							sizes [bp] += (nfloat)expandRemaining.NextSizePart ();
-					}
-				}
-
-				double x = cellFrame.X;
-				foreach (var s in sizes) {
-					yield return new CellPos () { Cell = (NSCell)s.Key, Frame = new CGRect (x, cellFrame.Y, s.Value, cellFrame.Height) };
-					x += s.Value;
-				}
-			} else {
-				nfloat y = cellFrame.Y;
-				foreach (NSCell c in VisibleCells) {
-					var s = c.CellSize;
-					var f = new CGRect (cellFrame.X, y, s.Width, cellFrame.Height);
-					y += s.Height;
-					yield return new CellPos () { Cell = c, Frame = f };
+						sizes [bp] += (nfloat)expandRemaining.NextSizePart ();
 				}
 			}
+
+			double x = cellFrame.X;
+			foreach (var s in sizes) {
+				var cell = (NSView)s.Key;
+				var height = cell.FittingSize.Height;
+				var y = (cellFrame.Height - height) / 2;
+				yield return new CellPos () { Cell = cell, Frame = new CGRect (x, y, s.Value, height) };
+				x += s.Value;
+			}
 		}
-		
+
 		class CellPos
 		{
-			public NSCell Cell;
+			public NSView Cell;
 			public CGRect Frame;
 		}
 
@@ -354,10 +316,29 @@ namespace Xwt.Mac
 				{
 					rem--;
 					return part + 1;
-				}
-				else
+				} else
 					return part;
 			}
+		}
+
+		bool isDisposed;
+
+		public bool IsDisposed {
+			get {
+				try {
+					// Cocoa may dispose the native view in NSView based table mode
+					// in this case Handle and SuperHandle will become Zero.
+					return isDisposed || Handle == IntPtr.Zero || SuperHandle == IntPtr.Zero;
+				} catch {
+					return true;
+				}
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			isDisposed = true;
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/ICellRenderer.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/ICellRenderer.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using AppKit;
 
 namespace Xwt.Mac
 {
@@ -31,6 +32,7 @@ namespace Xwt.Mac
 	{
 		CellViewBackend Backend { get; set; }
 		CompositeCell CellContainer { get; set; }
+		NSView CellView { get; }
 		void Fill ();
 	}
 	

--- a/Xwt.XamMac/Xwt.Mac.CellViews/ICellSource.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/ICellSource.cs
@@ -25,6 +25,8 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
+using AppKit;
 
 namespace Xwt.Mac
 {
@@ -33,6 +35,6 @@ namespace Xwt.Mac
 		object GetValue (object pos, int nField);
 		void SetValue (object pos, int nField, object value);
 		void SetCurrentEventRow (object pos);
-		nfloat RowHeight { get; set; }
+		List<NSTableColumn> Columns { get; }
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/ImageTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/ImageTableCell.cs
@@ -32,6 +32,8 @@ namespace Xwt.Mac
 {
 	class ImageTableCell : NSImageView, ICellRenderer
 	{
+		NSTrackingArea trackingArea;
+
 		IImageCellViewFrontend Frontend {
 			get { return (IImageCellViewFrontend)Backend.Frontend; }
 		}
@@ -39,6 +41,8 @@ namespace Xwt.Mac
 		public CellViewBackend Backend { get; set; }
 
 		public CompositeCell CellContainer { get; set; }
+
+		public NSView CellView { get { return this; } }
 
 		public void Fill ()
 		{
@@ -69,6 +73,89 @@ namespace Xwt.Mac
 		{
 			var ob = (ImageTableCell)other;
 			Backend = ob.Backend;
+		}
+
+		public override void UpdateTrackingAreas ()
+		{
+			if (trackingArea != null) {
+				RemoveTrackingArea (trackingArea);
+				trackingArea.Dispose ();
+			}
+			var options = NSTrackingAreaOptions.MouseMoved | NSTrackingAreaOptions.ActiveInKeyWindow | NSTrackingAreaOptions.MouseEnteredAndExited;
+			trackingArea = new NSTrackingArea (Bounds, options, this, null);
+			AddTrackingArea (trackingArea);
+		}
+
+		public override void RightMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.RightMouseDown (theEvent); 
+		}
+
+		public override void RightMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.RightMouseUp (theEvent); 
+		}
+
+		public override void MouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.MouseDown (theEvent); 
+		}
+
+		public override void MouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.MouseUp (theEvent); 
+		}
+
+		public override void OtherMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.OtherMouseDown (theEvent);
+		}
+
+		public override void OtherMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.OtherMouseUp (theEvent);
+		}
+
+		public override void MouseEntered (NSEvent theEvent)
+		{
+			this.HandleMouseEntered (theEvent);
+				base.MouseEntered (theEvent);
+		}
+
+		public override void MouseExited (NSEvent theEvent)
+		{
+			this.HandleMouseExited (theEvent);
+				base.MouseExited (theEvent);
+		}
+
+		public override void MouseMoved (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseMoved (theEvent);
+		}
+
+		public override void MouseDragged (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseDragged (theEvent);
+		}
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			if (!this.HandleKeyDown (theEvent))
+				base.KeyDown (theEvent);
+		}
+
+		public override void KeyUp (NSEvent theEvent)
+		{
+			if (!this.HandleKeyUp (theEvent))
+				base.KeyUp (theEvent);
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/ImageTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/ImageTableCell.cs
@@ -1,4 +1,4 @@
-// 
+﻿// 
 // ImageTableCell.cs
 //  
 // Author:
@@ -26,25 +26,14 @@
 
 using System;
 using AppKit;
-using CoreGraphics;
 using Xwt.Backends;
 
 namespace Xwt.Mac
 {
-	class ImageTableCell: NSImageCell, ICellRenderer
+	class ImageTableCell : NSImageView, ICellRenderer
 	{
-		bool visible = true;
-
-		public ImageTableCell ()
-		{
-		}
-		
-		public ImageTableCell (IntPtr p): base (p)
-		{
-		}
-		
 		IImageCellViewFrontend Frontend {
-			get { return (IImageCellViewFrontend) Backend.Frontend; }
+			get { return (IImageCellViewFrontend)Backend.Frontend; }
 		}
 
 		public CellViewBackend Backend { get; set; }
@@ -53,33 +42,29 @@ namespace Xwt.Mac
 
 		public void Fill ()
 		{
-			ObjectValue = Frontend.Image.ToImageDescription (CellContainer.Context).ToNSImage ();
-			visible = Frontend.Visible;
+			if (Frontend.Image != null) {
+				Image = Frontend.Image.ToImageDescription (Backend.Context).ToNSImage ();
+				SetFrameSize (Image.Size);
+			} else
+				SetFrameSize (CoreGraphics.CGSize.Empty);
+			Hidden = !Frontend.Visible;
 		}
-		
-		public override CGSize CellSize {
+
+		public override CoreGraphics.CGSize FittingSize {
 			get {
-				NSImage img = ObjectValue as NSImage;
-				if (img != null)
-					return img.Size;
-				else
-					return base.CellSize;
+				if (Image == null)
+					return base.FittingSize;
+				return Image.Size;
 			}
 		}
 
-		public override CGSize CellSizeForBounds (CGRect bounds)
+		public override void SizeToFit()
 		{
-			if (visible)
-				return base.CellSizeForBounds (bounds);
-			return CGSize.Empty;
+			base.SizeToFit();
+			if (Frame.Size.IsEmpty && Image != null)
+				SetFrameSize (Image.Size);
 		}
 
-		public override void DrawInteriorWithFrame (CGRect cellFrame, NSView inView)
-		{
-			if (visible)
-				base.DrawInteriorWithFrame (cellFrame, inView);
-		}
-		
 		public void CopyFrom (object other)
 		{
 			var ob = (ImageTableCell)other;
@@ -87,4 +72,3 @@ namespace Xwt.Mac
 		}
 	}
 }
-

--- a/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
@@ -31,6 +31,8 @@ namespace Xwt.Mac
 {
 	class RadioButtonTableCell: NSButton, ICellRenderer
 	{
+		NSTrackingArea trackingArea;
+
 		public RadioButtonTableCell ()
 		{
 			SetButtonType (NSButtonType.Radio);
@@ -67,6 +69,8 @@ namespace Xwt.Mac
 
 		public CompositeCell CellContainer { get; set; }
 
+		public NSView CellView { get { return this; } }
+
 		public void Fill ()
 		{
 			var cellView = Frontend;
@@ -79,6 +83,89 @@ namespace Xwt.Mac
 		{
 			var ob = (RadioButtonTableCell)other;
 			Backend = ob.Backend;
+		}
+
+		public override void UpdateTrackingAreas ()
+		{
+			if (trackingArea != null) {
+				RemoveTrackingArea (trackingArea);
+				trackingArea.Dispose ();
+			}
+			var options = NSTrackingAreaOptions.MouseMoved | NSTrackingAreaOptions.ActiveInKeyWindow | NSTrackingAreaOptions.MouseEnteredAndExited;
+			trackingArea = new NSTrackingArea (Bounds, options, this, null);
+			AddTrackingArea (trackingArea);
+		}
+
+		public override void RightMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.RightMouseDown (theEvent); 
+		}
+
+		public override void RightMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.RightMouseUp (theEvent); 
+		}
+
+		public override void MouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.MouseDown (theEvent); 
+		}
+
+		public override void MouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.MouseUp (theEvent); 
+		}
+
+		public override void OtherMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.OtherMouseDown (theEvent);
+		}
+
+		public override void OtherMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.OtherMouseUp (theEvent);
+		}
+
+		public override void MouseEntered (NSEvent theEvent)
+		{
+			this.HandleMouseEntered (theEvent);
+				base.MouseEntered (theEvent);
+		}
+
+		public override void MouseExited (NSEvent theEvent)
+		{
+			this.HandleMouseExited (theEvent);
+				base.MouseExited (theEvent);
+		}
+
+		public override void MouseMoved (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseMoved (theEvent);
+		}
+
+		public override void MouseDragged (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseDragged (theEvent);
+		}
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			if (!this.HandleKeyDown (theEvent))
+				base.KeyDown (theEvent);
+		}
+
+		public override void KeyUp (NSEvent theEvent)
+		{
+			if (!this.HandleKeyUp (theEvent))
+				base.KeyUp (theEvent);
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/TextTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/TextTableCell.cs
@@ -32,6 +32,7 @@ namespace Xwt.Mac
 {
 	class TextTableCell : NSTextField, ICellRenderer
 	{
+		NSTrackingArea trackingArea;
 		public TextTableCell ()
 		{
 			Editable = false;
@@ -46,6 +47,8 @@ namespace Xwt.Mac
 		public CellViewBackend Backend { get; set; }
 
 		public CompositeCell CellContainer { get; set; }
+
+		public NSView CellView { get { return this; } }
 
 		public void Fill ()
 		{
@@ -71,6 +74,89 @@ namespace Xwt.Mac
 		{
 			var ob = (TextTableCell)other;
 			Backend = ob.Backend;
+		}
+
+		public override void UpdateTrackingAreas ()
+		{
+			if (trackingArea != null) {
+				RemoveTrackingArea (trackingArea);
+				trackingArea.Dispose ();
+			}
+			var options = NSTrackingAreaOptions.MouseMoved | NSTrackingAreaOptions.ActiveInKeyWindow | NSTrackingAreaOptions.MouseEnteredAndExited;
+			trackingArea = new NSTrackingArea (Bounds, options, this, null);
+			AddTrackingArea (trackingArea);
+		}
+
+		public override void RightMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.RightMouseDown (theEvent); 
+		}
+
+		public override void RightMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.RightMouseUp (theEvent); 
+		}
+
+		public override void MouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.MouseDown (theEvent); 
+		}
+
+		public override void MouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.MouseUp (theEvent); 
+		}
+
+		public override void OtherMouseDown (NSEvent theEvent)
+		{
+			if (!this.HandleMouseDown (theEvent))
+				base.OtherMouseDown (theEvent);
+		}
+
+		public override void OtherMouseUp (NSEvent theEvent)
+		{
+			if (!this.HandleMouseUp (theEvent))
+				base.OtherMouseUp (theEvent);
+		}
+
+		public override void MouseEntered (NSEvent theEvent)
+		{
+			this.HandleMouseEntered (theEvent);
+				base.MouseEntered (theEvent);
+		}
+
+		public override void MouseExited (NSEvent theEvent)
+		{
+			this.HandleMouseExited (theEvent);
+				base.MouseExited (theEvent);
+		}
+
+		public override void MouseMoved (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseMoved (theEvent);
+		}
+
+		public override void MouseDragged (NSEvent theEvent)
+		{
+			if (!this.HandleMouseMoved (theEvent))
+				base.MouseDragged (theEvent);
+		}
+
+		public override void KeyDown (NSEvent theEvent)
+		{
+			if (!this.HandleKeyDown (theEvent))
+				base.KeyDown (theEvent);
+		}
+
+		public override void KeyUp (NSEvent theEvent)
+		{
+			if (!this.HandleKeyUp (theEvent))
+				base.KeyUp (theEvent);
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/TextTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/TextTableCell.cs
@@ -24,25 +24,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-
-using System;
 using AppKit;
+using Foundation;
 using Xwt.Backends;
 
 namespace Xwt.Mac
 {
-	class TextTableCell: NSCell, ICellRenderer
+	class TextTableCell : NSTextField, ICellRenderer
 	{
-		bool visible = true;
-
-
-		public TextTableCell (): base ("")
+		public TextTableCell ()
 		{
-			Wraps = false;
-		}
-		
-		public TextTableCell (IntPtr p): base (p)
-		{
+			Editable = false;
+			Bezeled = false;
+			DrawsBackground = false;
 		}
 		
 		ITextCellViewFrontend Frontend {
@@ -59,20 +53,18 @@ namespace Xwt.Mac
 				AttributedStringValue = FormattedText.FromMarkup (Frontend.Markup).ToAttributedString ();
 			else
 				StringValue = Frontend.Text ?? "";
-			visible = Frontend.Visible;
+			Hidden = !Frontend.Visible;
 		}
-
-		public override CoreGraphics.CGSize CellSizeForBounds (CoreGraphics.CGRect bounds)
-		{
-			if (visible)
-				return base.CellSizeForBounds (bounds);
-			return CoreGraphics.CGSize.Empty;
-		}
-
-		public override void DrawInteriorWithFrame (CoreGraphics.CGRect cellFrame, NSView inView)
-		{
-			if (visible)
-				base.DrawInteriorWithFrame (cellFrame, inView);
+		
+		public virtual NSBackgroundStyle BackgroundStyle {
+			[Export ("backgroundStyle")]
+			get {
+				return Cell.BackgroundStyle;
+			}
+			[Export ("setBackgroundStyle:")]
+			set {
+				Cell.BackgroundStyle = value;
+			}
 		}
 
 		public void CopyFrom (object other)

--- a/Xwt.XamMac/Xwt.Mac.CellViews/TextTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/TextTableCell.cs
@@ -43,6 +43,15 @@ namespace Xwt.Mac
 		ITextCellViewFrontend Frontend {
 			get { return (ITextCellViewFrontend) Backend.Frontend; }
 		}
+
+		public override bool AllowsVibrancy {
+			get {
+				// we don't support vibrancy
+				if (EffectiveAppearance.AllowsVibrancy)
+					return false;
+				return base.AllowsVibrancy;
+			}
+		}
 		
 		public CellViewBackend Backend { get; set; }
 

--- a/Xwt.XamMac/Xwt.Mac/ListBoxBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListBoxBackend.cs
@@ -32,7 +32,7 @@ namespace Xwt.Mac
 {
 	public class ListBoxBackend: ListViewBackend, IListBoxBackend
 	{
-		ListViewColumn column = new ListViewColumn ();
+		readonly ListViewColumn column = new ListViewColumn { Expands = true };
 		NSTableColumn columnHandle;
 
 		public ListBoxBackend ()
@@ -63,38 +63,6 @@ namespace Xwt.Mac
 			foreach (var v in views)
 				column.Views.Add (v);
 			UpdateColumn (column, columnHandle, ListViewColumnChange.Cells);
-		}
-
-		public override void SetSource (IListDataSource source, IBackend sourceBackend)
-		{
-			base.SetSource (source, sourceBackend);
-
-			source.RowInserted += HandleColumnSizeChanged;
-			source.RowDeleted += HandleColumnSizeChanged;
-			source.RowChanged += HandleColumnSizeChanged;
-			ResetColumnSize (source);
-		}
-
-		void HandleColumnSizeChanged (object sender, ListRowEventArgs e)
-		{
-			var source = (IListDataSource)sender;
-			ResetColumnSize (source);
-		}
-
-		void ResetColumnSize (IListDataSource source)
-		{
-			// Calculate size of column
-			// This is how Apple implements it; unfortunately, they don't expose this functionality in the API.
-			// https://developer.apple.com/library/mac/documentation/Cocoa/Reference/NSTableViewDelegate_Protocol/index.html#//apple_ref/occ/intfm/NSTableViewDelegate/tableView:sizeToFitWidthOfColumn:
-			nfloat w = 0;
-			for (var row = 0; row < source.RowCount; row++) {
-				using (var cell = Table.GetCell (0, row)) {
-					var size = cell.CellSize;
-					w = (nfloat)Math.Max (w, size.Width);
-				}
-			}
-			columnHandle.MinWidth = (nfloat)Math.Ceiling (w);
-			columnHandle.Width = (nfloat)Math.Ceiling (w);
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
@@ -53,6 +53,11 @@ namespace Xwt.Mac
 				return height;
 			}
 
+			public override NSTableRowView CoreGetRowView (NSTableView tableView, nint row)
+			{
+				return tableView.GetRowView (row, false) ?? new TableRowView ();
+			}
+
 			public override NSView GetViewForItem (NSTableView tableView, NSTableColumn tableColumn, nint row)
 			{
 				var col = tableColumn as TableColumn;

--- a/Xwt.XamMac/Xwt.Mac/Messaging.cs
+++ b/Xwt.XamMac/Xwt.Mac/Messaging.cs
@@ -57,5 +57,23 @@ namespace Xwt.Mac
 
 		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
 		public static extern void void_objc_msgSend_bool (IntPtr handle, IntPtr sel, bool a1);
+
+		//[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		//public static extern long Int64_objc_msgSend (IntPtr receiver, IntPtr selector);
+
+		//[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		//public static extern int int_objc_msgSend (IntPtr receiver, IntPtr selector);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public static extern void void_objc_msgSend_int (IntPtr receiver, IntPtr selector, int arg1);
+
+		[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public static extern void void_objc_msgSend_Int64 (IntPtr receiver, IntPtr selector, long arg1);
+
+		//[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
+		//public static extern void void_objc_msgSendSuper_int (IntPtr receiver, IntPtr selector, int arg1);
+
+		//[DllImport (LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
+		//public static extern void void_objc_msgSendSuper_Int64 (IntPtr receiver, IntPtr selector, long arg1);
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
@@ -32,6 +32,7 @@ using AppKit;
 using CoreGraphics;
 using Foundation;
 using Xwt.Backends;
+using ObjCRuntime;
 
 namespace Xwt.Mac
 {
@@ -40,20 +41,6 @@ namespace Xwt.Mac
 		IWidgetEventSink eventSink;
 		protected ApplicationContext context;
 		NSTrackingArea trackingArea;	// Captures Mouse Entered, Exited, and Moved events
-
-		class ListDelegate: NSTableViewDelegate
-		{
-			public override nfloat GetRowHeight (NSTableView tableView, nint row)
-			{
-				var height = tableView.RowHeight;
-				for (int i = 0; i < tableView.ColumnCount; i++) {
-					var cell = tableView.GetCell (i, row);
-					if (cell != null)
-						height = (nfloat) Math.Max (height, cell.CellSize.Height);
-				}
-				return height;
-			}
-		}
 
 		public override NSObject WeakDataSource {
 			get { return base.WeakDataSource; }
@@ -82,17 +69,13 @@ namespace Xwt.Mac
 		{
 			var column = IndexOfColumn (tableColumn);
 
-			var s = tableColumn.HeaderCell.CellSize;
+			var contentWidth = tableColumn.HeaderCell.CellSize.Width;
 			if (!tableColumn.ResizingMask.HasFlag (NSTableColumnResizing.UserResizingMask)) {
-				for (int i = 0; i < base.RowCount; i++)
-				{
-					var cell = base.GetCell (column, i);
-					s.Width = (nfloat)Math.Max (s.Width, cell.CellSize.Width);
-				}
+				contentWidth = Delegate.GetSizeToFitColumnWidth (this, column);
 				if (!tableColumn.ResizingMask.HasFlag (NSTableColumnResizing.Autoresizing))
-					tableColumn.Width = s.Width;
+					tableColumn.Width = contentWidth;
 			}
-			tableColumn.MinWidth = s.Width;
+			tableColumn.MinWidth = contentWidth;
 		}
 
 		nint IndexOfColumn (NSTableColumn tableColumn)
@@ -133,7 +116,6 @@ namespace Xwt.Mac
 		public NSTableViewBackend(IWidgetEventSink eventSink, ApplicationContext context) {
 			this.context = context;
 			this.eventSink = eventSink;
-			this.Delegate = new ListDelegate ();
 			AllowsColumnReordering = false;
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
@@ -106,7 +106,7 @@ namespace Xwt.Mac
 		{
 			if (!columnResizeQueued) {
 				columnResizeQueued = true;
-				Application.MainLoop.QueueExitAction (delegate {
+				(context.Toolkit.GetSafeBackend (context.Toolkit) as ToolkitEngineBackend).InvokeBeforeMainLoop (delegate {
 					columnResizeQueued = false;
 					AutosizeColumns ();
 				});

--- a/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
@@ -151,7 +151,7 @@ namespace Xwt.Mac
 		{
 			if (!columnResizeQueued) {
 				columnResizeQueued = true;
-				Application.MainLoop.QueueExitAction (delegate {
+				(context.Toolkit.GetSafeBackend (context.Toolkit) as ToolkitEngineBackend).InvokeBeforeMainLoop (delegate {
 					columnResizeQueued = false;
 					AutosizeColumns ();
 				});

--- a/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
@@ -78,22 +78,13 @@ namespace Xwt.Mac
 		{
 			var column = IndexOfColumn (tableColumn);
 
-			var s = tableColumn.HeaderCell.CellSize;
+			var contentWidth = tableColumn.HeaderCell.CellSize.Width;
 			if (!tableColumn.ResizingMask.HasFlag (NSTableColumnResizing.UserResizingMask)) {
-				for (int i = 0; i < base.RowCount; i++) {
-					var cell = GetCell (column, i);
-					if (column == 0)
-					{ // first column contains expanders
-						var f = GetCellFrame (column, i);
-						s.Width = (nfloat)Math.Max (s.Width, f.X + cell.CellSize.Width);
-					}
-					else
-						s.Width = (nfloat)Math.Max (s.Width, cell.CellSize.Width);
-				}
+				contentWidth = Delegate.GetSizeToFitColumnWidth (this, column);
 				if (!tableColumn.ResizingMask.HasFlag (NSTableColumnResizing.Autoresizing))
-					tableColumn.Width = s.Width;
+					tableColumn.Width = contentWidth;
 			}
-			tableColumn.MinWidth = s.Width;
+			tableColumn.MinWidth = contentWidth;
 		}
 
 		nint IndexOfColumn (NSTableColumn tableColumn)

--- a/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
@@ -218,7 +218,7 @@ namespace Xwt.Mac
 			var container = Table.GetView (cellBackend.Column, row, false) as CompositeCell;
 			if (container != null) {
 				var cellView = container.GetCellViewForBackend (cellBackend);
-				rect = cellView.ConvertRectToView (new CoreGraphics.CGRect (new CoreGraphics.CGPoint (0, 0), cellView.Frame.Size), Table).ToXwtRect ();
+				rect = cellView.ConvertRectToView (new CGRect (CGPoint.Empty, cellView.Frame.Size), Table).ToXwtRect ();
 				rect.Y -= scroll.DocumentVisibleRect.Y;
 				rect.X -= scroll.DocumentVisibleRect.X;
 			}

--- a/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
@@ -40,11 +40,15 @@ namespace Xwt.Mac
 		ScrollView scroll;
 		NSObject selChangeObserver;
 		NormalClipView clipView;
-		
-		public TableViewBackend ()
-		{
+
+		List<NSTableColumn> ICellSource.Columns {
+			get { return cols; }
 		}
-		
+
+		protected List<NSTableColumn> Columns {
+			get { return cols; }
+		}
+
 		public override void Initialize ()
 		{
 			Table = CreateView ();
@@ -181,28 +185,10 @@ namespace Xwt.Mac
 
 		public virtual NSTableColumn AddColumn (ListViewColumn col)
 		{
-			var tcol = new NSTableColumn ();
-			tcol.Editable = true;
+			var tcol = new TableColumn (ApplicationContext, this, Table);
 			cols.Add (tcol);
-			var c = CellUtil.CreateCell (ApplicationContext, Table, this, col.Views, cols.Count - 1);
-			tcol.DataCell = c;
+			tcol.UpdateColumn (col);
 			Table.AddColumn (tcol);
-			var hc = new NSTableHeaderCell ();
-			hc.Title = col.Title ?? "";
-			tcol.HeaderCell = hc;
-			tcol.HeaderCell.Alignment = col.Alignment.ToNSTextAlignment();
-
-
-			if (col.CanResize)
-				tcol.ResizingMask |= NSTableColumnResizing.UserResizingMask;
-			else
-				tcol.ResizingMask &= ~NSTableColumnResizing.UserResizingMask;
-			if (col.Expands)
-				tcol.ResizingMask |= NSTableColumnResizing.Autoresizing;
-			else
-				tcol.ResizingMask &= ~NSTableColumnResizing.Autoresizing;
-			tcol.SizeToFit();
-			Widget.InvalidateIntrinsicContentSize ();
 			return tcol;
 		}
 		object IColumnContainerBackend.AddColumn (ListViewColumn col)
@@ -212,72 +198,41 @@ namespace Xwt.Mac
 		
 		public void RemoveColumn (ListViewColumn col, object handle)
 		{
-			Table.RemoveColumn ((NSTableColumn)handle);
+			var tcol = (NSTableColumn)handle;
+			cols.Remove (tcol);
+			Table.RemoveColumn (tcol);
 		}
 
 		public void UpdateColumn (ListViewColumn col, object handle, ListViewColumnChange change)
 		{
-			NSTableColumn tcol = (NSTableColumn) handle;
-
-			switch (change) {
-				case ListViewColumnChange.CanResize:
-					if (col.CanResize)
-						tcol.ResizingMask |= NSTableColumnResizing.UserResizingMask;
-					else
-						tcol.ResizingMask &= ~NSTableColumnResizing.UserResizingMask;
-					break;
-				case ListViewColumnChange.Expanding:
-					if (col.Expands)
-						tcol.ResizingMask |= NSTableColumnResizing.Autoresizing;
-					else
-						tcol.ResizingMask &= ~NSTableColumnResizing.Autoresizing;
-					break;
-				case ListViewColumnChange.Cells:
-					var c = CellUtil.CreateCell(ApplicationContext, Table, this, col.Views, cols.IndexOf(tcol));
-					c.Alignment = col.Alignment.ToNSTextAlignment();
-					tcol.DataCell = c;
-					break;
-				case ListViewColumnChange.Title:
-					tcol.HeaderCell.Title = col.Title ?? string.Empty;
-					if (!col.CanResize)
-						tcol.SizeToFit();
-					break;
-				case ListViewColumnChange.Alignment:
-					tcol.HeaderCell.Alignment = col.Alignment.ToNSTextAlignment();
-					break;
-			}
+			var tcol = handle as TableColumn;
+			if (tcol != null)
+				tcol.UpdateColumn (col, change);
 		}
 
 		public Rectangle GetCellBounds (int row, CellView cell, bool includeMargin)
 		{
+			var rect = Rectangle.Zero;
 			var cellBackend = cell.GetBackend () as CellViewBackend;
-			var r = Table.GetCellFrame (cellBackend.Column, row);
-			var container = Table.GetCell (cellBackend.Column, row) as CompositeCell;
-			r = container.GetCellRect (r, (NSCell)cellBackend.CurrentCell);
-			r.Y -= scroll.DocumentVisibleRect.Y;
-			r.X -= scroll.DocumentVisibleRect.X;
-			if (HeadersVisible)
-				r.Y += Table.HeaderView.Frame.Height;
-			return new Rectangle (r.X, r.Y, r.Width, r.Height);
+			var container = Table.GetView (cellBackend.Column, row, false) as CompositeCell;
+			if (container != null) {
+				var cellView = container.GetCellViewForBackend (cellBackend);
+				rect = cellView.ConvertRectToView (new CoreGraphics.CGRect (new CoreGraphics.CGPoint (0, 0), cellView.Frame.Size), Table).ToXwtRect ();
+				rect.Y -= scroll.DocumentVisibleRect.Y;
+				rect.X -= scroll.DocumentVisibleRect.X;
+			}
+			return rect;
 		}
 
 		public Rectangle GetRowBounds (int row, bool includeMargin)
 		{
 			var rect = Rectangle.Zero;
-			var columns = Table.TableColumns ();
-
-			for (int i = 0; i < columns.Length; i++)
-			{
-				var r = Table.GetCellFrame (i, row);
-				if (rect == Rectangle.Zero)
-					rect = new Rectangle (r.X, r.Y, r.Width, r.Height);
-				else
-					rect = rect.Union (new Rectangle (r.X, r.Y, r.Width, r.Height));
+			var rowView = Table.GetRowView (row, false);
+			if (rowView != null) {
+				rect = rowView.Frame.ToXwtRect ();
+				rect.Y -= scroll.DocumentVisibleRect.Y;
+				rect.X -= scroll.DocumentVisibleRect.X;
 			}
-			rect.Y -= scroll.DocumentVisibleRect.Y;
-			rect.X -= scroll.DocumentVisibleRect.X;
-			if (HeadersVisible)
-				rect.Y += Table.HeaderView.Frame.Height;
 			return rect;
 		}
 
@@ -307,11 +262,6 @@ namespace Xwt.Mac
 
 		public abstract void SetCurrentEventRow (object pos);
 
-		nfloat ICellSource.RowHeight {
-			get { return Table.RowHeight; }
-			set { Table.RowHeight = value; }
-		}
-		
 		public bool BorderVisible {
 			get { return scroll.BorderType == NSBorderType.BezelBorder;}
 			set {
@@ -337,6 +287,125 @@ namespace Xwt.Mac
 		{
 			get { return Table.GridStyleMask.ToXwtValue (); }
 			set { Table.GridStyleMask = value.ToMacValue (); }
+		}
+	}
+
+	class TableColumn : NSTableColumn
+	{
+		readonly ICellSource backend;
+		readonly ApplicationContext context;
+
+		public CompositeCell DataView { get; private set; }
+
+		List<WeakReference> CachedViews = new List<WeakReference> ();
+
+		public TableColumn (ApplicationContext context, ICellSource backend, NSTableView table)
+		{
+			this.context = context;
+			Identifier = GetHashCode ().ToString (); // this is used to identify cached views
+			this.backend = backend;
+			TableView = table;
+		}
+
+		public CompositeCell CreateNewView ()
+		{
+			CleanViewCache ();
+			var view = DataView.Copy () as CompositeCell;
+			view.Identifier = Identifier;
+			// Cocoa will manage the native views in the background and eventually dispose
+			// them without letting us know. In order to keep track of the active views
+			// we store a weak ref for each view to not disturb the internal Cocoa caching login.
+			CachedViews.Add (new WeakReference (view));
+			return view;
+		}
+
+		void UpdateCachedViews (ICollection<CellView> cells)
+		{
+			if (CachedViews.Count == 0)
+				return;
+			var col = backend.Columns.IndexOf (this);
+			foreach (var cached in CachedViews) {
+				// update only the alive and not disposed views
+				if (cached.IsAlive) {
+					var view = cached.Target as CompositeCell;
+					if (view?.IsDisposed == false)
+						CellUtil.UpdateCellView (view, TableView, cells, col);
+				}
+			}
+
+			CleanViewCache ();
+		}
+
+		void CleanViewCache ()
+		{
+			// remove any GCd and/or disposed views
+			CachedViews.RemoveAll (c => {
+				if (!c.IsAlive)
+					return true;
+				var cell = c.Target as CompositeCell;
+				if (cell == null || cell.IsDisposed)
+					return true;
+				return false;
+			});
+		}
+
+		public void UpdateColumn (ListViewColumn col)
+		{
+			Editable = true;
+			var hc = new NSTableHeaderCell {
+				Title = col.Title ?? string.Empty
+			};
+			HeaderCell = hc;
+			HeaderCell.Alignment = col.Alignment.ToNSTextAlignment ();
+
+			DataView = CellUtil.CreateCellView (context, TableView, backend, col.Views, backend.Columns.IndexOf (this));
+			DataView.Identifier = Identifier;
+			UpdateCachedViews (col.Views);
+
+			if (col.CanResize)
+				ResizingMask |= NSTableColumnResizing.UserResizingMask;
+			else
+				ResizingMask &= ~NSTableColumnResizing.UserResizingMask;
+			if (col.Expands)
+				ResizingMask |= NSTableColumnResizing.Autoresizing;
+			else
+				ResizingMask &= ~NSTableColumnResizing.Autoresizing;
+			SizeToFit ();
+			TableView?.InvalidateIntrinsicContentSize ();
+		}
+
+		public void UpdateColumn (ListViewColumn col, ListViewColumnChange change)
+		{
+			if (TableView == null)
+				throw new InvalidOperationException ("Add the column to a table first");
+			switch (change) {
+			case ListViewColumnChange.CanResize:
+				if (col.CanResize)
+					ResizingMask |= NSTableColumnResizing.UserResizingMask;
+				else
+					ResizingMask &= ~NSTableColumnResizing.UserResizingMask;
+				break;
+			case ListViewColumnChange.Expanding:
+				if (col.Expands)
+					ResizingMask |= NSTableColumnResizing.Autoresizing;
+				else
+					ResizingMask &= ~NSTableColumnResizing.Autoresizing;
+				break;
+			case ListViewColumnChange.Cells:
+				DataView = CellUtil.CreateCellView (context, TableView, backend, col.Views, backend.Columns.IndexOf (this));
+				DataView.Identifier = Identifier;
+				UpdateCachedViews (col.Views);
+				TableView.ReloadData ();
+				break;
+			case ListViewColumnChange.Title:
+				HeaderCell.Title = col.Title ?? string.Empty;
+				if (!col.CanResize)
+					SizeToFit ();
+				break;
+			case ListViewColumnChange.Alignment:
+				HeaderCell.Alignment = col.Alignment.ToNSTextAlignment ();
+				break;
+			}
 		}
 	}
 	

--- a/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Collections.Generic;
 using AppKit;
+using CoreGraphics;
 using Foundation;
 using Xwt.Backends;
 
@@ -406,6 +407,45 @@ namespace Xwt.Mac
 				HeaderCell.Alignment = col.Alignment.ToNSTextAlignment ();
 				break;
 			}
+		}
+	}
+
+	class TableRowView : NSTableRowView
+	{
+
+		public override bool Selected {
+			get {
+				return base.Selected;
+			}
+			set {
+				base.Selected = value;
+				// the first time NSTableView is presented the background
+				// may be drawn already and it will not be redrawn even
+				// if Selection has been changed.
+				NeedsDisplay = true;
+			}
+		}
+
+		public override void DrawSelection (CGRect dirtyRect)
+		{
+			if (EffectiveAppearance.Name == NSAppearance.NameVibrantDark &&
+			    SelectionHighlightStyle != NSTableViewSelectionHighlightStyle.None) {
+				(Selected ? NSColor.AlternateSelectedControl : BackgroundColor).SetFill ();
+				var path = NSBezierPath.FromRect (dirtyRect);
+				path.Fill ();
+			} else
+				base.DrawSelection (dirtyRect);
+		}
+
+		public override void DrawBackground (CGRect dirtyRect)
+		{
+			if (Selected && EffectiveAppearance.Name == NSAppearance.NameVibrantDark &&
+				SelectionHighlightStyle != NSTableViewSelectionHighlightStyle.None) {
+				(Selected ? NSColor.AlternateSelectedControl : BackgroundColor).SetFill ();
+				var path = NSBezierPath.FromRect (dirtyRect);
+				path.Fill ();
+			} else
+				base.DrawBackground (dirtyRect);
 		}
 	}
 	

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -72,6 +72,11 @@ namespace Xwt.Mac
 				return height;
 			}
 
+			public override NSTableRowView RowViewForItem (NSOutlineView outlineView, NSObject item)
+			{
+				return outlineView.GetRowView (outlineView.RowForItem (item), false) ?? new TableRowView ();
+			}
+
 			public override NSView GetView (NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
 			{
 				var col = tableColumn as TableColumn;

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -551,6 +551,18 @@ namespace Xwt.Mac
 			return view.ConvertPointFromView(point, null);
 		}
 
+		public static PointerButton GetPointerButton (this NSEvent theEvent)
+		{
+			switch (theEvent.ButtonNumber) {
+			case 0: return PointerButton.Left;
+			case 1: return PointerButton.Right;
+			case 2: return PointerButton.Middle;
+			case 3: return PointerButton.ExtendedButton1;
+			case 4: return PointerButton.ExtendedButton2;
+			}
+			return (PointerButton)0;
+		}
+
 		public static Accessibility.Role GetXwtRole (INSAccessibility widget)
 		{
 			var r = widget.AccessibilityRole;

--- a/Xwt/Xwt/ListStore.cs
+++ b/Xwt/Xwt/ListStore.cs
@@ -387,7 +387,7 @@ namespace Xwt
 		{
 			int count = list.Count;
 			list.Clear ();
-			for (int n=0; n<count; n++) {
+			for (int n=count-1; n>=0; n--) {
 				if (RowDeleted != null)
 					RowDeleted (this, new ListRowEventArgs (n));
 			}


### PR DESCRIPTION
This PR replaces the deprecated NSCell based table/cell implementation with the recommended NSView based table mode.

Features:
* Makes use of the native NSView caching technique (reusable cell views)
* Less allocations (only one backend instance for each CellView)
* Faster row/column size calculations
* Full CellView event support