### PR TITLE
[Gtk] RichTextView: fix possible null reference at RichTextViewBackend::GtkTextView::UpdateLinkColor when requesting "link-color" property via StyleGetProperty call

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
@@ -584,7 +584,10 @@ namespace Xwt.GtkBackend
 			{
 				if (!IsRealized)
 					return;
-				var color = (Gdk.Color) StyleGetProperty ("link-color");
+				var objColor = StyleGetProperty ("link-color");
+				var color = Gdk.Color.Zero;
+				if (objColor != null)
+					color = (Gdk.Color) objColor;
 				if (color.Equals (Gdk.Color.Zero))
 					color = Toolkit.CurrentEngine.Defaults.FallbackLinkColor.ToGtkValue ();
 				if (Buffer != null)


### PR DESCRIPTION
I found possible bug in RichTextViewBackend class, when using Gtk3 backend.
It crashes in my test env, when I'm trying to use RichTextView widget.  Here is an example program and stack trace with error: https://gist.github.com/DarkCaster/81af3ff6c378ae94eebb128cb716492d

I've figured out that StyleGetProperty call at RichTextViewBackend.cs:587, returns null instead of expected Gdk.Color struct. So, i've created this workaround.

My system specs: OpenSuSE 42.2, Mono 5.4.0 from Mono:Factory (actually i'm using mono builds from my private derivative repo. It is in sync with Mono:Factory for now : https://build.opensuse.org/project/show/home:Warhammer40k:Mono:Factory)