### PR TITLE
[WPF] Fixed an exception when selecting multiple TreeView items

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
@@ -260,6 +260,10 @@ namespace Xwt.WPFBackend
 						return (newItems.Count + oldItems.Count > 0);
 					});
 				}
+
+				if (!changeActive) {
+					shiftStart = GetTreeItem (SelectedItems [0]);
+				}
 				break;
 			}
 
@@ -318,6 +322,8 @@ namespace Xwt.WPFBackend
 				SelectedItems.Clear();
 			if (ShiftPressed)
 			{
+				if (shiftStart == null)
+					shiftStart = item;
 				if (shiftEnd != null)//Erase previous selection of shift
 					foreach (var forEachItem in GetItemsBetween(shiftStart, shiftEnd))
 						SelectedItems.Remove(forEachItem.DataContext);


### PR DESCRIPTION
This fixes #740 

Just don't forget to fill up `shiftStart` when selected items are changed. Also, check for null.