### PR TITLE
[Wpf] Don't skip the Measure step all the time

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
@@ -129,9 +129,8 @@ namespace Xwt.WPFBackend
 					if (force) {
 						// Don't recalculate the size unless a relayout is being forced
 						element.InvalidateMeasure ();
-						element.Measure (new SW.Size (r.Width, r.Height));
 					}
-					
+					element.Measure (new SW.Size (r.Width, r.Height));
 					element.Arrange (r.ToWpfRect ());
 				//	element.UpdateLayout ();
 				}


### PR DESCRIPTION
If we add something to the live tree it will have
an invalid measure and arrange. The first measure pass
will run as-expected.

If you remove and re-add the widget to the live tree
then it's measure and arrange will be invalidated, but
because we do not call 'ArrangeChildren (force = true)'
then we will never invoke the Measure for the children
again.

For the case of ListBox this means an implciit measure
will occur, which passes Inf,Inf as the size, which
means we lose scrollbars as it expands to fill all
that space.

This fixes the ExceptionPopover in the designers.