### PR TITLE
[WPF] Accessibility support

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -143,7 +143,7 @@ namespace Xwt.GtkBackend
 			}
 		}
 
-		public Widget LabeledBy {
+		public Widget LabelWidget {
 			set { /* Not supported */ }
 		}
 

--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -143,6 +143,10 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		public Widget LabeledBy {
+			set { /* Not supported */ }
+		}
+
 		public virtual Uri Uri { get; set; }
 
 		public bool IsAccessible {

--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -47,6 +47,8 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
+    <Reference Include="UIAutomationProvider" />
+    <Reference Include="UIAutomationTypes" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
@@ -51,8 +51,7 @@ namespace Xwt.WPFBackend
 
 		public void Initialize (IWidgetBackend parentWidget, IAccessibleEventSink eventSink)
 		{
-			var parent = parentWidget as WidgetBackend;
-			Initialize (parent.Widget, eventSink);
+			Initialize (parentWidget.NativeWidget, eventSink);
 		}
 
 		public void Initialize (object parentWidget, IAccessibleEventSink eventSink)

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
@@ -31,7 +31,7 @@ namespace Xwt.WPFBackend
 
 		public string Title { get; set; }
 		public string Value { get; set; }
-		public Role Role { get; set; }
+		public Role Role { get; set; } = Role.Custom;
 		public Uri Uri { get; set; }
 		public Rectangle Bounds { get; set; }
 		public string RoleDescription { get; set; }
@@ -71,6 +71,44 @@ namespace Xwt.WPFBackend
 
 		public void RemoveChild (object nativeChild)
 		{
+		}
+
+		public static AutomationControlType RoleToControlType (Role role)
+		{
+			switch (role) {
+			case Role.Button:
+			case Role.MenuButton:
+			case Role.ToggleButton:
+				return AutomationControlType.Button;
+			case Role.CheckBox:
+				return AutomationControlType.CheckBox;
+			case Role.RadioButton:
+			case Role.RadioGroup:
+				return AutomationControlType.RadioButton;
+			case Role.ComboBox:
+				return AutomationControlType.ComboBox;
+			case Role.List:
+				return AutomationControlType.List;
+			case Role.Popup:
+			case Role.ToolTip:
+				return AutomationControlType.ToolTip;
+			case Role.ToolBar:
+				return AutomationControlType.ToolBar;
+			case Role.Label:
+				return AutomationControlType.Text;
+			case Role.Link:
+				return AutomationControlType.Hyperlink;
+			case Role.Image:
+				return AutomationControlType.Image;
+			case Role.Cell:
+				return AutomationControlType.DataItem;
+			case Role.Table:
+				return AutomationControlType.Table;
+			case Role.Paned:
+				return AutomationControlType.Pane;
+			default:
+				return AutomationControlType.Custom;
+			}
 		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
@@ -30,7 +30,7 @@ namespace Xwt.WPFBackend
 			get { return AutomationProperties.GetHelpText (element); }
 			set { AutomationProperties.SetHelpText (element, value); }
 		}
-		public Widget LabeledBy {
+		public Widget LabelWidget {
 			set {
 				AutomationProperties.SetLabeledBy (element, (Toolkit.GetBackend (value) as WidgetBackend)?.Widget);
 			}

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
@@ -13,6 +13,8 @@ namespace Xwt.WPFBackend
 	class AccessibleBackend : IAccessibleBackend
 	{
 		UIElement element;
+		IAccessibleEventSink eventSink;
+		ApplicationContext context;
 
 		public bool IsAccessible { get; set; }
 
@@ -59,22 +61,41 @@ namespace Xwt.WPFBackend
 			this.element = parentWidget as UIElement;
 			if (element == null)
 				throw new ArgumentException ("Widget is not a UIElement");
+			this.eventSink = eventSink;
 		}
 
 		public void InitializeBackend (object frontend, ApplicationContext context)
 		{
+			this.context = context;
 		}
 
+		internal void PerformInvoke ()
+		{
+			context.InvokeUserCode (() => eventSink.OnPress ());
+		}
+
+		// The following child methods are only supported for Canvas based widgets
 		public void AddChild (object nativeChild)
 		{
+			var peer = nativeChild as AutomationPeer;
+			var canvas = element as CustomCanvas;
+			if (peer != null && canvas != null)
+				canvas.AutomationPeer?.AddChild (peer);
 		}
 
 		public void RemoveAllChildren ()
 		{
+			var canvas = element as CustomCanvas;
+			if (canvas != null)
+				canvas.AutomationPeer?.RemoveAllChildren ();
 		}
 
 		public void RemoveChild (object nativeChild)
 		{
+			var peer = nativeChild as AutomationPeer;
+			var canvas = element as CustomCanvas;
+			if (peer != null && canvas != null)
+				canvas.AutomationPeer?.RemoveChild (peer);
 		}
 
 		public static AutomationControlType RoleToControlType (Role role)

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
@@ -54,6 +54,9 @@ namespace Xwt.WPFBackend
 		public void Initialize (IWidgetBackend parentWidget, IAccessibleEventSink eventSink)
 		{
 			Initialize (parentWidget.NativeWidget, eventSink);
+			var wpfBackend = parentWidget as WidgetBackend;
+			if (wpfBackend != null)
+				wpfBackend.HasAccessibleObject = true;
 		}
 
 		public void Initialize (object parentWidget, IAccessibleEventSink eventSink)

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
@@ -108,8 +108,9 @@ namespace Xwt.WPFBackend
 			case Role.CheckBox:
 				return AutomationControlType.CheckBox;
 			case Role.RadioButton:
-			case Role.RadioGroup:
 				return AutomationControlType.RadioButton;
+			case Role.RadioGroup:
+				return AutomationControlType.Group;
 			case Role.ComboBox:
 				return AutomationControlType.ComboBox;
 			case Role.List:
@@ -128,7 +129,7 @@ namespace Xwt.WPFBackend
 			case Role.Cell:
 				return AutomationControlType.DataItem;
 			case Role.Table:
-				return AutomationControlType.Table;
+				return AutomationControlType.DataGrid;
 			case Role.Paned:
 				return AutomationControlType.Pane;
 			default:

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
@@ -28,6 +28,11 @@ namespace Xwt.WPFBackend
 			get { return AutomationProperties.GetHelpText (element); }
 			set { AutomationProperties.SetHelpText (element, value); }
 		}
+		public Widget LabeledBy {
+			set {
+				AutomationProperties.SetLabeledBy (element, (Toolkit.GetBackend (value) as WidgetBackend)?.Widget);
+			}
+		}
 
 		public string Title { get; set; }
 		public string Value { get; set; }

--- a/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
@@ -33,6 +33,7 @@ using SWC = System.Windows.Controls;
 
 using Xwt.Backends;
 using Xwt.Drawing;
+using System.Windows.Automation.Peers;
 
 namespace Xwt.WPFBackend
 {
@@ -134,6 +135,23 @@ namespace Xwt.WPFBackend
 					element.Arrange (r.ToWpfRect ());
 				//	element.UpdateLayout ();
 				}
+			}
+		}
+
+		protected override AutomationPeer OnCreateAutomationPeer ()
+		{
+			return new CustomPanelAutomationPeer (this);
+		}
+
+		class CustomPanelAutomationPeer : FrameworkElementAutomationPeer
+		{
+			public CustomPanelAutomationPeer (CustomPanel panel) : base (panel)
+			{
+			}
+
+			protected override AutomationControlType GetAutomationControlTypeCore ()
+			{
+				return AutomationControlType.Pane;
 			}
 		}
 	}

--- a/Xwt.WPF/Xwt.WPFBackend/CanvasBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/CanvasBackend.cs
@@ -130,29 +130,29 @@ namespace Xwt.WPFBackend
 			{
 			}
 
-			Xwt.Widget Frontend => ((CustomCanvas)Owner)?.backend?.Frontend;
+			CanvasBackend Backend => ((CustomCanvas)Owner)?.backend;
+			Xwt.Widget Frontend => Backend?.Frontend;
 			AccessibleBackend Accessible => (AccessibleBackend)Toolkit.GetBackend (Frontend.Accessible);
 
 			protected override AutomationControlType GetAutomationControlTypeCore ()
 			{
-				var frontend = Frontend;
-				if (frontend == null || !frontend.HasAccessible)
+				var backend = Backend;
+				if (backend == null || !backend.HasAccessibleObject)
 					return AutomationControlType.Custom;
-				var role = frontend.Accessible.Role;
+				var role = Frontend.Accessible.Role;
 				return AccessibleBackend.RoleToControlType (role);
 			}
 
 			public override object GetPattern (PatternInterface patternInterface)
 			{
-				if (patternInterface == PatternInterface.Invoke && Frontend.HasAccessible)
+				if (patternInterface == PatternInterface.Invoke && Backend.HasAccessibleObject)
 					return this;
 				return base.GetPattern (patternInterface);
 			}
 
 			public void Invoke ()
 			{
-				var frontend = Frontend;
-				if (frontend.HasAccessible)
+				if (Backend.HasAccessibleObject)
 					Accessible.PerformInvoke ();
 			}
 

--- a/Xwt.WPF/Xwt.WPFBackend/DropDownButton.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/DropDownButton.cs
@@ -25,8 +25,10 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls.Primitives;
 using SWC = System.Windows.Controls;
 
@@ -107,6 +109,24 @@ namespace Xwt.WPFBackend
 			{
 				get;
 				set;
+			}
+		}
+
+		protected override AutomationPeer OnCreateAutomationPeer ()
+		{
+			return new DropDownButtonAutomationPeer (this);
+		}
+
+		class DropDownButtonAutomationPeer : ToggleButtonAutomationPeer
+		{
+			public DropDownButtonAutomationPeer (DropDownButton owner) : base (owner)
+			{
+			}
+
+			// Don't go into the children of this element
+			protected override List<AutomationPeer> GetChildrenCore ()
+			{
+				return null;
 			}
 		}
 	}

--- a/Xwt.WPF/Xwt.WPFBackend/LabelBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/LabelBackend.cs
@@ -34,6 +34,7 @@ using SWM = System.Windows.Media;
 using SWD = System.Windows.Documents;
 
 using Xwt.Backends;
+using System.Windows.Automation.Peers;
 
 namespace Xwt.WPFBackend
 {
@@ -241,6 +242,28 @@ namespace Xwt.WPFBackend
 		public SWC.TextBlock TextBlock {
 			get;
 			set;
+		}
+
+		protected override AutomationPeer OnCreateAutomationPeer ()
+		{
+			return new WpfLabelAutomationPeer (this);
+		}
+
+		class WpfLabelAutomationPeer : LabelAutomationPeer
+		{
+			public WpfLabelAutomationPeer (WpfLabel owner) : base (owner)
+			{
+			}
+
+			protected override List<AutomationPeer> GetChildrenCore ()
+			{
+				return null;
+			}
+
+			protected override string GetNameCore ()
+			{
+				return ((WpfLabel)Owner).TextBlock.Text;
+			}
 		}
 	}
 }

--- a/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WidgetBackend.cs
@@ -119,6 +119,8 @@ namespace Xwt.WPFBackend
 			}
 		}
 
+		internal bool HasAccessibleObject { get; set; }
+
 		Color? customBackgroundColor;
 
 		public virtual Color BackgroundColor {

--- a/Xwt.WPF/Xwt.WPFBackend/WindowsSpinButton.xaml.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowsSpinButton.xaml.cs
@@ -41,6 +41,7 @@ using System.ComponentModel;
 using System.Windows.Controls.Primitives;
 using System.Windows.Automation.Provider;
 using System.Windows.Automation;
+using System.Windows.Automation.Peers;
 
 namespace Xwt.WPFBackend
 {

--- a/Xwt.WPF/Xwt.WPFBackend/WindowsSpinButton.xaml.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowsSpinButton.xaml.cs
@@ -39,6 +39,8 @@ using System.Windows.Threading;
 using System.Globalization;
 using System.ComponentModel;
 using System.Windows.Controls.Primitives;
+using System.Windows.Automation.Provider;
+using System.Windows.Automation;
 
 namespace Xwt.WPFBackend
 {
@@ -452,6 +454,66 @@ namespace Xwt.WPFBackend
             else
                 DecreaseValue(Increment);
         }
-        #endregion
-    }
+		#endregion
+
+		#region Accessibility
+		protected override AutomationPeer OnCreateAutomationPeer ()
+		{
+			return new WindowsSpinButtonAutomationPeer (this);
+		}
+
+		class WindowsSpinButtonAutomationPeer : UserControlAutomationPeer, IRangeValueProvider
+		{
+			public WindowsSpinButtonAutomationPeer (WindowsSpinButton owner) : base (owner)
+			{
+			}
+
+			WindowsSpinButton Button => (WindowsSpinButton)Owner;
+
+			protected override string GetClassNameCore ()
+			{
+				return nameof (WindowsSpinButton);
+			}
+
+			protected override List<AutomationPeer> GetChildrenCore ()
+			{
+				return null;
+			}
+
+			protected override AutomationControlType GetAutomationControlTypeCore ()
+			{
+				return AutomationControlType.Spinner;
+			}
+
+			public override object GetPattern (PatternInterface patternInterface)
+			{
+				if (patternInterface == PatternInterface.RangeValue) {
+					return this;
+				}
+				return base.GetPattern (patternInterface);
+			}
+
+			public void SetValue (double value)
+			{
+				if (IsReadOnly)
+					throw new ElementNotEnabledException ();
+				if (value < Button.MinimumValue || value > Button.MaximumValue)
+					throw new ArgumentOutOfRangeException (nameof (value));
+				Button.Value = value;
+			}
+
+			public double Value => Button.Value;
+
+			public bool IsReadOnly => !Button.IsEnabled;
+
+			public double Maximum => Button.MaximumValue;
+
+			public double Minimum => Button.MinimumValue;
+
+			public double LargeChange => Button.Increment;
+
+			public double SmallChange => Button.Increment;
+		}
+		#endregion
+	}
 }

--- a/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
@@ -174,8 +174,10 @@ namespace Xwt.Mac
 			}
 		}
 
-		Widget IAccessibleBackend.LabeledBy {
-			set { /* Not supported */ }
+		Widget IAccessibleBackend.LabelWidget {
+			set {
+				widget.AccessibilityTitleUIElement = (Toolkit.GetBackend (value) as ViewBackend)?.Widget;
+			}
 		}
 
 		public void AddChild (object nativeChild)

--- a/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
@@ -174,6 +174,10 @@ namespace Xwt.Mac
 			}
 		}
 
+		Widget IAccessibleBackend.LabeledBy {
+			set { /* Not supported */ }
+		}
+
 		public void AddChild (object nativeChild)
 		{
 			var accessible = nativeChild as INSAccessibility;

--- a/Xwt/Xwt.Accessibility/Accessible.cs
+++ b/Xwt/Xwt.Accessibility/Accessible.cs
@@ -199,6 +199,11 @@ namespace Xwt.Accessibility
 			Backend.RemoveChild (nativeChild);
 		}
 
+		public void RemoveAllChildren ()
+		{
+			Backend.RemoveAllChildren ();
+		}
+
 		bool OnPress ()
 		{
 			var args = new WidgetEventArgs ();

--- a/Xwt/Xwt.Accessibility/Accessible.cs
+++ b/Xwt/Xwt.Accessibility/Accessible.cs
@@ -120,6 +120,12 @@ namespace Xwt.Accessibility
 			}
 		}
 
+		public Widget LabeledBy {
+			set {
+				Backend.LabeledBy = value;
+			}
+		}
+
 		public string Title {
 			get {
 				return Backend.Title;
@@ -222,6 +228,8 @@ namespace Xwt.Accessibility
 		public string Identifier { get; set; }
 
 		public string Label { get; set; }
+
+		public Widget LabeledBy { set { } }
 
 		public Role Role { get; set; }
 

--- a/Xwt/Xwt.Accessibility/Accessible.cs
+++ b/Xwt/Xwt.Accessibility/Accessible.cs
@@ -36,6 +36,8 @@ namespace Xwt.Accessibility
 
 		readonly AccessibleBackendHost backendHost;
 
+		Widget labelWidget;
+
 		class AccessibleBackendHost : BackendHost<Accessible, IAccessibleBackend>, IAccessibleEventSink
 		{
 			protected override IBackend OnCreateBackend ()
@@ -120,9 +122,11 @@ namespace Xwt.Accessibility
 			}
 		}
 
-		public Widget LabeledBy {
+		public Widget LabelWidget {
+			get { return labelWidget;  }
 			set {
-				Backend.LabeledBy = value;
+				labelWidget = value;
+				Backend.LabelWidget = value;
 			}
 		}
 
@@ -234,7 +238,7 @@ namespace Xwt.Accessibility
 
 		public string Label { get; set; }
 
-		public Widget LabeledBy { set { } }
+		public Widget LabelWidget { set { } }
 
 		public Role Role { get; set; }
 

--- a/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
+++ b/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
@@ -40,7 +40,7 @@ namespace Xwt.Backends
 
 		string Label { get; set; }
 
-		Widget LabeledBy { set; }
+		Widget LabelWidget { set; }
 
 		string Title { get; set; }
 

--- a/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
+++ b/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
@@ -40,6 +40,8 @@ namespace Xwt.Backends
 
 		string Label { get; set; }
 
+		Widget LabeledBy { set; }
+
 		string Title { get; set; }
 
 		string Description { get; set; }

--- a/Xwt/Xwt/FrameBox.cs
+++ b/Xwt/Xwt/FrameBox.cs
@@ -249,6 +249,12 @@ namespace Xwt
 				canvas.Child = value; 
 			}
 		}
+
+		protected Widget InternalContent {
+			get {
+				return canvas;
+			}
+		}
 	}
 }
 

--- a/Xwt/Xwt/Widget.cs
+++ b/Xwt/Xwt/Widget.cs
@@ -332,10 +332,6 @@ namespace Xwt
 				return accessible;
 			}
 		}
-
-		public bool HasAccessible {
-			get { return accessible != null; }
-		}
 		
 		/// <summary>
 		/// Gets the parent window of the widget.

--- a/Xwt/Xwt/Widget.cs
+++ b/Xwt/Xwt/Widget.cs
@@ -332,6 +332,10 @@ namespace Xwt
 				return accessible;
 			}
 		}
+
+		public bool HasAccessible {
+			get { return accessible != null; }
+		}
 		
 		/// <summary>
 		/// Gets the parent window of the widget.


### PR DESCRIPTION
This PR expands the accessibility support for the WPF backend in those ways:

- Add `LabeledBy` API to allow another widget to label this one
- Support the children accessibility API (for `Canvas` only as WPF doesn't allow to modify this information for existing widgets in general without subclassing and we mostly only care about supplying children accessibility object for custom-drawn and thus Canvas based elements anyway).
- Add a few more automation peers to some custom WPF controls we have