### PR TITLE
[WPF] Only take border size into account when decorated

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WindowFrameBackend.cs
@@ -407,13 +407,12 @@ namespace Xwt.WPFBackend
 			var size = rect.Size;
 			var loc = rect.Location;
 
-			var border = GetBorderSize ();
-			size.Height += border.Height * 2;
-			size.Width += border.Width * 2;
-			loc.X -= border.Width;
-			loc.Y -= border.Height;
-
 			if (((IWindowFrameBackend)this).Decorated) {
+			    var border = GetBorderSize ();
+			    size.Height += border.Height * 2;
+			    size.Width += border.Width * 2;
+			    loc.X -= border.Width;
+			    loc.Y -= border.Height;
 				size.Height += SystemParameters.WindowCaptionHeight;
 				loc.Y -= SystemParameters.WindowCaptionHeight;
 			}
@@ -430,13 +429,13 @@ namespace Xwt.WPFBackend
 			var size = rect.Size;
 			var loc = rect.Location;
 
-			var border = GetBorderSize ();
-			size.Height -= border.Height * 2;
-			size.Width -= border.Width * 2;
-			loc.X += border.Width;
-			loc.Y += border.Height;
 
 			if (((IWindowFrameBackend)this).Decorated) {
+			    var border = GetBorderSize ();
+			    size.Height -= border.Height * 2;
+			    size.Width -= border.Width * 2;
+			    loc.X += border.Width;
+			    loc.Y += border.Height;
                 size.Height -= SystemParameters.WindowCaptionHeight;
                 loc.Y += SystemParameters.WindowCaptionHeight;
 			}


### PR DESCRIPTION
I was trying to make an unstyled window movable via dragging the background and the window would move even when setting the location to itself, after some digging and trial & error I discovered GetBorderSize() would still return a size, even though there was none

This would cause the window to move by 3px in both x/y when setting the Location/calling Move

I'm not 100% sure this is the right way to fix it (you might want to change GetBorderSize?), but it certainly works and fixes the issue. I'll gladly change things around if anyone wants to suggest a better way

I've only tested it on Windows 10