### PR TITLE
[Mac] Fix DrawingImage rendering on macOS Mojave

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
@@ -305,6 +305,17 @@ namespace Xwt.Mac
 			AddRepresentation (imgRep);
 		}
 
+		public override CGSize Size
+		{
+			get {
+				return base.Size;
+			}
+			set {
+				base.Size = value;
+				imgRep.Size = value;
+			}
+		}
+
 		[Export ("drawIt:")]
 		public void DrawIt (NSObject ob)
 		{


### PR DESCRIPTION
The NSCustomImageRep used for DrawingImage rendering
had always a zero size. However a modern macOS uses
the size to select the best matching image representation.
To ensure that our custom representation will be selected
for drawing, its size must match the NSImage size.

Fixes VSTS #648265