### PR TITLE
Return null if unable to find an image

### DIFF
--- a/Xwt/Xwt.Backends/ImageBackendHandler.cs
+++ b/Xwt/Xwt.Backends/ImageBackendHandler.cs
@@ -43,7 +43,7 @@ namespace Xwt.Backends
 		{
 			using (var s = asm.GetManifestResourceStream (name)) {
 				if (s == null)
-					throw new InvalidOperationException ("Resource not found: " + name);
+					return null;
 				return LoadFromStream (s);
 			}
 		}

--- a/Xwt/Xwt.Drawing/Image.cs
+++ b/Xwt/Xwt.Drawing/Image.cs
@@ -191,6 +191,9 @@ namespace Xwt.Drawing
 				throw new ToolkitNotInitializedException ();
 
 			var img = loader.LoadImage (fileName);
+			if (img == null)
+				return null;
+
 			var reqSize = toolkit.ImageBackendHandler.GetSize (img);
 
 			var ext = GetExtension (fileName);
@@ -1014,8 +1017,6 @@ namespace Xwt.Drawing
 		public override object LoadImage (string fileName)
 		{
 			var img = toolkit.ImageBackendHandler.LoadFromResource (assembly, fileName);
-			if (img == null)
-				throw new InvalidOperationException ("Resource not found: " + fileName);
 			return img;
 		}
 


### PR DESCRIPTION
Avoids a first-chance exception. We catch an InvalidOperationException later anyway, so might as well just use null to represent a missing value.