### PR TITLE
Remove warning in gtk accessibility code

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -135,7 +135,6 @@ namespace Xwt.GtkBackend
 			}
 			set {
 				if (widget.Accessible is AtkValue) {
-					GLib.Value val = GLib.Value.Empty;
 					(widget.Accessible as AtkValue)?.SetCurrentValue (new GLib.Value (value));
 				} else if (widget.Accessible is AtkEditableText) {
 					var atkText = (widget.Accessible as AtkEditableText);


### PR DESCRIPTION
Found via https://github.com/mono/monodevelop/issues/4237
```
"/home/pi/sources/monodevelop/main/Main.sln" (default target) (1) ->
"/home/pi/sources/monodevelop/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.csproj" (default target) (5) ->
"/home/pi/sources/monodevelop/main/external/xwt/Xwt.Gtk/Xwt.Gtk.csproj" (default target) (9:2) ->
  Xwt.GtkBackend/AccessibleBackend.cs(138,17): error CS0219: Warning as Error: The variable `val' is assigned but its value is never used [/home/pi/sources/monodevelop/main/external/xwt/Xwt.Gtk/Xwt.Gtk.csproj]
```