### PR TITLE
[Gtk] Fix enumeration corruption on recursive size allocation

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/BoxBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/BoxBackend.cs
@@ -145,7 +145,7 @@ namespace Xwt.GtkBackend
 			} catch {
 				IsReallocating = false;
 			}
-			foreach (var cr in children) {
+			foreach (var cr in children.ToArray()) {
 				var r = cr.Value.Rect;
 				cr.Key.SizeAllocate (new Gdk.Rectangle (allocation.X + (int)r.X, allocation.Y + (int)r.Y, (int)r.Width, (int)r.Height));
 			}

--- a/Xwt.Gtk/Xwt.GtkBackend/CanvasBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CanvasBackend.cs
@@ -141,7 +141,7 @@ namespace Xwt.GtkBackend
 			lastAllocation = allocation;
 			var dx = VisibleWindow ? 0 : allocation.X;
 			var dy = VisibleWindow ? 0 : allocation.Y;
-			foreach (var cr in children) {
+			foreach (var cr in children.ToArray()) {
 				var r = cr.Value;
 				var w = (int) Math.Max (r.Width, 0);
 				var h = (int) Math.Max (r.Height, 0);


### PR DESCRIPTION
When containers reallocate their children, a child might
request the container to re-reallocate. This leads to
a modificytion of the child collection during its enumeration,
resulting in an InvalidOperationException. Enumerating
the children to an array before reallocation solves
this rare case.