### PR TITLE
Remove requires specific version for gtk

### DIFF
--- a/TestApps/GtkOnWindowsTest/GtkOnWindowsTest.csproj
+++ b/TestApps/GtkOnWindowsTest/GtkOnWindowsTest.csproj
@@ -33,9 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="pango-sharp, Version=2.4.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
+    <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f"/>
     <Reference Include="Mono.Posix" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes the build for linux where gtk# 3.0 is also installed on the system.