### PR TITLE
Add default button support

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/ButtonBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ButtonBackend.cs
@@ -47,8 +47,12 @@ namespace Xwt.GtkBackend
 		{
 			NeedsEventBox = false;
 			Widget = new Gtk.Button ();
+			Widget.Realized += (o, arg) =>
+			{
+				if (Widget.IsRealized && Widget.CanDefault)
+					Widget.GrabDefault();
+			};
 			base.Widget.Show ();
-			
 		}
 		
 		protected new Gtk.Button Widget {
@@ -81,6 +85,11 @@ namespace Xwt.GtkBackend
 					labelWidget.SetForegroundColor (Gtk.StateType.Prelight, value);
 				}
 			}
+		}
+
+		public virtual bool IsDefault {
+			get { return Widget.CanDefault; }
+			set { Widget.CanDefault = value; }
 		}
 
 		public override object Font {

--- a/Xwt.WPF/Xwt.WPFBackend/ButtonBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ButtonBackend.cs
@@ -135,7 +135,17 @@ namespace Xwt.WPFBackend
 			set { Button.Foreground = ResPool.GetSolidBrush (value.ToWpfColor()); }
 		}
 
-		public bool IsDefault { get; set; } //TODO: Default Button
+		bool isDefault;
+		public virtual bool IsDefault {
+			get { return (Button as SWC.Button)?.IsDefault ?? isDefault; }
+			set {
+				var button = Button as SWC.Button;
+				if (button != null)
+					button.IsDefault = value;
+				else
+					isDefault = value; // just cache the value
+			}
+		}
 
 		public override void EnableEvent (object eventId)
 		{

--- a/Xwt.WPF/Xwt.WPFBackend/ButtonBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ButtonBackend.cs
@@ -135,6 +135,8 @@ namespace Xwt.WPFBackend
 			set { Button.Foreground = ResPool.GetSolidBrush (value.ToWpfColor()); }
 		}
 
+		public bool IsDefault { get; set; } //TODO: Default Button
+
 		public override void EnableEvent (object eventId)
 		{
 			base.EnableEvent (eventId);

--- a/Xwt.XamMac/Xwt.Mac/ButtonBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ButtonBackend.cs
@@ -143,6 +143,17 @@ namespace Xwt.Mac
 				break;
 			}
 		}
+		bool isDefault;
+		public bool IsDefault {
+			get { return isDefault; }
+			set {
+				isDefault = value;
+				if (Widget.Window != null && Widget.Window.DefaultButtonCell != Widget.Cell)
+					Widget.Window.DefaultButtonCell = Widget.Cell;
+			}
+		}
+
+
 		
 		#endregion
 
@@ -221,6 +232,12 @@ namespace Xwt.Mac
 
 		public void DisableEvent (ButtonEvent ev)
 		{
+		}
+
+		public override void ViewDidMoveToWindow ()
+		{
+			if ((Backend as ButtonBackend)?.IsDefault == true && Window != null)
+				Window.DefaultButtonCell = Cell;
 		}
 
 		void OnActivatedInternal ()

--- a/Xwt/Xwt.Backends/IButtonBackend.cs
+++ b/Xwt/Xwt.Backends/IButtonBackend.cs
@@ -32,6 +32,7 @@ namespace Xwt.Backends
 	public interface IButtonBackend: IWidgetBackend
 	{
 		Color LabelColor { get; set; }
+		bool IsDefault { get; set; }
 		void SetButtonStyle (ButtonStyle style);
 		void SetButtonType (ButtonType type);
 		void SetContent (string label, bool useMnemonic, ImageDescription image, ContentPosition position);

--- a/Xwt/Xwt/Button.cs
+++ b/Xwt/Xwt/Button.cs
@@ -167,6 +167,11 @@ namespace Xwt
 			get { return Backend.LabelColor; }
 			set { Backend.LabelColor = value; }
 		}
+
+		public bool IsDefault {
+			get { return Backend.IsDefault; }
+			set { Backend.IsDefault = value; }
+		}
 		
 		protected virtual void OnClicked (EventArgs e)
 		{


### PR DESCRIPTION
This patch adds `Button.IsDefault` support. Depending on the toolkit, default buttons will be activated on special default actions inside a window (usually when the user presses the `Enter` key on the keyboard) and have a different design.

TODO: WPF support