### PR TITLE
ExTreeView: Don't try to explicitly render virtualized items

### DIFF
--- a/Testing/Tests/TreeViewTests.cs
+++ b/Testing/Tests/TreeViewTests.cs
@@ -50,6 +50,7 @@ namespace Xwt
 		}
 
 		[Test]
+		[Ignore("Disabling this test because the fix it relies on breaks the treeview. See https://bugzilla.xamarin.com/show_bug.cgi?id=58917 for more details")]
 		public void HiddenTree ()
 		{
 			var f = new DataField<string> ();

--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
@@ -195,15 +195,8 @@ namespace Xwt.WPFBackend
 
 			foreach (object item in items) {
 				var treeItem = (ExTreeViewItem)g.ContainerFromItem (item);
-				if (treeItem == null) {
-					var ig = (IItemContainerGenerator)g;
-					using (ig.StartAt (new GeneratorPosition (-1, 1), GeneratorDirection.Forward)) {
-						ig.GenerateNext ();
-					}
-					treeItem = (ExTreeViewItem)g.ContainerFromItem (item);
-					if (treeItem == null)
-						continue;
-				}
+				if (treeItem == null)
+					continue;
 
 				if (!action (item, treeItem))
 					return false;


### PR DESCRIPTION
this fixes https://bugzilla.xamarin.com/show_bug.cgi?id=58917