### PR TITLE
[WPF] Fixed TreeView multiple child selection not working properly

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
@@ -250,7 +250,7 @@ namespace Xwt.WPFBackend
 					HashSet<object> oldItems = (e.OldItems != null)
 												? new HashSet<object> (e.OldItems.Cast<object> ())
 												: new HashSet<object> ();
-					
+
 					TraverseTree ((o, ti) => {
 						if (newItems.Remove (o))
 							ti.IsSelected = true;
@@ -259,10 +259,6 @@ namespace Xwt.WPFBackend
 
 						return (newItems.Count + oldItems.Count > 0);
 					});
-				}
-
-				if (!changeActive) {
-					shiftStart = GetTreeItem (SelectedItems [0]);
 				}
 				break;
 			}
@@ -328,8 +324,12 @@ namespace Xwt.WPFBackend
 					foreach (var forEachItem in GetItemsBetween(shiftStart, shiftEnd))
 						SelectedItems.Remove(forEachItem.DataContext);
 				shiftEnd = item;
-				foreach (var forEachItem in GetItemsBetween(shiftStart, shiftEnd))
-					SelectedItems.Add(forEachItem.DataContext);
+				if (this.SelectionMode == SWC.SelectionMode.Single) {
+					SelectedItems.Add(item.DataContext);
+				} else {
+					foreach (var forEachItem in GetItemsBetween(shiftStart, shiftEnd))
+						SelectedItems.Add(forEachItem.DataContext);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
This fixes https://github.com/mono/xwt/issues/748

Removed malfunctioning call to `GetTreeItem()` method. It was calling `ItemContainerGenerator.ContainerFromItem()`, which for some reason returns null for any child item.

So while the root of the problem may lie somewhere deeper in the depths of WPF, these changes do fix the issue for us.