### PR TITLE
[A11y] Allow native accessible children to be added to Xwt.Accessible

### DIFF
--- a/Xwt.Gtk.Mac/GtkMacAccessibleBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacAccessibleBackend.cs
@@ -24,10 +24,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
-
+using System.Linq;
 using AppKit;
 using Foundation;
 using ObjCRuntime;
+using Xwt.Accessibility;
 using Xwt.GtkBackend;
 
 namespace Xwt.Gtk.Mac
@@ -82,6 +83,47 @@ namespace Xwt.Gtk.Mac
 
 				nsa.AccessibilityUrl = new NSUrl (value.AbsoluteUri);
 			}
+		}
+
+		public override void AddChild (object nativeChild)
+		{
+			var nsa = GetNSAccessibilityElement (widget.Accessible);
+			if (nsa == null) {
+				return;
+			}
+
+			var parent = nsa as NSAccessibilityElement;
+			if (parent != null) {
+				var child = nativeChild as NSAccessibilityElement;
+				if (child == null) {
+					throw new ArgumentException ($"{nativeChild.GetType ().ToString ()} - should be NSAccessibilityElement", nameof (nativeChild));
+				}
+				parent.AccessibilityAddChildElement (child);
+			}
+		}
+
+		public override void RemoveChild (object nativeChild)
+		{
+			var nsa = GetNSAccessibilityElement (widget.Accessible);
+			if (nsa == null) {
+				return;
+			}
+
+			var parent = nsa as NSAccessibilityElement;
+
+			if (parent != null) {
+				parent.AccessibilityChildren = parent.AccessibilityChildren.Where(c => c != nativeChild).ToArray ();
+			}
+		}
+
+		public override void RemoveAllChildren ()
+		{
+			var nsa = GetNSAccessibilityElement (widget.Accessible);
+			if (nsa == null) {
+				return;
+			}
+
+			nsa.AccessibilityChildren = null;
 		}
 	}
 }

--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -157,6 +157,21 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		public virtual void AddChild (object nativeChild)
+		{
+			// TODO
+		}
+
+		public virtual void RemoveChild (object nativeChild)
+		{
+			// TODO
+		}
+
+		public virtual void RemoveAllChildren ()
+		{
+			// TODO
+		}
+
 		public void DisableEvent (object eventId)
 		{
 			throw new NotImplementedException ();

--- a/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Linq;
 using AppKit;
 using Foundation;
 using Xwt.Accessibility;
@@ -171,6 +172,50 @@ namespace Xwt.Mac
 			set {
 				widget.AccessibilityRoleDescription = value;
 			}
+		}
+
+		public void AddChild (object nativeChild)
+		{
+			var accessible = nativeChild as INSAccessibility;
+			if (accessible == null) {
+				throw new ArgumentException ($"{nativeChild.GetType ().ToString ()} - should be INSAccessibility", nameof (nativeChild));
+			}
+
+			var child = nativeChild as NSAccessibilityElement;
+			var element = widget as NSAccessibilityElement;
+			if (element != null && child != null) {
+				element.AccessibilityAddChildElement (child);
+			} else {
+				var children = accessible.AccessibilityChildren;
+				if (children == null || children.Length == 0) {
+					accessible.AccessibilityChildren = new NSObject[] {(NSObject)accessible};
+				} else {
+					var length = children.Length;
+					var newChildren = new NSObject[children.Length + 1];
+					Array.Copy (children, newChildren, children.Length);
+					accessible.AccessibilityChildren = newChildren;
+				}
+			}
+		}
+
+		public void RemoveChild (object nativeChild)
+		{
+			var accessible = widget as INSAccessibility;
+			if (accessible == null) {
+				return;
+			}
+
+			accessible.AccessibilityChildren = accessible.AccessibilityChildren.Where(c => c != nativeChild).ToArray ();
+		}
+
+		public void RemoveAllChildren ()
+		{
+			var accessible = widget as INSAccessibility;
+			if (accessible == null) {
+				return;
+			}
+
+			accessible.AccessibilityChildren = null;
 		}
 
 		public void EnableEvent (object eventId)

--- a/Xwt/Xwt.Accessibility/Accessible.cs
+++ b/Xwt/Xwt.Accessibility/Accessible.cs
@@ -183,6 +183,16 @@ namespace Xwt.Accessibility
 			}
 		}
 
+		public void AddChild (object nativeChild)
+		{
+			Backend.AddChild (nativeChild);
+		}
+
+		public void RemoveChild (object nativeChild)
+		{
+			Backend.RemoveChild (nativeChild);
+		}
+
 		bool OnPress ()
 		{
 			var args = new WidgetEventArgs ();
@@ -224,6 +234,18 @@ namespace Xwt.Accessibility
 		public Uri Uri { get; set; }
 
 		public bool IsAccessible { get; set; }
+
+		public void AddChild (object nativeChild)
+		{
+		}
+
+		public void RemoveChild (object nativeChild)
+		{
+		}
+
+		public void RemoveAllChildren ()
+		{
+		}
 
 		public void DisableEvent (object eventId)
 		{

--- a/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
+++ b/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
@@ -53,6 +53,10 @@ namespace Xwt.Backends
 		Role Role { get; set; }
 
 		string RoleDescription { get; set; }
+
+		void AddChild (object nativeChild);
+		void RemoveChild (object nativeChild);
+		void RemoveAllChildren ();
 	}
 
 	public interface IAccessibleEventSink


### PR DESCRIPTION
Sometimes widgets have subregions that need their own accessible object. This
change allows native accessible objects to be added to Xwt.Accessible objects
as children