### PR TITLE
Fix so dialog button group ItemsControls aren't Focusable

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/DialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DialogBackend.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // DialogBackend.cs
 //
 // Author:
@@ -64,6 +64,10 @@ namespace Xwt.WPFBackend
 		public DialogBackend()
 		{
 			cmd = new DelegatedCommand<WpfDialogButton> (OnButtonClicked);
+
+			// Surprisingly, the ItemsControls are focusable by default; disable that to fix tab navigation
+			this.leftButtonContainer.Focusable = false;
+			this.rightButtonContainer.Focusable = false;
 
 			this.leftButtonContainer.ItemsPanel = leftPanelTemplate;
 			this.leftButtonContainer.ItemTemplateSelector = new DialogButtonTemplateSelector(ButtonStyle, cmd);


### PR DESCRIPTION
Previously, the WPF ItemControls for dialog button groups, used to
lay out the buttons, were Focusable. That's apparently the
default for ItemControls (for reasons I don't fully understand, as it's
not normally for other WPF container controls).

Anyway, this caused the problem that when tabbing thru the dialog
controls you can set the focus not just to the buttons
themselves but also to the ItemsControl that contains them.
So tab navigation in the dialogs was somewhat broken, with two extra
stops for the two groups. Setting Focusable to false fixes that.

This fixes:
https://devdiv.visualstudio.com/DevDiv/Xamarin%20Android%20Designer/_workitems/edit/601178
https://devdiv.visualstudio.com/DevDiv/Xamarin%20Android%20Designer/_workitems/edit/601174
https://devdiv.visualstudio.com/DevDiv/Xamarin%20Android%20Designer/_workitems/edit/601170