### PR TITLE
[Mac] Fixed `NRE` converting points from events.

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -559,7 +559,7 @@ namespace Xwt.Mac
 		public static CGPoint ConvertPointFromEvent(this NSView view, NSEvent theEvent)
 		{
 			var point = theEvent.LocationInWindow;
-			if (theEvent.WindowNumber != view.Window.WindowNumber)
+			if (view.Window != null && theEvent.WindowNumber != view.Window.WindowNumber)
 			{
 				point = theEvent.Window.ConvertBaseToScreen(point);
 				point = view.Window.ConvertScreenToBase(point);


### PR DESCRIPTION
a NSView without a Window will cause `ConvertPointFromEvent` to throw a `NRE`, in this case is better just skip the BaseToScreen conversion.