### PR TITLE
Add TreeView.AnimationsEnabled

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/TreeViewBackend.cs
@@ -204,6 +204,8 @@ namespace Xwt.GtkBackend
 				Widget.Model = b.Store;
 		}
 
+		public bool AnimationsEnabled { get; set; }
+
 		public TreePosition[] SelectedRows {
 			get {
 				var rows = Widget.Selection.GetSelectedRows ();

--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -162,6 +162,8 @@ namespace Xwt.WPFBackend
 			}
 		}
 
+		public bool AnimationsEnabled { get; set; }
+
 		public void SelectRow (TreePosition pos)
 		{
 			Tree.SelectedItems.Add (pos);

--- a/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
@@ -59,6 +59,12 @@ namespace Xwt.Mac
 			}
 		}
 
+		bool animationsEnabled = true;
+		public bool AnimationsEnabled {
+			get { return animationsEnabled; }
+			set { animationsEnabled = value; }
+		}
+
 		public override void AddColumn (NSTableColumn tableColumn)
 		{
 			base.AddColumn (tableColumn);
@@ -100,26 +106,48 @@ namespace Xwt.Mac
 
 		public override void ExpandItem (NSObject item)
 		{
+			BeginExpandCollapseAnimation ();
 			base.ExpandItem (item);
+			EndExpandCollapseAnimation ();
 			QueueColumnResize ();
 		}
 
 		public override void ExpandItem (NSObject item, bool expandChildren)
 		{
+			BeginExpandCollapseAnimation ();
 			base.ExpandItem (item, expandChildren);
+			EndExpandCollapseAnimation ();
 			QueueColumnResize ();
 		}
 
 		public override void CollapseItem (NSObject item)
 		{
+			BeginExpandCollapseAnimation ();
 			base.CollapseItem (item);
+			EndExpandCollapseAnimation ();
 			QueueColumnResize ();
 		}
 
 		public override void CollapseItem (NSObject item, bool collapseChildren)
 		{
+			BeginExpandCollapseAnimation ();
 			base.CollapseItem (item, collapseChildren);
+			EndExpandCollapseAnimation ();
 			QueueColumnResize ();
+		}
+
+		void BeginExpandCollapseAnimation ()
+		{
+			if (!AnimationsEnabled) {
+				NSAnimationContext.BeginGrouping ();
+				NSAnimationContext.CurrentContext.Duration = 0;
+			}
+		}
+
+		void EndExpandCollapseAnimation ()
+		{
+			if (!AnimationsEnabled)
+				NSAnimationContext.EndGrouping ();
 		}
 
 		public override void ReloadData ()

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -110,8 +110,8 @@ namespace Xwt.Mac
 			}
 		}
 		
-		NSOutlineView Tree {
-			get { return (NSOutlineView) Table; }
+		OutlineViewBackend Tree {
+			get { return (OutlineViewBackend) Table; }
 		}
 		
 		protected override NSTableView CreateView ()
@@ -119,6 +119,15 @@ namespace Xwt.Mac
 			var t = new OutlineViewBackend (EventSink, ApplicationContext);
 			t.Delegate = new TreeDelegate () { Backend = this };
 			return t;
+		}
+
+		public bool AnimationsEnabled {
+			get {
+				return Tree.AnimationsEnabled;
+			}
+			set {
+				Tree.AnimationsEnabled = value;
+			}
 		}
 		
 		protected override string SelectionChangeEventName {

--- a/Xwt/Xwt.Backends/ITreeViewBackend.cs
+++ b/Xwt/Xwt.Backends/ITreeViewBackend.cs
@@ -48,6 +48,7 @@ namespace Xwt.Backends
 		bool HeadersVisible { get; set; }
 		GridLines GridLinesVisible { get; set; }
 		bool UseAlternatingRowColors { get; set; }
+		bool AnimationsEnabled { get; set; }
 		
 		bool GetDropTargetRow (double x, double y, out RowDropPosition pos, out TreePosition nodePosition);
 

--- a/Xwt/Xwt/TreeView.cs
+++ b/Xwt/Xwt/TreeView.cs
@@ -214,6 +214,24 @@ namespace Xwt
 			get { return Backend.GridLinesVisible; }
 			set { Backend.GridLinesVisible = value; }
 		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether native animations are enabled.
+		/// </summary>
+		/// <value><c>true</c> if animations enabled; otherwise, <c>false</c>.</value>
+		/// <remarks>
+		/// This property controls native TreeView animations (like slow expanding collapsing rows)
+		/// only and is not related to <see cref="T:Xwt.Motion.Animation"/>.
+		/// </remarks>
+		public bool AnimationsEnabled
+		{
+			get {
+				return Backend.AnimationsEnabled;
+			}
+			set {
+				Backend.AnimationsEnabled = value;
+			}
+		}
 		
 		/// <summary>
 		/// Gets or sets the selection mode.


### PR DESCRIPTION
The new property allows the client to enable/disable native TreeView animations.
For now only the Mac Backend supports this preference and is able to disable the row expand/collapse animations. 