### PR TITLE
[Mac] Improve tree data source handling

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -389,10 +389,9 @@ namespace Xwt.Mac
 	class TreeSource: NSOutlineViewDataSource
 	{
 		ITreeDataSource source;
-		
-		// TODO: remove unused positions
+
 		Dictionary<TreePosition,TreeItem> items = new Dictionary<TreePosition, TreeItem> ();
-		
+
 		public TreeSource (ITreeDataSource source)
 		{
 			this.source = source;
@@ -400,6 +399,12 @@ namespace Xwt.Mac
 			source.NodeInserted += (sender, e) => {
 				if (!items.ContainsKey (e.Node))
 					items.Add (e.Node, new TreeItem { Position = e.Node });
+			};
+			source.NodeDeleted += (sender, e) => {
+				items.Remove (e.Child);
+			};
+			source.Cleared += (sender, e) => {
+				items.Clear ();
 			};
 		}
 		

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -80,9 +80,11 @@ namespace Xwt.Mac
 			public override NSView GetView (NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
 			{
 				var col = tableColumn as TableColumn;
-				var cell = outlineView.MakeView (tableColumn.Identifier, this);
+				var cell = outlineView.MakeView (tableColumn.Identifier, this) as CompositeCell;
 				if (cell == null)
 					cell = col.CreateNewView ();
+				if (cell.ObjectValue != item)
+					cell.ObjectValue = item;
 				return cell;
 			}
 

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -156,14 +156,23 @@ namespace Xwt.Mac
 			tsource = new TreeSource (source);
 			Tree.DataSource = tsource;
 
-			source.NodeInserted += (sender, e) => Tree.ReloadItem (tsource.GetItem (source.GetParent(e.Node)), true);
-			source.NodeDeleted += (sender, e) => Tree.ReloadItem (tsource.GetItem (e.Node), true);
+			source.NodeInserted += (sender, e) => {
+				var parent = tsource.GetItem (source.GetParent (e.Node));
+				Tree.ReloadItem (parent, parent == null || Tree.IsItemExpanded (parent));
+			};
+			source.NodeDeleted += (sender, e) => {
+				var parent = tsource.GetItem (e.Node);
+				Tree.ReloadItem (parent, parent == null || Tree.IsItemExpanded (parent));
+			};
 			source.NodeChanged += (sender, e) => {
 				var item = tsource.GetItem (e.Node);
 				Tree.ReloadItem (item, false);
 				UpdateRowHeight (item);
 			};
-			source.NodesReordered += (sender, e) => Tree.ReloadItem (tsource.GetItem (e.Node), true);
+			source.NodesReordered += (sender, e) => {
+				var parent = tsource.GetItem (e.Node);
+				Tree.ReloadItem (parent, parent == null || Tree.IsItemExpanded (parent));
+			};
 			source.Cleared += (sender, e) => Tree.ReloadData ();
 		}
 		

--- a/Xwt/Xwt/TreeStore.cs
+++ b/Xwt/Xwt/TreeStore.cs
@@ -424,6 +424,11 @@ namespace Xwt
 		
 		public void Remove (TreePosition pos)
 		{
+			// Remove all child nodes in reverse order and notify client of each removed child.
+			// This allows clients to keep track of all removed nodes, before the current node
+			// will be removed and invalidated.
+			for (int i = GetChildrenCount (pos) - 1; i >= 0 ; i--)
+				Remove (GetChild (pos, i));
 			NodePosition np = GetPosition (pos);
 			np.ParentList.RemoveAt (np.NodeIndex);
 			var parent = np.ParentList.Parent;


### PR DESCRIPTION
All tree nodes are added to a list in the custom `NSOutlineViewDataSource`, but we never remove them. This patch makes sure that we correctly release deleted tree nodes, however this approach has a small perf issue: the tree backend will reload all children of a deleted node, until the node itself is removed. Reloading only expanded nodes reduces the impact.

* `DefaultTreeStoreBackend`: remove nodes recursively in reverse order and notify the tree backend of each removed node
* Release removed nodes
* Reload node children only if the node is expanded