### PR TITLE
Constrained CanvasCellView sizing

### DIFF
--- a/TestApps/Samples/Samples/TreeViewEvents.cs
+++ b/TestApps/Samples/Samples/TreeViewEvents.cs
@@ -115,7 +115,7 @@ namespace Samples
 			return status;
 		}
 
-		protected override Size OnGetRequiredSize ()
+		protected override Size OnGetRequiredSize (SizeConstraint widthConstraint)
 		{
 			var node = GetValue (NodeField);
 			var status = GetViewStatus (node);
@@ -124,11 +124,13 @@ namespace Samples
 			layout.Text = node.Text;
 			var textSize = layout.GetSize ();
 
+			var maxWidth = widthConstraint.IsConstrained ? widthConstraint.AvailableSize : status.LastRenderWidth;
+
 			// When in expanded mode, the height of the row depends on the width. Since we don't know the width,
 			// let's use the last width that was used for rendering.
 
-			if (status.Expanded && status.LastRenderWidth != 0 && layout.GetSize ().Width > status.LastRenderWidth) {
-				layout.Width = status.LastRenderWidth - addImage.Width - MoreLinkSpacing;
+			if (status.Expanded && maxWidth > 0 && textSize.Width > maxWidth) {
+				layout.Width = maxWidth - addImage.Width - MoreLinkSpacing;
 				textSize = layout.GetSize ();
 			}
 

--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRenderer.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRenderer.cs
@@ -156,8 +156,9 @@ namespace Xwt.GtkBackend
 		protected override void OnGetSize (Gtk.Widget widget, ref Gdk.Rectangle cell_area, out int x_offset, out int y_offset, out int width, out int height)
 		{
 			Size size = new Size ();
+			var widthConstraint = cell_area.Width > 0 ? SizeConstraint.WithSize(cell_area.Width) : SizeConstraint.Unconstrained;
 			CellView.ApplicationContext.InvokeUserCode (delegate {
-				size = CellView.GetRequiredSize ();
+				size = CellView.GetRequiredSize (widthConstraint);
 			});
 			width = (int) size.Width;
 			height = (int) size.Height;

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CanvasTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CanvasTableCell.cs
@@ -30,7 +30,7 @@ using Xwt.Backends;
 
 namespace Xwt.Mac
 {
-	class CanvasTableCell: NSView, ICellRenderer
+	class CanvasTableCell: NSView, ICanvasCellRenderer
 	{
 		NSTrackingArea trackingArea;
 
@@ -63,11 +63,20 @@ namespace Xwt.Mac
 			get {
 				var size = CGSize.Empty;
 				Frontend.ApplicationContext.InvokeUserCode (delegate {
-					var s = Frontend.GetRequiredSize ();
+					var s = Frontend.GetRequiredSize (SizeConstraint.Unconstrained);
 					size = new CGSize ((nfloat)s.Width, (nfloat)s.Height);
 				});
 				return size;
 			}
+		}
+
+		public Size GetRequiredSize(SizeConstraint widthConstraint)
+		{
+			var size = Size.Zero;
+			Frontend.ApplicationContext.InvokeUserCode (delegate {
+				size = Frontend.GetRequiredSize (widthConstraint);
+			});
+			return size;
 		}
 
 		public override void DrawRect (CGRect dirtyRect)

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -297,7 +297,8 @@ namespace Xwt.Mac
 			double x = 0;
 			foreach (var cellFrame in cellFrames) {
 				var width = cellFrame.Frame.Width;
-				var height = cellFrame.Cell.FittingSize.Height;
+				var canvas = cellFrame.Cell as ICanvasCellRenderer;
+				var height = (canvas != null) ? canvas.GetRequiredSize (SizeConstraint.WithSize (width)).Height : cellFrame.Cell.FittingSize.Height;
 				// y-align only if the cell has a valid height, otherwise we're just recalculating the required size
 				var y = cellSize.Height > 0 ? (cellSize.Height - height) / 2 : 0;
 				cellFrame.Frame = new CGRect (x, y, width, height);

--- a/Xwt.XamMac/Xwt.Mac.CellViews/ICellRenderer.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/ICellRenderer.cs
@@ -35,6 +35,11 @@ namespace Xwt.Mac
 		NSView CellView { get; }
 		void Fill ();
 	}
+
+	interface ICanvasCellRenderer : ICellRenderer
+	{
+		Size GetRequiredSize (SizeConstraint widthConstraint);
+	}
 	
 	interface ITablePosition
 	{

--- a/Xwt/Xwt.Backends/ICanvasCellViewFrontend.cs
+++ b/Xwt/Xwt.Backends/ICanvasCellViewFrontend.cs
@@ -33,7 +33,9 @@ namespace Xwt.Backends
 		ApplicationContext ApplicationContext { get; }
 		void Draw (object ctxBackend, Rectangle cellArea);
 		Rectangle GetDrawingAreaForBounds (Rectangle cellBounds);
+		[Obsolete("Use OnGetRequiredSize (SizeConstraint widthConstraint)")]
 		Size GetRequiredSize ();
+		Size GetRequiredSize (SizeConstraint widthConstraint);
 	}
 
 	public class CellViewStatus

--- a/Xwt/Xwt.Backends/ICanvasCellViewFrontend.cs
+++ b/Xwt/Xwt.Backends/ICanvasCellViewFrontend.cs
@@ -33,7 +33,7 @@ namespace Xwt.Backends
 		ApplicationContext ApplicationContext { get; }
 		void Draw (object ctxBackend, Rectangle cellArea);
 		Rectangle GetDrawingAreaForBounds (Rectangle cellBounds);
-		[Obsolete("Use OnGetRequiredSize (SizeConstraint widthConstraint)")]
+		[Obsolete("Use GetRequiredSize (SizeConstraint)")]
 		Size GetRequiredSize ();
 		Size GetRequiredSize (SizeConstraint widthConstraint);
 	}

--- a/Xwt/Xwt/CanvasCellView.cs
+++ b/Xwt/Xwt/CanvasCellView.cs
@@ -64,9 +64,17 @@ namespace Xwt
 			return cellBounds;
 		}
 
+		[Obsolete("Use OnGetRequiredSize (SizeConstraint widthConstraint)")]
 		protected virtual Size OnGetRequiredSize ()
 		{
 			return new Size ();
+		}
+
+		protected virtual Size OnGetRequiredSize (SizeConstraint widthConstraint)
+		{
+			#pragma warning disable 618
+			return OnGetRequiredSize ();
+			#pragma warning restore 618
 		}
 		
 		#region ICanvasCellRenderer implementation
@@ -86,7 +94,12 @@ namespace Xwt
 
 		Size ICanvasCellViewFrontend.GetRequiredSize ()
 		{
-			return OnGetRequiredSize ();
+			return OnGetRequiredSize (SizeConstraint.Unconstrained);
+		}
+
+		Size ICanvasCellViewFrontend.GetRequiredSize (SizeConstraint widthConstraint)
+		{
+			return OnGetRequiredSize (widthConstraint);
 		}
 
 		ApplicationContext ICanvasCellViewFrontend.ApplicationContext {


### PR DESCRIPTION
This adds a new `CanvasCellView.GetRequiredSize (SizeConstraint widthConstraint)` func for size calculation and deprecates `CanvasCellView.GetRequiredSize ()`.
The `widthConstraint` will be set to the available width inside the column and row, or be unconstrained to calculate a default desired size.

TODO: WPF support (still uses deprecated calc without constraint).