### PR TITLE
Revert "[Wpf] Don't skip the Measure step all the time"

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/BoxBackend.cs
@@ -130,8 +130,9 @@ namespace Xwt.WPFBackend
 					if (force) {
 						// Don't recalculate the size unless a relayout is being forced
 						element.InvalidateMeasure ();
+						element.Measure (new SW.Size (r.Width, r.Height));
 					}
-					element.Measure (new SW.Size (r.Width, r.Height));
+					
 					element.Arrange (r.ToWpfRect ());
 				//	element.UpdateLayout ();
 				}


### PR DESCRIPTION
This reverts commit cd022e582ada54440bee219cb38200946191fb64.

Context: http://work.devdiv.io/625851

The fix caused a regression in the Android designer where it seems to cause an infinite measure/layout pass for some users causing the CPU to go to 100% and make the whole system unusuable.