### PR TITLE
[WPF] Fix layout for ScrollView with ScrollPolicy.Never

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/CustomScrollViewPort.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/CustomScrollViewPort.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // CustomScrollViewPort.cs
 //
 // Author:
@@ -315,10 +315,12 @@ namespace Xwt.WPFBackend
 				return child.DesiredSize;
 			}
 			else {
-				// We don't use the child size here, but WPF requires Measure to
-				// be called for all children of a widget in the container's MeasureOverride
+				// We only use child size for the dimensions that scrolling is disabled. This
+				//  allows the child to properly influence the measure of the scroll view in that
+				//  case.
 				child.Measure (InfiniteSize);
-				return new WSize (0, 0);
+				var sz = child.DesiredSize;
+				return new WSize (CanHorizontallyScroll? 0 : sz.Width, CanVerticallyScroll? 0 : sz.Height);
 			}
 		}
 

--- a/Xwt.WPF/Xwt.WPFBackend/ScrollViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ScrollViewBackend.cs
@@ -1,4 +1,4 @@
-﻿// 
+// 
 // ScrollViewBackend.cs
 //  
 // Author:
@@ -183,7 +183,7 @@ namespace Xwt.WPFBackend
 				case ScrollPolicy.Automatic:
 					return ScrollBarVisibility.Auto;
 				case ScrollPolicy.Never:
-					return ScrollBarVisibility.Hidden;
+					return ScrollBarVisibility.Disabled;
 
 				default:
 					throw new NotSupportedException();
@@ -197,7 +197,7 @@ namespace Xwt.WPFBackend
 					return ScrollPolicy.Automatic;
 				case ScrollBarVisibility.Visible:
 					return ScrollPolicy.Always;
-				case ScrollBarVisibility.Hidden:
+				case ScrollBarVisibility.Disabled:
 					return ScrollPolicy.Never;
 
 				default:


### PR DESCRIPTION
When ScrollPolicy.Never is specified for a dimension, the ScrollView
should use the preferred size of the child to calculate its preferred
size for that dimension. This fixes the WPF backend to do that instead
of always measuring a zero size.