### PR TITLE
[Mac] Fix Window.TransientFor

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -162,25 +162,8 @@ namespace Xwt.Mac
 
 		public void RunLoop (IWindowFrameBackend parent)
 		{
-			if (parent != null)
-				StyleMask &= ~NSWindowStyle.Miniaturizable;
-			else
-				StyleMask |= NSWindowStyle.Miniaturizable;
 			Visible = true;
 			modalSessionRunning = true;
-			var win = parent as NSWindow ?? ApplicationContext.Toolkit.GetNativeWindow (parent) as NSWindow;
-			if (win != null) {
-				win.AddChildWindow (this, NSWindowOrderingMode.Above);
-				// always use NSWindow for alignment when running in guest mode and
-				// don't rely on AddChildWindow to position the window correctly
-				if (!(parent is WindowBackend)) {
-					var parentBounds = MacDesktopBackend.ToDesktopRect (win.ContentRectFor (win.Frame));
-					var bounds = ((IWindowFrameBackend)this).Bounds;
-					bounds.X = parentBounds.Center.X - (Frame.Width / 2);
-					bounds.Y = parentBounds.Center.Y - (Frame.Height / 2);
-					((IWindowFrameBackend)this).Bounds = bounds;
-				}
-			}
 			NSApplication.SharedApplication.RunModalForWindow (this);
 		}
 


### PR DESCRIPTION
The original TransientFor impl. was just faking a dialog like behaviour by enforcing a window level and making a window float above all open window (including other apps). This patch makes use of the official Cocoa API to set and manage a window parent.