### PR TITLE
ExTreeView: Fixed missing first root element

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
@@ -191,6 +191,8 @@ namespace Xwt.WPFBackend
 			if (parent != null) {
 				items = parent.Items;
 				g = parent.ItemContainerGenerator;
+			} else {
+				UpdateLayout ();
 			}
 
 			foreach (object item in items) {


### PR DESCRIPTION
Manually updating the widget layout only for root elements, as children are not affected by this bug

This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58917
This closes #720