### PR TITLE
[WPF] CustomScrollViewPort: Ensure content offset is updated if child size changes

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/CustomScrollViewPort.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/CustomScrollViewPort.cs
@@ -196,37 +196,9 @@ namespace Xwt.WPFBackend
 			set;
 		}
 
-		public void SetHorizontalOffset (double offset)
-		{
-			if (offset < 0 || this.viewport.Width >= this.extent.Width)
-				offset = 0;
-			else if (offset + this.viewport.Width >= this.extent.Width)
-				offset = this.extent.Width - this.viewport.Width;
+		public void SetHorizontalOffset (double offset) => SetOffset (x: offset);
 
-			this.contentOffset.X = offset;
-			if (usingCustomScrolling)
-				this.horizontalBackend.SetOffset (offset);
-			else
-				this.transform.X = -offset;
-			if (ScrollOwner != null)
-				ScrollOwner.InvalidateScrollInfo ();
-		}
-
-		public void SetVerticalOffset (double offset)
-		{
-			if (offset < 0 || this.viewport.Height >= this.extent.Height)
-				offset = 0;
-			else if (offset + this.viewport.Height >= this.extent.Height)
-				offset = this.extent.Height - this.viewport.Height;
-
-			this.contentOffset.Y = offset;
-			if (usingCustomScrolling)
-				this.verticalBackend.SetOffset (offset);
-			else
-				this.transform.Y = -offset;
-			if (ScrollOwner != null)
-				ScrollOwner.InvalidateScrollInfo ();
-		}
+		public void SetVerticalOffset (double offset) => SetOffset (y: offset);
 
 		public void SetOffset (ScrollAdjustmentBackend scroller, double offset)
 		{
@@ -234,6 +206,40 @@ namespace Xwt.WPFBackend
 				SetVerticalOffset (offset);
 			else
 				SetHorizontalOffset (offset);
+		}
+
+		void SetOffset (double? x = null, double? y = null)
+		{
+			var offset = this.contentOffset;
+			if (x.HasValue)
+				offset.X = x.Value;
+			if (y.HasValue)
+				offset.Y = y.Value;
+
+			// Clamp horizontal
+			if (offset.X < 0 || this.viewport.Width >= this.extent.Width)
+				offset.X = 0;
+			else if (offset.X + this.viewport.Width >= this.extent.Width)
+				offset.X = this.extent.Width - this.viewport.Width;
+
+			// Clamp vertical
+			if (offset.Y < 0 || this.viewport.Height >= this.extent.Height)
+				offset.Y = 0;
+			else if (offset.Y + this.viewport.Height >= this.extent.Height)
+				offset.Y = this.extent.Height - this.viewport.Height;
+
+			if (offset != this.contentOffset) {
+				this.contentOffset = offset;
+				if (usingCustomScrolling) {
+					this.horizontalBackend.SetOffset (offset.X);
+					this.verticalBackend.SetOffset (offset.Y);
+				}  else {
+					this.transform.X = -offset.X;
+					this.transform.Y = -offset.Y;
+				}
+				if (ScrollOwner != null)
+					ScrollOwner.InvalidateScrollInfo ();
+			}
 		}
 
 		public void UpdateCustomExtent ()
@@ -349,6 +355,10 @@ namespace Xwt.WPFBackend
 					this.viewport = finalSize;
 					ScrollOwner.InvalidateScrollInfo ();
 				}
+
+				// It's possible our child is now smaller than our viewport, in which case we need to
+				//  update the content offset, otherwise the child may be scrolled entirely out of view.
+				SetOffset ();
 			}
 
 			child.Arrange (new Rect (0, 0, childSize.Width, childSize.Height));


### PR DESCRIPTION
If a larger child is replaced by a smaller one, we need to ensure the content offset
is re-clamped based on the new extents, otherwise the child may be scrolled entirely
out of the viewport.