### PR TITLE
[Mac] Improve table row height calculation

### DIFF
--- a/Xwt.XamMac/Xwt.Mac.CellViews/CheckBoxTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CheckBoxTableCell.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 using System;
 using AppKit;
+using CoreGraphics;
 using Foundation;
 using Xwt.Backends;
 
@@ -112,6 +113,16 @@ namespace Xwt.Mac
 			[Export ("setBackgroundStyle:")]
 			set {
 				Cell.BackgroundStyle = value;
+			}
+		}
+
+		static CGSize defaultSize = CGSize.Empty;
+		public override CGSize FittingSize {
+			get {
+				// CheckBox has always the same size, measure it only once
+				if (defaultSize.IsEmpty)
+					defaultSize = base.FittingSize;
+				return defaultSize;
 			}
 		}
 

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -273,35 +273,34 @@ namespace Xwt.Mac
 			var cellFrames = new List<CellPos> (cells.Count);
 
 			// Get the natural size of each child
-			for (int i = 0; i < cells.Count; i++) {
-				if (!cells [i].Backend.Frontend.Visible)
+			foreach (var cell in cells) {
+				if (!cell.Backend.Frontend.Visible)
 					continue;
-				var cellPos = new CellPos { Cell = (NSView)cells[i], Frame = CGRect.Empty };
+				var cellPos = new CellPos { Cell = (NSView)cell, Frame = CGRect.Empty };
 				cellFrames.Add (cellPos);
-				var view = cellPos.Cell;
-				var size = view.FittingSize;
+				var size = cellPos.Cell.FittingSize;
 				cellPos.Frame.Width = size.Width;
 				requiredSize += size.Width;
-				if (((ICellRenderer)cellPos.Cell).Backend.Frontend.Expands)
+				if (cell.Backend.Frontend.Expands)
 					nexpands++;
 			}
 
 			double remaining = availableSize - requiredSize;
 			if (remaining > 0) {
 				var expandRemaining = new SizeSplitter (remaining, nexpands);
-				for (int i = 0; i < cellFrames.Count; i++) {
-					if (((ICellRenderer)cellFrames [i].Cell).Backend.Frontend.Expands)
-						cellFrames [i].Frame.Width += (nfloat)expandRemaining.NextSizePart ();
+				foreach (var cellFrame in cellFrames) {
+					if (((ICellRenderer)cellFrame.Cell).Backend.Frontend.Expands)
+						cellFrame.Frame.Width += (nfloat)expandRemaining.NextSizePart ();
 				}
 			}
 
 			double x = 0;
-			for (int i = 0; i < cellFrames.Count; i++) {
-				var width = cellFrames [i].Frame.Width;
-				var height = cellFrames [i].Cell.FittingSize.Height;
+			foreach (var cellFrame in cellFrames) {
+				var width = cellFrame.Frame.Width;
+				var height = cellFrame.Cell.FittingSize.Height;
 				// y-align only if the cell has a valid height, otherwise we're just recalculating the required size
 				var y = cellSize.Height > 0 ? (cellSize.Height - height) / 2 : 0;
-				cellFrames [i].Frame = new CGRect (x, y, width, height);
+				cellFrame.Frame = new CGRect (x, y, width, height);
 				x += width;
 			}
 			return cellFrames;

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -228,8 +228,6 @@ namespace Xwt.Mac
 					continue;
 				var c = (NSView)cell;
 				var s = c.FittingSize;
-				if (s.IsEmpty && SizeToFit (c))
-					s = c.Frame.Size;
 				w += s.Width;
 				if (s.Height > h)
 					h = s.Height;
@@ -265,17 +263,6 @@ namespace Xwt.Mac
 						cell.NeedsDisplay = true;
 			}
 		}
-
-		static readonly Selector sizeToFitSel = new Selector ("sizeToFit");
-
-		protected virtual bool SizeToFit (NSView view)
-		{
-			if (view.RespondsToSelector (sizeToFitSel)) {
-				Messaging.void_objc_msgSend (view.Handle, sizeToFitSel.Handle);
-				return true;
-			}
-			return false;
-		}
 		
 		List <CellPos> GetCells (CGSize cellSize)
 		{
@@ -293,8 +280,6 @@ namespace Xwt.Mac
 				cellFrames.Add (cellPos);
 				var view = cellPos.Cell;
 				var size = view.FittingSize;
-				if (size.IsEmpty && SizeToFit (view))
-					size = view.Frame.Size;
 				cellPos.Frame.Width = size.Width;
 				requiredSize += size.Width;
 				if (((ICellRenderer)cellPos.Cell).Backend.Frontend.Expands)

--- a/Xwt.XamMac/Xwt.Mac.CellViews/ImageTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/ImageTableCell.cs
@@ -26,6 +26,7 @@
 
 using System;
 using AppKit;
+using CoreGraphics;
 using Xwt.Backends;
 
 namespace Xwt.Mac
@@ -57,14 +58,13 @@ namespace Xwt.Mac
 		public override CoreGraphics.CGSize FittingSize {
 			get {
 				if (Image == null)
-					return base.FittingSize;
+					return CGSize.Empty;
 				return Image.Size;
 			}
 		}
 
 		public override void SizeToFit()
 		{
-			base.SizeToFit();
 			if (Frame.Size.IsEmpty && Image != null)
 				SetFrameSize (Image.Size);
 		}

--- a/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
@@ -26,6 +26,7 @@
 using System;
 using Xwt.Backends;
 using AppKit;
+using CoreGraphics;
 
 namespace Xwt.Mac
 {
@@ -70,6 +71,16 @@ namespace Xwt.Mac
 		public CompositeCell CellContainer { get; set; }
 
 		public NSView CellView { get { return this; } }
+
+		static CGSize defaultSize = CGSize.Empty;
+		public override CGSize FittingSize {
+			get {
+				// Radio NSButton has always the same size, measure it only once
+				if (defaultSize.IsEmpty)
+					defaultSize = base.FittingSize;
+				return defaultSize;
+			}
+		}
 
 		public void Fill ()
 		{

--- a/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
@@ -191,12 +191,12 @@ namespace Xwt.Mac
 
 			for (int i = 0; i < Columns.Count; i++) {
 				CompositeCell cell = tryReuse ? Table.GetView (i, row, false) as CompositeCell : null;
-				if (cell == null)
+				if (cell == null) {
 					cell = (Columns [i] as TableColumn)?.DataView as CompositeCell;
-
-				if (cell != null) {
 					cell.ObjectValue = NSNumber.FromNInt (row);
 					height = (nfloat)Math.Max (height, cell.FittingSize.Height);
+				} else {
+					height = (nfloat)Math.Max (height, cell.GetRequiredHeightForWidth (cell.Frame.Width));
 				}
 			}
 			updatingRowHeight = false;

--- a/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
@@ -128,6 +128,13 @@ namespace Xwt.Mac
 			QueueColumnResize ();
 		}
 
+		public override void NoteHeightOfRowsWithIndexesChanged(NSIndexSet indexSet)
+		{
+			BeginExpandCollapseAnimation();
+			base.NoteHeightOfRowsWithIndexesChanged(indexSet);
+			EndExpandCollapseAnimation();
+		}
+
 		void BeginExpandCollapseAnimation ()
 		{
 			if (!AnimationsEnabled) {

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -204,12 +204,12 @@ namespace Xwt.Mac
 
 			for (int i = 0; i < Columns.Count; i++) {
 				CompositeCell cell = tryReuse ? Tree.GetView (i, row, false) as CompositeCell : null;
-				if (cell == null)
+				if (cell == null) {
 					cell = (Columns [i] as TableColumn)?.DataView as CompositeCell;
-
-				if (cell != null) {
 					cell.ObjectValue = pos;
 					height = (nfloat)Math.Max (height, cell.FittingSize.Height);
+				} else {
+					height = (nfloat)Math.Max (height, cell.GetRequiredHeightForWidth (cell.Frame.Width));
 				}
 			}
 			updatingRowHeight = false;


### PR DESCRIPTION
This patch reduces the amount of required recalculations while resizing rows and fixes row reallocation when the NSTableView is being resized.