### PR TITLE
[WPF] Fix measuring for CustomPanel

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
@@ -120,7 +120,7 @@ namespace Xwt.WPFBackend
 			// Use the 'widgets' field so we can easily map a control position by looking at 'rects'.
 			for (int i = 0; i < widgets.Length; i++) {
 				var element = WidgetBackend.GetFrameworkElement (widgets [i]);
-				if (!element.IsArrangeValid || force) {
+				if (!element.IsArrangeValid || !element.IsMeasureValid || force) {
 					// Measure the widget again using the allocation constraints. This is necessary
 					// because WPF widgets my cache some measurement information based on the
 					// constraints provided in the last Measure call (which when calculating the


### PR DESCRIPTION
It is possible for IsArrangeValid to return true when
IsMeasureValid returns false. This is probably a bug
in WPF, but it is unfortunately what is happening.

This is a workaround for that issue. We should measure
when the measure is invalid :)

This fixes the case where the embedded exception dialog
or the loading spinner do not appear when opening a
storyboard file in Visual Studio.