### PR TITLE
[A11y] Add ability to add native accessibility children to Xwt access…

### DIFF
--- a/Xwt.Gtk.Mac/GtkMacAccessibleBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacAccessibleBackend.cs
@@ -83,5 +83,25 @@ namespace Xwt.Gtk.Mac
 				nsa.AccessibilityUrl = new NSUrl (value.AbsoluteUri);
 			}
 		}
+
+		public override void AddChild(object childAccessible)
+		{
+			if (!(childAccessible is INSAccessibility)) {
+				throw new ArgumentException ("Not an INSAccessibility", nameof (childAccessible));
+			}
+
+			var nsa = GetNSAccessibilityElement (widget.Accessible);
+			if (nsa == null) {
+				return;
+			}
+
+			var accessibilityElement = nsa as NSAccessibilityElement;
+			var childElement = childAccessible as NSAccessibilityElement;
+			if (accessibilityElement != null && childElement != null) {
+				accessibilityElement.AccessibilityAddChildElement (childElement);
+			} else {
+				throw new NotSupportedException ();
+			}
+		}
 	}
 }

--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -146,6 +146,10 @@ namespace Xwt.GtkBackend
 
 		public virtual Uri Uri { get; set; }
 
+		public virtual void AddChild (object childAccessible)
+		{
+		}
+
 		public bool IsAccessible {
 			get {
 				return widget.Accessible?.Role != Atk.Role.Invalid;

--- a/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.Linq;
 using AppKit;
 using Foundation;
 using Xwt.Accessibility;
@@ -171,6 +172,19 @@ namespace Xwt.Mac
 			set {
 				widget.AccessibilityRoleDescription = value;
 			}
+		}
+
+		public void AddChild (object nativeAccessible)
+		{
+			var nativeObject = nativeAccessible as NSObject;
+
+			if (nativeObject == null) {
+				throw new ArgumentException ("Not NSObject", nameof (nativeAccessible));
+			}
+
+			var children = widget.AccessibilityChildren.ToList ();
+			children.Add (nativeObject);
+			widget.AccessibilityChildren = children.ToArray ();
 		}
 
 		public void EnableEvent (object eventId)

--- a/Xwt/Xwt.Accessibility/Accessible.cs
+++ b/Xwt/Xwt.Accessibility/Accessible.cs
@@ -244,5 +244,9 @@ namespace Xwt.Accessibility
 		public void InitializeBackend (object frontend, ApplicationContext context)
 		{
 		}
+
+		public void AddChild (object nativeAccessible)
+		{
+		}
 	}
 }

--- a/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
+++ b/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
@@ -53,6 +53,8 @@ namespace Xwt.Backends
 		Role Role { get; set; }
 
 		string RoleDescription { get; set; }
+
+		void AddChild (object accessible);
 	}
 
 	public interface IAccessibleEventSink


### PR DESCRIPTION
…ibles

Sometimes widgets need accessible children that aren't backed by individual
widgets, this allows them to be created natively and added to Xwt Widgets