### PR TITLE
[Mac] Improve CellView height recalculation

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -164,7 +164,9 @@ namespace Xwt.Mac
 			};
 			source.NodeDeleted += (sender, e) => {
 				var parent = tsource.GetItem (e.Node);
-				RowHeights.Remove (tsource.GetItem (e.Child));
+				var item = tsource.GetItem(e.Child);
+				if (item != null)
+					RowHeights.Remove (null);
 				Tree.ReloadItem (parent, parent == null || Tree.IsItemExpanded (parent));
 			};
 			source.NodeChanged += (sender, e) => {


### PR DESCRIPTION
Try to measure visible cells for row height recalculation to avoid populating the template cell with data to measure the required cell size.