### PR TITLE
[Mac] Fix ListBox column autosizing

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ListBoxBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListBoxBackend.cs
@@ -64,38 +64,6 @@ namespace Xwt.Mac
 				column.Views.Add (v);
 			UpdateColumn (column, columnHandle, ListViewColumnChange.Cells);
 		}
-
-		public override void SetSource (IListDataSource source, IBackend sourceBackend)
-		{
-			base.SetSource (source, sourceBackend);
-
-			source.RowInserted += HandleColumnSizeChanged;
-			source.RowDeleted += HandleColumnSizeChanged;
-			source.RowChanged += HandleColumnSizeChanged;
-			ResetColumnSize (source);
-		}
-
-		void HandleColumnSizeChanged (object sender, ListRowEventArgs e)
-		{
-			var source = (IListDataSource)sender;
-			ResetColumnSize (source);
-		}
-
-		void ResetColumnSize (IListDataSource source)
-		{
-			// Calculate size of column
-			// This is how Apple implements it; unfortunately, they don't expose this functionality in the API.
-			// https://developer.apple.com/library/mac/documentation/Cocoa/Reference/NSTableViewDelegate_Protocol/index.html#//apple_ref/occ/intfm/NSTableViewDelegate/tableView:sizeToFitWidthOfColumn:
-			nfloat w = 0;
-			for (var row = 0; row < source.RowCount; row++) {
-				using (var cell = Table.GetCell (0, row)) {
-					var size = cell.CellSize;
-					w = (nfloat)Math.Max (w, size.Width);
-				}
-			}
-			columnHandle.MinWidth = (nfloat)Math.Ceiling (w);
-			columnHandle.Width = (nfloat)Math.Ceiling (w);
-		}
 	}
 }
 


### PR DESCRIPTION
Remove deprecated column sizing code, since column sizing
is now handled by the base backend code (changed in #662)

(fixes #765)