### PR TITLE
 Add ITreeDataSource.Cleared event 

### DIFF
--- a/TestApps/Samples/Samples/TreeViewCustomStore.cs
+++ b/TestApps/Samples/Samples/TreeViewCustomStore.cs
@@ -225,6 +225,7 @@ namespace Samples
 		public event EventHandler<TreeNodeChildEventArgs> NodeDeleted;
 		public event EventHandler<TreeNodeEventArgs> NodeChanged;
 		public event EventHandler<TreeNodeOrderEventArgs> NodesReordered;
+		public event EventHandler Cleared;
 
 		public void Add (DataNode node)
 		{

--- a/TestApps/Samples/Samples/TreeViews.cs
+++ b/TestApps/Samples/Samples/TreeViews.cs
@@ -218,6 +218,12 @@ namespace Samples
 			};
 			PackStart (removeButton);
 
+			Button clearButton = new Button("Clear");
+			clearButton.Clicked += delegate (object sender, EventArgs e) {
+				store.Clear();
+			};
+			PackStart(clearButton);
+
 			var label = new Label ();
 			PackStart (label);
 

--- a/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeStoreBackend.cs
@@ -71,6 +71,7 @@ namespace Xwt.GtkBackend
 		public event EventHandler<TreeNodeChildEventArgs> NodeDeleted;
 		public event EventHandler<TreeNodeEventArgs> NodeChanged;
 		public event EventHandler<TreeNodeOrderEventArgs> NodesReordered;
+		public event EventHandler Cleared;
 		
 		IterPos GetIterPos (TreePosition pos)
 		{
@@ -86,6 +87,8 @@ namespace Xwt.GtkBackend
 		{
 			version++;
 			Tree.Clear ();
+			if (Cleared != null)
+				Cleared (this, EventArgs.Empty);
 		}
 
 		public TreePosition GetChild (TreePosition pos, int index)

--- a/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
@@ -49,6 +49,7 @@ namespace Xwt.WPFBackend
 		public event EventHandler<TreeNodeChildEventArgs> NodeDeleted;
 		public event EventHandler<TreeNodeEventArgs> NodeChanged;
 		public event EventHandler<TreeNodeOrderEventArgs> NodesReordered;
+		public event EventHandler Cleared;
 
 		public Type[] ColumnTypes
 		{
@@ -181,6 +182,7 @@ namespace Xwt.WPFBackend
 		public void Clear ()
 		{
 			this.topNodes.Clear();
+			Cleared?.Invoke(this, EventArgs.Empty);
 		}
 
 		public IEnumerator GetEnumerator ()

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -150,6 +150,7 @@ namespace Xwt.Mac
 				UpdateRowHeight (item);
 			};
 			source.NodesReordered += (sender, e) => Tree.ReloadItem (tsource.GetItem (e.Node), true);
+			source.Cleared += (sender, e) => Tree.ReloadData ();
 		}
 		
 		public override object GetValue (object pos, int nField)

--- a/Xwt/Xwt/ITreeDataSource.cs
+++ b/Xwt/Xwt/ITreeDataSource.cs
@@ -44,6 +44,7 @@ namespace Xwt
 		event EventHandler<TreeNodeChildEventArgs> NodeDeleted;
 		event EventHandler<TreeNodeEventArgs> NodeChanged;
 		event EventHandler<TreeNodeOrderEventArgs> NodesReordered;
+		event EventHandler Cleared;
 	}
 	
 	public class TreeNodeEventArgs: EventArgs

--- a/Xwt/Xwt/TreeStore.cs
+++ b/Xwt/Xwt/TreeStore.cs
@@ -167,6 +167,11 @@ namespace Xwt
 			add { Backend.NodesReordered += value; }
 			remove { Backend.NodesReordered -= value; }
 		}
+		event EventHandler ITreeDataSource.Cleared
+		{
+			add { Backend.Cleared += value; }
+			remove { Backend.Cleared -= value; }
+		}
 		
 		TreePosition ITreeDataSource.GetChild (TreePosition pos, int index)
 		{
@@ -243,6 +248,7 @@ namespace Xwt
 		public event EventHandler<TreeNodeChildEventArgs> NodeDeleted;
 		public event EventHandler<TreeNodeEventArgs> NodeChanged;
 		public event EventHandler<TreeNodeOrderEventArgs> NodesReordered;
+		public event EventHandler Cleared;
 
 		public void InitializeBackend (object frontend, ApplicationContext context)
 		{
@@ -256,6 +262,8 @@ namespace Xwt
 		public void Clear ()
 		{
 			rootNodes.Clear ();
+			if (Cleared != null)
+				Cleared (this, EventArgs.Empty);
 		}
 		
 		NodePosition GetPosition (TreePosition pos)


### PR DESCRIPTION
This allows the MAC NSOutlineView backend to handle `TreeStore.Clear()` properly. Right now ITreeDataSource does not notify at all when it's being cleared. Especially for large trees removing each note using the `NodeRemoved` event would be really slow, and a `Cleared` event might be useful in other cases too.

EDIT: Bug: NSOutlineView tried to render removed nodes, since it never noticed that the tree has been cleared.