### PR TITLE
[Mac] Cache cell width to improve size calculations

### DIFF
--- a/Xwt.XamMac/Xwt.Mac.CellViews/CellViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CellViewBackend.cs
@@ -90,7 +90,7 @@ namespace Xwt.Mac
 		public void QueueResize ()
 		{
 			CurrentCellView.NeedsDisplay = true;
-			((ICellRenderer)CurrentCellView).CellContainer.InvalidateRowHeight ();
+			((ICellRenderer)CurrentCellView).CellContainer.QueueResize ();
 		}
 
 		public Rectangle CellBounds {

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CompositeCell.cs
@@ -89,11 +89,11 @@ namespace Xwt.Mac
 		}
 
 		bool recalculatingHeight = false;
-		public void InvalidateRowHeight ()
+		public void QueueResize ()
 		{
 			if (tablePosition != null && !recalculatingHeight) {
 				recalculatingHeight = true;
-				source.InvalidateRowHeight (tablePosition.Position);
+				source.QueueResizeRow (tablePosition.Position);
 				recalculatingHeight = false;
 			}
 		}
@@ -193,7 +193,7 @@ namespace Xwt.Mac
 						height = Math.Max (height, c.Frame.Height);
 					}
 					if (Math.Abs(value.Height - height) > double.Epsilon)
-						InvalidateRowHeight ();
+						QueueResize ();
 					
 				}
 			}

--- a/Xwt.XamMac/Xwt.Mac.CellViews/ICellSource.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/ICellSource.cs
@@ -35,7 +35,7 @@ namespace Xwt.Mac
 		object GetValue (object pos, int nField);
 		void SetValue (object pos, int nField, object value);
 		void SetCurrentEventRow (object pos);
-		void InvalidateRowHeight (object pos);
+		void QueueResizeRow (object pos);
 		List<NSTableColumn> Columns { get; }
 		NSTableView TableView { get; }
 	}

--- a/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
@@ -213,7 +213,7 @@ namespace Xwt.Mac
 			};
 		}
 
-		public override void InvalidateRowHeight (object pos)
+		public override void QueueResizeRow (object pos)
 		{
 			UpdateRowHeight((int)pos);
 		}
@@ -223,7 +223,10 @@ namespace Xwt.Mac
 		{
 			if (updatingRowHeight)
 				return;
-			foreach (var colWidths in ColumnRowWidths)
+			
+			// FIXME: this won't resize the columns, which might be needed for custom cells
+			// In order to resize horizontally we'll need trigger column autosizing.
+			foreach (var colWidths in ColumnRowWidths) // invalidate widths for full recalculation
 				colWidths[(int)row] = -1;
 			RowHeights[(int)row] = CalcRowHeight (row);
 			Table.NoteHeightOfRowsWithIndexesChanged (NSIndexSet.FromIndex (row));

--- a/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ListViewBackend.cs
@@ -72,16 +72,25 @@ namespace Xwt.Mac
 			{
 				var tableColumn = Backend.Columns[(int)column] as TableColumn;
 				var width = tableColumn.HeaderCell.CellSize.Width;
+				var rowWidths = Backend.ColumnRowWidths[(int)column];
 
 				CompositeCell templateCell = null;
 				for (int i = 0; i < tableView.RowCount; i++) {
+					if (rowWidths[i] > -1)
+						width = (nfloat)Math.Max (width, rowWidths[i]);
+					else {
 					var cellView = tableView.GetView (column, i, false) as CompositeCell;
-					if (cellView == null) { // use template for invisible rows
-						cellView = templateCell ?? (templateCell = (tableColumn as TableColumn)?.DataView?.Copy () as CompositeCell);
-						if (cellView != null)
-							cellView.ObjectValue = NSNumber.FromInt32 (i);
+						if (cellView == null) { // use template for invisible rows
+							cellView = templateCell ?? (templateCell = (tableColumn as TableColumn)?.DataView as CompositeCell);
+							if (cellView != null)
+								cellView.ObjectValue = NSNumber.FromInt32 (i);
+						}
+						if (cellView != null) {
+							var size = cellView.FittingSize;
+							rowWidths[i] = size.Width;
+							width = (nfloat)Math.Max (width, size.Width);
+						}
 					}
-					width = (nfloat)Math.Max (width, cellView.FittingSize.Width);
 				}
 				return width;
 			}
@@ -94,6 +103,9 @@ namespace Xwt.Mac
 
 		IListDataSource source;
 		ListSource tsource;
+
+		List<List<nfloat>> ColumnRowWidths = new List<List<nfloat>> ();
+		List<nfloat> RowHeights = new List<nfloat> ();
 
 		protected override NSTableView CreateView ()
 		{
@@ -140,7 +152,25 @@ namespace Xwt.Mac
 				});
 			}
 		}
-		
+
+		public override NSTableColumn AddColumn (ListViewColumn col)
+		{
+			NSTableColumn tcol = base.AddColumn (col);
+			var widths = new List<nfloat> ();
+			if (Table.RowCount > 0)
+				widths.InsertRange (0, Enumerable.Repeat<nfloat> (-1f, (int)Table.RowCount));
+			ColumnRowWidths.Add (widths);
+			return tcol;
+		}
+
+		public override void RemoveColumn (ListViewColumn col, object handle)
+		{
+			var tcol = (NSTableColumn)handle;
+			var index = Columns.IndexOf (tcol);
+			ColumnRowWidths.RemoveAt (index);
+			base.RemoveColumn (col, handle);
+		}
+
 		public virtual void SetSource (IListDataSource source, IBackend sourceBackend)
 		{
 			this.source = source;
@@ -148,6 +178,10 @@ namespace Xwt.Mac
 			RowHeights = new List<nfloat> ();
 			for (int i = 0; i < source.RowCount; i++)
 				RowHeights.Add (-1);
+			foreach (var colWidths in ColumnRowWidths) {
+				colWidths.Clear ();
+				colWidths.AddRange (Enumerable.Repeat<nfloat> (-1, source.RowCount));
+			}
 
 			tsource = new ListSource (source);
 			Table.DataSource = tsource;
@@ -157,30 +191,40 @@ namespace Xwt.Mac
 			//      only the visible rows are reloaded.
 			source.RowInserted += (sender, e) => {
 				RowHeights.Insert (e.Row, -1);
+				foreach (var colWidths in ColumnRowWidths)
+					colWidths.Insert (e.Row, -1);
 				Table.ReloadData ();
 			};
 			source.RowDeleted += (sender, e) => {
 				RowHeights.RemoveAt (e.Row);
+				foreach (var colWidths in ColumnRowWidths)
+					colWidths.RemoveAt (e.Row);
 				Table.ReloadData ();
 			};
 			source.RowChanged += (sender, e) => {
 				UpdateRowHeight (e.Row);
 				Table.ReloadData (NSIndexSet.FromIndex (e.Row), NSIndexSet.FromNSRange (new NSRange (0, Table.ColumnCount)));
 			};
-			source.RowsReordered += (sender, e) => { RowHeights.Clear (); Table.ReloadData (); };
+			source.RowsReordered += (sender, e) => {
+				RowHeights.Clear ();
+				foreach (var colWidths in ColumnRowWidths)
+					colWidths.Clear ();
+				Table.ReloadData ();
+			};
 		}
 
 		public override void InvalidateRowHeight (object pos)
 		{
 			UpdateRowHeight((int)pos);
 		}
-		
-		List<nfloat> RowHeights = new List<nfloat> ();
+
 		bool updatingRowHeight;
 		public void UpdateRowHeight (nint row)
 		{
 			if (updatingRowHeight)
 				return;
+			foreach (var colWidths in ColumnRowWidths)
+				colWidths[(int)row] = -1;
 			RowHeights[(int)row] = CalcRowHeight (row);
 			Table.NoteHeightOfRowsWithIndexesChanged (NSIndexSet.FromIndex (row));
 		}

--- a/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
@@ -205,7 +205,7 @@ namespace Xwt.Mac
 			return AddColumn (col);
 		}
 		
-		public void RemoveColumn (ListViewColumn col, object handle)
+		public virtual void RemoveColumn (ListViewColumn col, object handle)
 		{
 			var tcol = (NSTableColumn)handle;
 			cols.Remove (tcol);

--- a/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TableViewBackend.cs
@@ -271,7 +271,7 @@ namespace Xwt.Mac
 
 		public abstract void SetCurrentEventRow (object pos);
 
-		public abstract void InvalidateRowHeight (object pos);
+		public abstract void QueueResizeRow (object pos);
 
 		public bool BorderVisible {
 			get { return scroll.BorderType == NSBorderType.BezelBorder;}

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -38,6 +38,9 @@ namespace Xwt.Mac
 		ITreeDataSource source;
 		TreeSource tsource;
 
+		List<Dictionary<TreePosition, nfloat>> ColumnRowWidths = new List<Dictionary<TreePosition, nfloat>> ();
+		Dictionary<TreeItem, nfloat> RowHeights = new Dictionary<TreeItem, nfloat> ();
+
 		class TreeDelegate: NSOutlineViewDelegate
 		{
 			public TreeViewBackend Backend;
@@ -95,17 +98,23 @@ namespace Xwt.Mac
 
 				CompositeCell templateCell = null;
 				for (int i = 0; i < outlineView.RowCount; i++) {
-					var cellView = outlineView.GetView (column, i, false) as CompositeCell;
-					if (cellView == null) { // use template for invisible rows
-						cellView = templateCell ?? (templateCell = (tableColumn as TableColumn)?.DataView?.Copy () as CompositeCell);
-						if (cellView != null)
-							cellView.ObjectValue = outlineView.ItemAtRow (i);
-					}
-					if (cellView != null) {
-						if (column == 0) // first column contains expanders
-							width = (nfloat)Math.Max (width, cellView.Frame.X + cellView.FittingSize.Width);
-						else
-							width = (nfloat)Math.Max (width, cellView.FittingSize.Width);
+					nfloat cellWidth;
+					var item = (TreeItem)outlineView.ItemAtRow (i);
+					if (Backend.ColumnRowWidths[(int)column].TryGetValue (item.Position, out cellWidth) && cellWidth > -1)
+						width = (nfloat)Math.Max (width, cellWidth);
+					else {
+						var cellView = outlineView.GetView (column, i, false) as CompositeCell;
+						if (cellView == null) { // use template for invisible rows
+							cellView = templateCell ?? (templateCell = (tableColumn as TableColumn)?.DataView as CompositeCell);
+							if (cellView != null)
+								cellView.ObjectValue = item;
+						}
+						if (cellView != null) {
+							// first column contains expanders
+							cellWidth = column == 0 ? cellView.Frame.X + cellView.FittingSize.Width : cellView.FittingSize.Width;
+							Backend.ColumnRowWidths[(int)column][item.Position] = cellWidth;
+							width = (nfloat)Math.Max (width, cellWidth);
+						}
 					}
 				}
 				return width;
@@ -148,7 +157,16 @@ namespace Xwt.Mac
 			NSTableColumn tcol = base.AddColumn (col);
 			if (Tree.OutlineTableColumn == null)
 				Tree.OutlineTableColumn = tcol;
+			ColumnRowWidths.Add (new Dictionary<TreePosition, nfloat> ());
 			return tcol;
+		}
+
+		public override void RemoveColumn (ListViewColumn col, object handle)
+		{
+			var tcol = (NSTableColumn)handle;
+			var index = Columns.IndexOf (tcol);
+			ColumnRowWidths.RemoveAt (index);
+			base.RemoveColumn (col, handle);
 		}
 		
 		public void SetSource (ITreeDataSource source, IBackend sourceBackend)
@@ -163,6 +181,8 @@ namespace Xwt.Mac
 				Tree.ReloadItem (parent, parent == null || Tree.IsItemExpanded (parent));
 			};
 			source.NodeDeleted += (sender, e) => {
+				foreach (var colWidths in ColumnRowWidths)
+					colWidths.Remove (e.Child);
 				var parent = tsource.GetItem (e.Node);
 				var item = tsource.GetItem(e.Child);
 				if (item != null)
@@ -173,17 +193,24 @@ namespace Xwt.Mac
 				var item = tsource.GetItem (e.Node);
 				if (item != null) {
 					Tree.ReloadItem (item, false);
+					foreach (var colWidths in ColumnRowWidths)
+						colWidths [e.Node] = -1;
 					UpdateRowHeight (item);
 				}
 			};
 			source.NodesReordered += (sender, e) => {
 				var parent = tsource.GetItem (e.Node);
+				foreach (var colWidths in ColumnRowWidths)
+					for (int i = 0; i < source.GetChildrenCount (e.Node); i++)
+						colWidths [source.GetChild (e.Node, i)] = -1;
 				Tree.ReloadItem (parent, parent == null || Tree.IsItemExpanded (parent));
 			};
 			source.Cleared += (sender, e) =>
 			{
 				Tree.ReloadData ();
 				RowHeights.Clear ();
+				foreach (var colWidths in ColumnRowWidths)
+					colWidths.Clear ();
 			};
 		}
 		
@@ -202,7 +229,6 @@ namespace Xwt.Mac
 			UpdateRowHeight (tsource.GetItem((TreePosition)pos));
 		}
 
-		Dictionary<TreeItem, nfloat> RowHeights = new Dictionary<TreeItem, nfloat> ();
 		bool updatingRowHeight;
 
 		void UpdateRowHeight (TreeItem pos)
@@ -213,6 +239,8 @@ namespace Xwt.Mac
 			if (row >= 0) {
 				// calculate new height now by reusing the visible cell to avoid using the template cell with unnecessary data reloads
 				// NOTE: cell reusing is not supported in Delegate.GetRowHeight and would require an other data reload to the template cell
+				foreach (var colWidths in ColumnRowWidths)
+					colWidths [pos.Position] = -1;
 				RowHeights[pos] = CalcRowHeight (pos);
 				Table.NoteHeightOfRowsWithIndexesChanged (NSIndexSet.FromIndex (row));
 			} else // Invalidate the height, to force recalculation in Delegate.GetRowHeight
@@ -226,13 +254,21 @@ namespace Xwt.Mac
 			var row = Tree.RowForItem (pos);
 
 			for (int i = 0; i < Columns.Count; i++) {
+				var col = (TableColumn)Columns [i];
 				CompositeCell cell = tryReuse && row >= 0 ? Tree.GetView (i, row, false) as CompositeCell : null;
 				if (cell == null) {
-					cell = (Columns [i] as TableColumn)?.DataView as CompositeCell;
+					cell = col.DataView;
 					cell.ObjectValue = pos;
 					height = (nfloat)Math.Max (height, cell.FittingSize.Height);
 				} else {
-					height = (nfloat)Math.Max (height, cell.GetRequiredHeightForWidth (cell.Frame.Width));
+					nfloat cellWidth = -1;
+					ColumnRowWidths [i].TryGetValue (pos.Position, out cellWidth);
+					if (cellWidth <= 0)
+						cellWidth = cell.Frame.Width;
+					if (cellWidth <= 0)
+						height = (nfloat)Math.Max (height, cell.FittingSize.Height);
+					else
+						height = (nfloat)Math.Max (height, cell.GetRequiredHeightForWidth (cellWidth));
 				}
 			}
 			updatingRowHeight = false;

--- a/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/TreeViewBackend.cs
@@ -224,7 +224,7 @@ namespace Xwt.Mac
 			source.SetValue ((TreePosition)pos, nField, value);
 		}
 
-		public override void InvalidateRowHeight (object pos)
+		public override void QueueResizeRow (object pos)
 		{
 			UpdateRowHeight (tsource.GetItem((TreePosition)pos));
 		}
@@ -237,9 +237,11 @@ namespace Xwt.Mac
 				return;
 			var row = Tree.RowForItem (pos);
 			if (row >= 0) {
-				// calculate new height now by reusing the visible cell to avoid using the template cell with unnecessary data reloads
+				// calculate new size now by reusing the visible cell to avoid using the template cell with unnecessary data reloads
 				// NOTE: cell reusing is not supported in Delegate.GetRowHeight and would require an other data reload to the template cell
-				foreach (var colWidths in ColumnRowWidths)
+				// FIXME: this won't resize the columns, which might be needed for custom cells
+				// In order to resize horizontally we'll need trigger column autosizing.
+				foreach (var colWidths in ColumnRowWidths) // invalidate widths for full recalculation
 					colWidths [pos.Position] = -1;
 				RowHeights[pos] = CalcRowHeight (pos);
 				Table.NoteHeightOfRowsWithIndexesChanged (NSIndexSet.FromIndex (row));


### PR DESCRIPTION
By caching the widths required to render each CompositeCell, the amount of required size calculations is reduced drastically. This also reduces the amount of drawing cycles and improves the overall speed and responsivness of lists/trees a lot.

**Limitation:** this adds caching only, but full cell resize is still not supported. A call to `QueueResize` will remeasure the cell and update the height required to render the cell with its current width. For a full resize we'll need to hook the column autosizing into the resizing process. 