### PR TITLE
Handle context menu

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CellViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CellViewBackend.cs
@@ -229,7 +229,8 @@ namespace Xwt.GtkBackend
 						var a = new ButtonEventArgs {
 							X = args.Event.X,
 							Y = args.Event.Y,
-							Button = (PointerButton) args.Event.Button
+							Button = (PointerButton) args.Event.Button,
+							IsContextMenuTrigger = args.Event.TriggersContextMenu ()
 						};
 						EventSink.OnButtonPressed (a);
 						if (a.Handled)

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -894,6 +894,8 @@ namespace Xwt.GtkBackend
 				a.MultiplePress = 3;
 			else
 				a.MultiplePress = 1;
+
+			a.IsContextMenuTrigger = args.Event.TriggersContextMenu ();
 			return a;
 		}
 		

--- a/Xwt.WPF/Xwt.WPFBackend/DataConverter.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DataConverter.cs
@@ -380,7 +380,8 @@ namespace Xwt.WPFBackend
 				X = pos.X,
 				Y = pos.Y,
 				MultiplePress = e.ClickCount,
-				Button = e.ChangedButton.ToXwtButton ()
+				Button = e.ChangedButton.ToXwtButton (),
+				IsContextMenuTrigger = e.ChangedButton == MouseButton.Right && e.RightButton == MouseButtonState.Released
 			};
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/ComboBoxEntryBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ComboBoxEntryBackend.cs
@@ -171,6 +171,7 @@ namespace Xwt.Mac
 			args.X = p.X;
 			args.Y = p.Y;
 			args.Button = PointerButton.Right;
+			args.IsContextMenuTrigger = theEvent.TriggersContextMenu ();
 			context.InvokeUserCode (delegate {
 				eventSink.OnButtonPressed (args);
 			});
@@ -197,6 +198,7 @@ namespace Xwt.Mac
 			args.X = p.X;
 			args.Y = p.Y;
 			args.Button = PointerButton.Left;
+			args.IsContextMenuTrigger = theEvent.TriggersContextMenu ();
 			context.InvokeUserCode (delegate {
 				eventSink.OnButtonPressed (args);
 			});

--- a/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSTableViewBackend.cs
@@ -164,6 +164,7 @@ namespace Xwt.Mac
 			args.X = p.X;
 			args.Y = p.Y;
 			args.Button = PointerButton.Right;
+			args.IsContextMenuTrigger = theEvent.TriggersContextMenu ();
 			context.InvokeUserCode (delegate {
 				eventSink.OnButtonPressed (args);
 			});
@@ -190,6 +191,7 @@ namespace Xwt.Mac
 			args.X = p.X;
 			args.Y = p.Y;
 			args.Button = PointerButton.Left;
+			args.IsContextMenuTrigger = theEvent.TriggersContextMenu ();
 			context.InvokeUserCode (delegate {
 				eventSink.OnButtonPressed (args);
 			});

--- a/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
@@ -187,6 +187,7 @@ namespace Xwt.Mac
 			args.X = p.X;
 			args.Y = p.Y;
 			args.Button = PointerButton.Right;
+			args.IsContextMenuTrigger = theEvent.TriggersContextMenu ();
 			context.InvokeUserCode (delegate {
 				eventSink.OnButtonPressed (args);
 			});
@@ -213,6 +214,7 @@ namespace Xwt.Mac
 			args.X = p.X;
 			args.Y = p.Y;
 			args.Button = PointerButton.Left;
+			args.IsContextMenuTrigger = theEvent.TriggersContextMenu ();
 			context.InvokeUserCode (delegate {
 				eventSink.OnButtonPressed (args);
 			});

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -240,6 +240,21 @@ namespace Xwt.Mac
 			}
 		}
 
+		public static bool TriggersContextMenu (this NSEvent theEvent)
+		{
+			if (theEvent.ButtonNumber == 1 &&
+					(NSEvent.CurrentPressedMouseButtons & 1 | NSEvent.CurrentPressedMouseButtons & 4) == 0) {
+				return true;
+			}
+
+			if (theEvent.ButtonNumber == 0 && (theEvent.ModifierFlags & NSEventModifierMask.ControlKeyMask) != 0 &&
+					(NSEvent.CurrentPressedMouseButtons & 2 | NSEvent.CurrentPressedMouseButtons & 4) == 0) {
+				return true;
+			}
+
+			return false;
+		}
+
 		public static NSImage ToNSImage (this ImageDescription idesc)
 		{
 			if (idesc.IsNull)

--- a/Xwt.XamMac/Xwt.Mac/WidgetView.cs
+++ b/Xwt.XamMac/Xwt.Mac/WidgetView.cs
@@ -101,6 +101,7 @@ namespace Xwt.Mac
 			args.X = p.X;
 			args.Y = p.Y;
 			args.Button = PointerButton.Right;
+			args.IsContextMenuTrigger = theEvent.TriggersContextMenu ();
 			context.InvokeUserCode (delegate {
 				eventSink.OnButtonPressed (args);
 			});
@@ -129,6 +130,7 @@ namespace Xwt.Mac
 			args.X = p.X;
 			args.Y = p.Y;
 			args.Button = PointerButton.Left;
+			args.IsContextMenuTrigger = theEvent.TriggersContextMenu ();
 			context.InvokeUserCode (delegate {
 				eventSink.OnButtonPressed (args);
 			});

--- a/Xwt/Xwt/ButtonEventArgs.cs
+++ b/Xwt/Xwt/ButtonEventArgs.cs
@@ -80,6 +80,12 @@ namespace Xwt
 		/// </summary>
 		/// <value>The number of the presses of the same button.</value>
 		public int MultiplePress { get; set; }
+
+		/// <summary>
+		/// Gets or sets value indicating whether context menu should be shown
+		/// </summary>
+		/// <value><c>true</c> if this context menu should be shown; otherwise, <c>false</c>.</value>
+		public bool IsContextMenuTrigger { get; set; }
 	}
 }
 


### PR DESCRIPTION
I discussed with @sevoku a while back about exposing an API to allow us to cleanly support the macos specific behaviour of displaying context menu's when the user uses `control-click`.

Docs: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/MenuList/Articles/HowMenusWork.html

Does this approach make sense to you guys? If so we'll finalise and merge it!