### PR TITLE
Fixed ITreeDataSource support in Gtk.TreeView

### DIFF
--- a/TestApps/Samples/MainWindow.cs
+++ b/TestApps/Samples/MainWindow.cs
@@ -109,6 +109,7 @@ namespace Samples
 			AddSample (w, "Password Entry", typeof (PasswordEntries));
 			var treeview = AddSample (w, "TreeView", typeof(TreeViews));
 			AddSample (treeview, "Cell Bounds", typeof(TreeViewCellBounds));
+			AddSample (treeview, "Custom Data Source", typeof (TreeViewCustomStore));
 			AddSample (w, "WebView", typeof(WebViewSample));
 
 			var n = AddSample (null, "Drawing", null);

--- a/TestApps/Samples/Samples.csproj
+++ b/TestApps/Samples/Samples.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Samples\FolderSelectorSample.cs" />
     <Compile Include="Samples\ListViewCombos.cs" />
     <Compile Include="Samples\PopupWindows.cs" />
+    <Compile Include="Samples\TreeViewCustomStore.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/TestApps/Samples/Samples/TreeViewCustomStore.cs
+++ b/TestApps/Samples/Samples/TreeViewCustomStore.cs
@@ -1,0 +1,291 @@
+﻿//
+// TreeViewCustomStore.cs
+//
+// Author:
+//       Lluis Sanchez <llsan@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xwt;
+using Xwt.Drawing;
+
+namespace Samples
+{
+	public class TreeViewCustomStore: VBox
+	{
+		public TreeViewCustomStore ()
+		{
+			DataNode root = new DataNode ("Root",
+				new DataNode [] {
+					new DataNode ("One", new DataNode [] {
+						new DataNode ("Elephant"),
+						new DataNode ("Tiger")
+					}),
+					new DataNode ("Two", new DataNode [] {
+						new DataNode ("Monkey"),
+						new DataNode ("Lion")
+					}),
+				}
+			);
+			DataNode root2 = new DataNode ("Second Root",
+				new DataNode [] {
+					new DataNode ("One", new DataNode [] {
+						new DataNode ("Elephant"),
+						new DataNode ("Tiger")
+					}),
+					new DataNode ("Two", new DataNode [] {
+						new DataNode ("Monkey"),
+						new DataNode ("Lion")
+					}),
+				}
+			);
+
+			MyTreeSource source = new MyTreeSource ();
+			source.Add (root);
+			source.Add (root2);
+			source.Add (new InfiniteDataNode ("Infinite"));
+
+			TreeView tree = new TreeView ();
+
+			var col = new ListViewColumn ("Data");
+			col.Views.Add (new ImageCellView (source.ImageField));
+			col.Views.Add (new TextCellView (source.LabelField));
+			tree.Columns.Add (col);
+
+			PackStart (tree, true);
+
+			var hbox = new HBox ();
+			var add = new Button ("Add nodes");
+			var change = new Button ("Change nodes");
+			var remove = new Button ("Remove nodes");
+
+			hbox.PackStart (add);
+			hbox.PackStart (change);
+			hbox.PackStart (remove);
+			PackStart (hbox);
+
+			add.Clicked += delegate {
+				var node = new DataNode ("New child");
+				root.InsertChild (1, node);
+				tree.SelectRow (node);
+			};
+
+			remove.Clicked += delegate {
+				if (root.Children.Count > 0)
+					root.RemoveChild (root.Children [root.Children.Count - 1]);
+			};
+
+			change.Clicked += delegate {
+				var sel = (DataNode)tree.SelectedRow;
+				if (sel != null)
+					sel.Name = "Modified";
+			};
+
+			tree.DataSource = source;
+		}
+	}
+
+	class DataNode: TreePosition
+	{
+		protected List<DataNode> children;
+		public DataNode Parent { get; set; }
+		public virtual List<DataNode> Children => children;
+		string name;
+
+		public string Name {
+			get {
+				return name;
+			}
+
+			set {
+				name = value;
+				GetEventSink ()?.NotifyNodeChanged (this, -1);
+			}
+		}
+		Image image;
+
+		public Image Image {
+			get {
+				return image;
+			}
+
+			set {
+				image = value;
+				GetEventSink ()?.NotifyNodeChanged (this, -1);
+			}
+		}
+
+		public IEventSink EventSink { get; set; }
+
+		IEventSink GetEventSink ()
+		{
+			return EventSink ?? Parent?.GetEventSink ();
+		}
+
+		public DataNode (string name, params DataNode[] children)
+		{
+			Name = name;
+			if (children.Length > 0) {
+				this.children = children.ToList ();
+				foreach (var c in children)
+					c.Parent = this;
+			}
+		}
+
+		public void AddChild (DataNode node)
+		{
+			if (children == null)
+				children = new List<DataNode> ();
+			Children.Add (node);
+			node.Parent = this;
+			GetEventSink ()?.NotifyNodeAdded (node, Children.Count - 1);
+		}
+
+		public void InsertChild (int index, DataNode node)
+		{
+			if (children == null)
+				children = new List<DataNode> ();
+			Children.Insert (index, node);
+			node.Parent = this;
+			GetEventSink ()?.NotifyNodeAdded (node, index);
+		}
+
+		public void RemoveChild (DataNode node)
+		{
+			if (children != null) {
+				int i = children.IndexOf (node);
+				if (i != -1) {
+					children.RemoveAt (i);
+					GetEventSink ()?.NotifyNodeRemoved (this, i, node);
+				}
+			}
+		}
+
+        public override string ToString()
+        {
+			return "[" + Name + "]";
+        }
+    }
+
+	class InfiniteDataNode: DataNode
+	{
+		public InfiniteDataNode (string name, params DataNode [] children) : base (name, children)
+		{
+			
+		}
+
+        public override List<DataNode> Children {
+			get {
+				if (children == null) {
+					AddChild (new InfiniteDataNode ("Child 1"));
+					AddChild (new InfiniteDataNode ("Child 2"));
+				}
+				return base.Children;
+			}
+		}
+    }
+
+	interface IEventSink
+	{
+		void NotifyNodeAdded (DataNode node, int childIndex);
+		void NotifyNodeRemoved (TreePosition parent, int childIndex, TreePosition child);
+		void NotifyNodeChanged (DataNode node, int childIndex);
+	}
+
+	class MyTreeSource : ITreeDataSource, IEventSink
+	{
+		public DataField<string> LabelField = new DataField<string> (0);
+		public DataField<Image> ImageField = new DataField<Image> (1);
+
+		List<DataNode> data = new List<DataNode> ();
+
+		public Type [] ColumnTypes => new [] { typeof (string), typeof (Image) };
+
+		public event EventHandler<TreeNodeEventArgs> NodeInserted;
+		public event EventHandler<TreeNodeChildEventArgs> NodeDeleted;
+		public event EventHandler<TreeNodeEventArgs> NodeChanged;
+		public event EventHandler<TreeNodeOrderEventArgs> NodesReordered;
+
+		public void Add (DataNode node)
+		{
+			data.Add (node);
+			node.EventSink = this;
+		}
+
+		public TreePosition GetChild (TreePosition pos, int index)
+		{
+			var node = (DataNode)pos;
+			var list = node != null ? node.Children : data;
+			if (list == null || index >= list.Count)
+				return null;
+			return list [index];
+		}
+
+		public int GetChildrenCount (TreePosition pos)
+		{
+			var node = (DataNode)pos;
+			var list = node != null ? node.Children : data;
+			return list != null ? list.Count : 0;
+		}
+
+		public TreePosition GetParent (TreePosition pos)
+		{
+			var node = (DataNode)pos;
+			return node?.Parent;
+		}
+
+		public object GetValue (TreePosition pos, int column)
+		{
+			var node = (DataNode)pos;
+			if (column == 0)
+				return node.Name;
+			if (column == 1)
+				return node.Image;
+			return null;
+		}
+
+		public void SetValue (TreePosition pos, int column, object value)
+		{
+			var node = (DataNode)pos;
+			if (column == 0)
+				node.Name = (string) value;
+			if (column == 1)
+				node.Image = (Image) value;
+		}
+
+		void IEventSink.NotifyNodeAdded (DataNode node, int index)
+		{
+			NodeInserted?.Invoke (this, new TreeNodeEventArgs (node, index));
+		}
+
+		void IEventSink.NotifyNodeChanged (DataNode node, int index)
+		{
+			NodeChanged?.Invoke (this, new TreeNodeEventArgs (node, index));
+		}
+
+		void IEventSink.NotifyNodeRemoved (TreePosition parent, int childIndex, TreePosition child)
+		{
+			NodeDeleted?.Invoke (this, new TreeNodeChildEventArgs (parent, childIndex, child));
+		}
+	}
+}

--- a/Testing/MacTestRunner.csproj
+++ b/Testing/MacTestRunner.csproj
@@ -29,6 +29,9 @@
     <CreatePackage>False</CreatePackage>
     <UseRefCounting>false</UseRefCounting>
     <Profiling>false</Profiling>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <LinkMode>None</LinkMode>
+    <AOTMode>None</AOTMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -47,6 +50,8 @@
     <UseRefCounting>false</UseRefCounting>
     <Profiling>false</Profiling>
     <DebugSymbols>true</DebugSymbols>
+    <HttpClientHandler>HttpClientHandler</HttpClientHandler>
+    <AOTMode>None</AOTMode>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Xwt.Gtk/Xwt.GtkBackend/CustomTreeModel.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/CustomTreeModel.cs
@@ -33,15 +33,25 @@ using TreeModelImplementor = Gtk.ITreeModelImplementor;
 
 namespace Xwt.GtkBackend
 {
-	public class CustomTreeModel: TreeModelImplementor
+	public class CustomTreeModel: GLib.Object, TreeModelImplementor
 	{
 
 		ITreeDataSource source;
-        Dictionary<GCHandle,TreePosition> nodeHash = new Dictionary<GCHandle,TreePosition> ();
-        Dictionary<TreePosition,GCHandle> handleHash = new Dictionary<TreePosition,GCHandle> ();
+		Dictionary<TreePosition,NodeData> handleHash = new Dictionary<TreePosition,NodeData> ();
 		Type[] colTypes;
 		Gtk.TreeModelAdapter adapter;
-		
+		int stamp;
+
+		/// <summary>
+		/// Stores information about the index of a noda and the GCHandle
+		/// used by the native reference
+		/// </summary>
+		class NodeData
+		{
+			public GCHandle Handle;
+			public int Index;
+		}
+
 		public CustomTreeModel (ITreeDataSource source)
 		{
 			this.source = source;
@@ -57,55 +67,123 @@ namespace Xwt.GtkBackend
 		public Gtk.TreeModelAdapter Store {
 			get { return adapter; }
 		}
-		
-		public IntPtr Handle {
-			get {
-				return IntPtr.Zero;
-			}
-		}
-		
-        Gtk.TreeIter IterFromNode (TreePosition node)
+
+		public Gtk.TreeIter IterFromNode (TreePosition node, int index = -1)
 		{
-			GCHandle gch;
-			if (!handleHash.TryGetValue (node, out gch)) {
-				gch = GCHandle.Alloc (node);
-				handleHash [node] = gch;
-				nodeHash [gch] = node;
+			// The returned iter will have a reference to the TreePosition
+			// through a GCHandle. At the same time we store a NodeData
+			// object to a hashtable, which contains the GCHandle and
+			// the index of the node
+
+			NodeData data;
+			if (!handleHash.TryGetValue (node, out data)) {
+				// It is the first time the node is referenced.
+				// Store it in handleHash.
+				handleHash [node] = data = new NodeData {
+					Handle = GCHandle.Alloc (node),
+					Index = index
+				};
 			}
+
+			// If the index of the node changed, update it in its NodeData
+			if (index != -1 && index != data.Index)
+				data.Index = index;
+
 			Gtk.TreeIter result = Gtk.TreeIter.Zero;
-			result.UserData = (IntPtr)gch;
+			result.UserData = (IntPtr)data.Handle;
+			result.Stamp = stamp;
 			return result;
 		}
-		
-		TreePosition NodeFromIter (Gtk.TreeIter iter)
+
+		int GetCachedIndex (TreePosition node)
 		{
-			TreePosition node;
-			GCHandle gch = (GCHandle)iter.UserData;
-			nodeHash.TryGetValue (gch, out node);
-			return node;
+			// Gets the index of a node, or -1 if that information is not available
+			NodeData data;
+			if (handleHash.TryGetValue (node, out data))
+				return data.Index;
+			return -1;
 		}
 		
+		void CacheIndex (TreePosition node, int index)
+		{
+			// Stores the index of a node
+			if (handleHash.TryGetValue (node, out var data))
+				data.Index = index;
+		}
+		
+		public bool NodeFromIter (Gtk.TreeIter iter, out TreePosition pos)
+		{
+			if (iter.UserData == IntPtr.Zero) {
+				pos = null;
+				return true;
+			}
+			if (iter.Stamp != stamp) {
+				// The iter has been invalidated
+				pos = null;
+				return false;
+			}
+			GCHandle gch = GCHandle.FromIntPtr (iter.UserData);
+			pos = (TreePosition) gch.Target;
+			return true;
+		}
+
 		#region TreeModelImplementor implementation
 
 		void HandleNodesReordered (object sender, TreeNodeOrderEventArgs e)
 		{
-			Gtk.TreeIter it = IterFromNode (e.Node);
-			adapter.EmitRowsReordered (GetPath (it), it, e.ChildrenOrder);
+			// Don't increase the stamp because no nodes have been removed, so all iters are still valid
+			// Update the cached indexes for all the children that have chanfed
+			for (int n = 0; n < e.ChildrenOrder.Length; n++) {
+				if (e.ChildrenOrder [n] != n) {
+					var child = source.GetChild (e.Node, n);
+					if (child != null)
+						CacheIndex (child, n);
+				}
+			} 
+			adapter.EmitRowsReordered (GetPath (e.Node), IterFromNode (e.Node), e.ChildrenOrder);
 		}
 
 		void HandleNodeInserted (object sender, TreeNodeEventArgs e)
 		{
-			Gtk.TreeIter it = IterFromNode (e.Node);
-			adapter.EmitRowInserted (GetPath (it), it);
+			// Don't increase the stamp because no nodes have been removed, so all iters are still valid
+			// Update the cached indexes
+			var parent = source.GetParent (e.Node);
+			var count = source.GetChildrenCount (parent);
+			for (int n = e.ChildIndex + 1; n < count; n++) {
+				var child = source.GetChild (parent, n);
+				if (child != null)
+					CacheIndex (child, n);
+			} 
+			var iter = IterFromNode (e.Node, e.ChildIndex);
+			adapter.EmitRowInserted (GetPath (e.Node), iter);
 		}
 
 		void HandleNodeDeleted (object sender, TreeNodeChildEventArgs e)
 		{
+			if (e.Node != null && !handleHash.ContainsKey (e.Node))
+				return;
+
+			if (e.Child != null && handleHash.TryGetValue (e.Child, out var data)) {
+				// Increase the model stamp since the node is gone and there may
+				// be iters referencing that node. Increasing the stamp will
+				// invalidate all those nodes
+				stamp++;
+				data.Handle.Free ();
+				handleHash.Remove (e.Child);
+
+				// Update the indexes of the node following the deleted one
+				var count = source.GetChildrenCount (e.Node);
+				for (int n = e.ChildIndex; n < count; n++) {
+					var child = source.GetChild (e.Node, n);
+					if (child != null)
+						CacheIndex (child, n);
+				}
+			}
+
 			if (e.Node == null) {
 				adapter.EmitRowDeleted (new Gtk.TreePath (new int[] { e.ChildIndex }));
 			} else {
-				Gtk.TreeIter it = IterFromNode (e.Node);
-				var p = GetPath (it);
+				var p = GetPath (e.Node);
 				int[] idx = new int [p.Indices.Length + 1];
 				p.Indices.CopyTo (idx, 0);
 				idx [idx.Length - 1] = e.ChildIndex;
@@ -115,8 +193,8 @@ namespace Xwt.GtkBackend
 
 		void HandleNodeChanged (object sender, TreeNodeEventArgs e)
 		{
-			Gtk.TreeIter it = IterFromNode (e.Node);
-			adapter.EmitRowChanged (GetPath (it), it);
+			if (handleHash.ContainsKey (e.Node))
+				adapter.EmitRowChanged (GetPath (e.Node), IterFromNode (e.Node));
 		}
 		
 		public GLib.GType GetColumnType (int index)
@@ -136,13 +214,19 @@ namespace Xwt.GtkBackend
 				if (pos == null)
 					return false;
 			}
-			iter = IterFromNode (pos);
+			iter = IterFromNode (pos, indices[indices.Length - 1]);
 			return true;
 		}
 
 		public Gtk.TreePath GetPath (Gtk.TreeIter iter)
 		{
-			TreePosition pos = NodeFromIter (iter);
+			if (NodeFromIter (iter, out var pos))
+				return GetPath (pos);
+			return Gtk.TreePath.NewFirst ();
+		}
+		
+		public Gtk.TreePath GetPath (TreePosition pos)
+		{
 			List<int> idx = new List<int> ();
 			while (pos != null) {
 				var parent = source.GetParent (pos);
@@ -155,34 +239,47 @@ namespace Xwt.GtkBackend
 		
 		int GetIndex (TreePosition parent, TreePosition pos)
 		{
+			var res = GetCachedIndex (pos);
+			if (res != -1)
+				return res;
+
 			int n = 0;
 			do {
 				var c = source.GetChild (parent, n);
 				if (c == null)
 					return -1;
-				if (c == pos || c.Equals(pos))
+				if (c == pos || c.Equals (pos)) {
+					CacheIndex (pos, n);
 					return n;
+				}
 				n++;
 			} while (true);
 		}
 
 		public void GetValue (Gtk.TreeIter iter, int column, ref GLib.Value value)
 		{
-			TreePosition pos = NodeFromIter (iter);
+			if (!NodeFromIter (iter, out var pos)) {
+				value = GLib.Value.Empty;
+				return;
+			}
 			var v = source.GetValue (pos, column);
-			value = new GLib.Value (v);
+			if (v == null)
+				value = GLib.Value.Empty;
+			else
+				value = new GLib.Value (v);
 		}
 
 		public bool IterNext (ref Gtk.TreeIter iter)
 		{
-			TreePosition pos = NodeFromIter (iter);
+			if (!NodeFromIter (iter, out var pos))
+				return false;
 			TreePosition parent = source.GetParent (pos);
 			int i = GetIndex (parent, pos);
-			if (source.GetChildrenCount (parent) >= i)
+			if (i == -1)
 				return false;
 			pos = source.GetChild (parent, i + 1);
 			if (pos != null) {
-				iter = IterFromNode (pos);
+				iter = IterFromNode (pos, i + 1);
 				return true;
 			} else
 				return false;
@@ -191,12 +288,13 @@ namespace Xwt.GtkBackend
 		#if XWT_GTK3
 		public bool IterPrevious (ref Gtk.TreeIter iter)
 		{
-			TreePosition pos = NodeFromIter (iter);
+			if (!NodeFromIter (iter, out var pos))
+				return false;
 			TreePosition parent = source.GetParent (pos);
 			int i = GetIndex (parent, pos);
 			pos = source.GetChild (parent, i - 1);
 			if (pos != null) {
-				iter = IterFromNode (pos);
+				iter = IterFromNode (pos, i - 1);
 				return true;
 			} else
 				return false;
@@ -205,11 +303,12 @@ namespace Xwt.GtkBackend
 
 		public bool IterChildren (out Gtk.TreeIter iter, Gtk.TreeIter parent)
         {
-            iter = Gtk.TreeIter.Zero;
-			TreePosition pos = NodeFromIter (parent);
+			iter = parent;
+			if (!NodeFromIter (parent, out var pos))
+				return false;
 			pos = source.GetChild (pos, 0);
 			if (pos != null) {
-				iter = IterFromNode (pos);
+				iter = IterFromNode (pos, 0);
 				return true;
 			} else
 				return false;
@@ -217,23 +316,26 @@ namespace Xwt.GtkBackend
 
 		public bool IterHasChild (Gtk.TreeIter iter)
 		{
-			TreePosition pos = NodeFromIter (iter);
+			if (!NodeFromIter (iter, out var pos))
+				return false;
 			return source.GetChildrenCount (pos) != 0;
 		}
 
 		public int IterNChildren (Gtk.TreeIter iter)
 		{
-			TreePosition pos = NodeFromIter (iter);
+			if (!NodeFromIter (iter, out var pos))
+				return 0;
 			return source.GetChildrenCount (pos);
 		}
 
 		public bool IterNthChild (out Gtk.TreeIter iter, Gtk.TreeIter parent, int n)
         {
-            iter = Gtk.TreeIter.Zero;
-			TreePosition pos = NodeFromIter (parent);
+			iter = parent;
+			if (!NodeFromIter (parent, out var pos))
+				return false;
 			pos = source.GetChild (pos, n);
 			if (pos != null) {
-				iter = IterFromNode (pos);
+				iter = IterFromNode (pos, n);
 				return true;
 			} else
 				return false;
@@ -241,9 +343,11 @@ namespace Xwt.GtkBackend
 
 		public bool IterParent (out Gtk.TreeIter iter, Gtk.TreeIter child)
         {
-            iter = Gtk.TreeIter.Zero;
-			TreePosition pos = NodeFromIter (iter);
-			pos = source.GetParent (pos);
+			iter = child;
+			if (!NodeFromIter (iter, out var pos))
+				return false;
+			if (pos != null)
+				pos = source.GetParent (pos);
 			if (pos != null) {
 				iter = IterFromNode (pos);
 				return true;

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
@@ -212,7 +212,7 @@ namespace Xwt.GtkBackend
 			IterPos tpos = GetIterPos (pos);
 			Gtk.TreeIter it = tpos.Iter;
 			var delPath = Tree.GetPath (it);
-			var eventArgs = new TreeNodeChildEventArgs (GetParent (tpos), delPath.Indices[delPath.Indices.Length - 1]);
+			var eventArgs = new TreeNodeChildEventArgs (GetParent (tpos), delPath.Indices[delPath.Indices.Length - 1], pos);
 			Tree.Remove (ref it);
 			if (NodeDeleted != null)
 				NodeDeleted (this, eventArgs);

--- a/Xwt/Xwt/DataField.cs
+++ b/Xwt/Xwt/DataField.cs
@@ -50,6 +50,11 @@ namespace Xwt
 			Index = -1;
 		}
 		
+		public DataField (int index)
+		{
+			Index = index;
+		}
+		
 		public int Index { get; private set; }
 
 		void IDataFieldInternal.SetIndex (int index)

--- a/Xwt/Xwt/ITreeDataSource.cs
+++ b/Xwt/Xwt/ITreeDataSource.cs
@@ -48,12 +48,22 @@ namespace Xwt
 	
 	public class TreeNodeEventArgs: EventArgs
 	{
-		public TreeNodeEventArgs (TreePosition node)
+		public TreeNodeEventArgs (TreePosition node): this (node, -1)
+		{
+		}
+
+		public TreeNodeEventArgs (TreePosition node, int childIndex)
 		{
 			Node = node;
+			ChildIndex = childIndex;
 		}
 		
 		public TreePosition Node {
+			get;
+			private set;
+		}
+
+		public int ChildIndex {
 			get;
 			private set;
 		}
@@ -61,12 +71,19 @@ namespace Xwt
 	
 	public class TreeNodeChildEventArgs: TreeNodeEventArgs
 	{
-		public TreeNodeChildEventArgs (TreePosition parent, int childIndex): base (parent)
+		[Obsolete ("Use the constructor that takes the child object")]
+		public TreeNodeChildEventArgs (TreePosition parent, int childIndex): base (parent, childIndex)
 		{
-			ChildIndex = childIndex;
+		}
+
+#pragma warning disable CS0618 // Type or member is obsolete
+		public TreeNodeChildEventArgs (TreePosition parent, int childIndex, TreePosition child): this (parent, childIndex)
+#pragma warning restore CS0618 // Type or member is obsolete
+		{
+			Child = child;
 		}
 		
-		public int ChildIndex {
+		public TreePosition Child {
 			get;
 			private set;
 		}
@@ -74,7 +91,7 @@ namespace Xwt
 	
 	public class TreeNodeOrderEventArgs: TreeNodeEventArgs
 	{
-		public TreeNodeOrderEventArgs (TreePosition parentNode, int[] childrenOrder): base (parentNode)
+		public TreeNodeOrderEventArgs (TreePosition parentNode, int[] childrenOrder): base (parentNode, -1)
 		{
 			ChildrenOrder = childrenOrder;
 		}

--- a/Xwt/Xwt/TreeStore.cs
+++ b/Xwt/Xwt/TreeStore.cs
@@ -288,7 +288,7 @@ namespace Xwt
 			}
 			node.Data [column] = value;
 			if (NodeChanged != null)
-				NodeChanged (this, new TreeNodeEventArgs (pos));
+				NodeChanged (this, new TreeNodeEventArgs (pos, n.NodeIndex));
 		}
 
 		public object GetValue (TreePosition pos, int column)
@@ -359,7 +359,7 @@ namespace Xwt
 			
 			var node = new NodePosition () { ParentList = np.ParentList, NodeId = nn.NodeId, NodeIndex = np.NodeIndex - 1, StoreVersion = version };
 			if (NodeInserted != null)
-				NodeInserted (this, new TreeNodeEventArgs (node));
+				NodeInserted (this, new TreeNodeEventArgs (node, node.NodeIndex));
 			return node;
 		}
 
@@ -377,7 +377,7 @@ namespace Xwt
 			
 			var node = new NodePosition () { ParentList = np.ParentList, NodeId = nn.NodeId, NodeIndex = np.NodeIndex + 1, StoreVersion = version };
 			if (NodeInserted != null)
-				NodeInserted (this, new TreeNodeEventArgs (node));
+				NodeInserted (this, new TreeNodeEventArgs (node, node.NodeIndex));
 			return node;
 		}
 		
@@ -410,7 +410,7 @@ namespace Xwt
 			
 			var node = new NodePosition () { ParentList = list, NodeId = nn.NodeId, NodeIndex = list.Count - 1, StoreVersion = version };
 			if (NodeInserted != null)
-				NodeInserted (this, new TreeNodeEventArgs (node));
+				NodeInserted (this, new TreeNodeEventArgs (node, node.NodeIndex));
 			return node;
 		}
 		
@@ -422,7 +422,7 @@ namespace Xwt
 			var index = np.NodeIndex;
 			version++;
 			if (NodeDeleted != null)
-				NodeDeleted (this, new TreeNodeChildEventArgs (parent, index));
+				NodeDeleted (this, new TreeNodeChildEventArgs (parent, index, pos));
 		}
 		
 		public TreePosition GetParent (TreePosition pos)


### PR DESCRIPTION
The fix implements caching of indexes, to avoid scanning child lists every
time an index is required.

Fixed Gtk.TreeViewBacked, which didn't support custom TreePosition
implementations.

Added new sample.