### PR TITLE
Fix leaks coming in from event subscription

### DIFF
--- a/Xwt/Xwt.Backends/BackendHost.cs
+++ b/Xwt/Xwt.Backends/BackendHost.cs
@@ -131,8 +131,10 @@ namespace Xwt.Backends
 		/// </summary>
 		protected virtual void OnBackendCreated ()
 		{
-			foreach (var ev in DefaultEnabledEvents)
+			foreach (var ev in DefaultEnabledEvents) {
+				enabledEvents.Add (ev);
 				Backend.EnableEvent (ev);
+			}
 		}
 		
 		/// <summary>
@@ -171,12 +173,15 @@ namespace Xwt.Backends
 			}
 		}
 
+		List<object> enabledEvents = new List<object> ();
+
 		/// <summary>
 		/// Enables an event with the specified identifier.
 		/// </summary>
 		/// <param name="eventId">Event identifier (must be a valid event enum value).</param>
 		protected override void OnEnableEvent (object eventId)
 		{
+			enabledEvents.Add (eventId);
 			Backend.EnableEvent (eventId);
 		}
 
@@ -186,7 +191,28 @@ namespace Xwt.Backends
 		/// <param name="eventId">Event identifier (must be a valid event enum value).</param>
 		protected override void OnDisableEvent (object eventId)
 		{
+			enabledEvents.Remove (eventId);
 			Backend.DisableEvent (eventId);
+		}
+
+
+		internal void ClearEvents (bool disposing)
+		{
+			if (!BackendCreated)
+				return;
+
+			if (disposing) {
+				ClearEventsOnUIThread ();
+			} else {
+				EngineBackend.InvokeAsync (() => ClearEventsOnUIThread ());
+			}
+		}
+
+		void ClearEventsOnUIThread()
+		{
+			foreach (var ev in enabledEvents)
+				backend.DisableEvent (ev);
+			enabledEvents.Clear ();
 		}
 	}
 }

--- a/Xwt/Xwt/Paned.cs
+++ b/Xwt/Xwt/Paned.cs
@@ -44,17 +44,18 @@ namespace Xwt
 			{
 				IPanedBackend b = (IPanedBackend) base.OnCreateBackend ();
 				
-				// We always want to listen this event because we use it
-				// to reallocate the children
-				if (!EngineBackend.HandlesSizeNegotiation)
-					b.EnableEvent (PanedEvent.PositionChanged);
-				
 				return b;
 			}
 		
 			protected override void OnBackendCreated ()
 			{
 				Backend.Initialize (Parent.direction);
+
+				// We always want to listen this event because we use it
+				// to reallocate the children
+				if (!EngineBackend.HandlesSizeNegotiation)
+					OnEnableEvent (PanedEvent.PositionChanged);
+
 				base.OnBackendCreated ();
 			}
 				

--- a/Xwt/Xwt/Toolkit.cs
+++ b/Xwt/Xwt/Toolkit.cs
@@ -830,7 +830,7 @@ namespace Xwt
 
 	class NativeWindowFrame: WindowFrame
 	{
-		public NativeWindowFrame (IWindowFrameBackend backend)
+		public NativeWindowFrame (IWindowFrameBackend backend) : base (owned: false)
 		{
 			BackendHost.SetCustomBackend (backend);
 		}

--- a/Xwt/Xwt/XwtComponent.cs
+++ b/Xwt/Xwt/XwtComponent.cs
@@ -183,6 +183,7 @@ namespace Xwt
 
 		protected override void Dispose (bool release_all)
 		{
+			backendHost.ClearEvents (release_all);
 			base.Dispose (release_all);
 			IsDisposed = true;
 		}


### PR DESCRIPTION
This reverts commit 98e0110a073950aada926a68e1ca96ad843a3fff.

This is here so I don't forget to work on the patch.

```
** (MonoDevelop:702): WARNING **: Gtk operations should be done on the main Thread
  at System.Environment.get_StackTrace () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono-pullrequest/pr/external/bockbuild/builds/mono-x64/mcs/class/corlib/System/Environment.cs:316 
  at Gtk.Application.AssertMainThread () [0x00023] in /Users/builder/jenkins/workspace/build-package-osx-mono-pullrequest/pr/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:124 
  at Gtk.Widget.set_Events (Gdk.EventMask value) [0x00001] in /Users/builder/jenkins/workspace/build-package-osx-mono-pullrequest/pr/external/bockbuild/builds/gtk-sharp-None/gtk/generated/Widget.cs:97 
  at Xwt.GtkBackend.WidgetBackend.DisableEvent (System.Object eventId) [0x00461] in /Users/davidkarlas/GIT/MD3/monodevelop/main/external/xwt/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs:666 
  at Xwt.Backends.BackendHost.Dispose () [0x00018] in /Users/davidkarlas/GIT/MD3/monodevelop/main/external/xwt/Xwt/Xwt.Backends/BackendHost.cs:201 
  at Xwt.XwtComponent.Dispose (System.Boolean release_all) [0x00001] in /Users/davidkarlas/GIT/MD3/monodevelop/main/external/xwt/Xwt/Xwt/XwtComponent.cs:79 
  at Xwt.Widget.Dispose (System.Boolean disposing) [0x00001] in /Users/davidkarlas/GIT/MD3/monodevelop/main/external/xwt/Xwt/Xwt/Widget.cs:312 
  at System.ComponentModel.Component.Finalize () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono-pullrequest/pr/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System/compmod/system/componentmodel/Component.cs:35 
```