### PR TITLE
 Fallback to using the WPF MainWindow if can't get parent window

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/Util.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/Util.cs
@@ -90,6 +90,21 @@ namespace Xwt.WPFBackend
 
 			return null;
 		}
+
+		/// <summary>
+		/// Get the the parent System.Windows.Window. If that fails for whatever reason (which can happen if the WPF
+		/// visual tree isn't rooted with a System.Windows.Window, like in the case where it's rooted in a WinForms
+		/// component), then fallback to returning the WPF MainWindow.
+		/// <param name="element">WPF element</param>
+		/// <returns>ancestor System.Windows.Window or MainWindow</returns>
+		public static System.Windows.Window GetParentOrMainWindow (this FrameworkElement element)
+		{
+			System.Windows.Window parentWindow = GetParentWindow (element);
+			if (parentWindow != null)
+				return parentWindow;
+
+			return System.Windows.Application.Current.MainWindow;
+		}
 	}
 
 	class XwtWin32Window : System.Windows.Forms.IWin32Window

--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -695,6 +695,11 @@ namespace Xwt.WPFBackend
 			return Widget.GetParentWindow ();
 		}
 
+		private SW.Window GetParentOrMainWindow ()
+		{
+			return Widget.GetParentOrMainWindow ();
+		}
+
 		public void DragStart (DragStartData data)
 		{
 			if (data.Data == null)
@@ -703,7 +708,7 @@ namespace Xwt.WPFBackend
 			DataObject dataObj = data.Data.ToDataObject();
 
 			if (data.ImageBackend != null) {
-				AdornedWindow = GetParentWindow ();
+				AdornedWindow = GetParentOrMainWindow ();
 				AdornedWindow.AllowDrop = true;
 
 				var e = (UIElement)AdornedWindow.Content;
@@ -870,7 +875,7 @@ namespace Xwt.WPFBackend
 		void WidgetDragOverHandler (object sender, System.Windows.DragEventArgs e)
 		{
 			if (Adorner != null) {
-				var w = GetParentWindow ();
+				var w = GetParentOrMainWindow ();
 				var v = (UIElement)w.Content;
 
 				if (w != AdornedWindow) {


### PR DESCRIPTION
This fixes two scenarios for the Android designer:
- When the designer is hosted in a _floating_ VS window,
  GetParentWindow returns null.
 - When the designer is hosted in the new XET tabbed editor control
   GetParentWindow returns null (since it's actually a WinForms
   component,   not WPF, that contains the designer)

In both cases, falling back to the WPF Application.Current.MainWindow
makes things work propertly.