### PR TITLE
[WPF] Use Tree.BorderThickness instead of ScrollView.BorderThickness

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // TreeViewBackend.cs
 //
 // Author:
@@ -118,10 +118,10 @@ namespace Xwt.WPFBackend
 
 		public bool BorderVisible {
 			get {
-				return ScrollViewer.BorderThickness.Left != 0;
+				return Tree.BorderThickness.Left != 0;
 			}
 			set {
-				ScrollViewer.BorderThickness = value ? new Thickness (1) : new Thickness (0);
+				Tree.BorderThickness = value ? new Thickness (1) : new Thickness (0);
 			}
 		}
 


### PR DESCRIPTION
The implementation of the `ScrollViewer` property calls `VisualTreeHelper.GetChild`, which throws if you call it before the WPF widget internal template has been realized:

```
System.ArgumentOutOfRangeException: Specified index is out of range or child at index is null. Do not call this method if VisualChildrenCount returns zero, indicating that the Visual has no children.
Parameter name: index
Actual value was 0.
  Source=PresentationFramework
  StackTrace:
   at System.Windows.FrameworkElement.GetVisualChild(Int32 index) in f:\dd\wpf\src\Framework\System\Windows\FrameworkElement.cs:line 661
```

Setting `BorderThickness` on `Tree` fixes this and still has the desired effect.