### PR TITLE
[d15-9][Mac] Fix PopupWindow background rendering on Mojave 

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/MacSystemInformation.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacSystemInformation.cs
@@ -30,6 +30,8 @@ namespace Xwt.Mac
 {
 	class MacSystemInformation
 	{
+		public static readonly Version Mojave = new Version(10, 14);
+		public static readonly Version HighSierra = new Version(10, 13);
 		public static readonly Version Sierra = new Version (10, 12);
 		public static readonly Version ElCapitan = new Version (10, 11);
 		public static readonly Version Yosemite = new Version (10, 10);

--- a/Xwt.XamMac/Xwt.Mac/PopupWindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopupWindowBackend.cs
@@ -133,9 +133,14 @@ namespace Xwt.Mac
 				MovableByWindowBackground = true;
 				TitlebarAppearsTransparent = true;
 				TitleVisibility = NSWindowTitleVisibility.Hidden;
-				this.StandardWindowButton (NSWindowButton.CloseButton).Hidden = true;
-				this.StandardWindowButton (NSWindowButton.MiniaturizeButton).Hidden = true;
-				this.StandardWindowButton (NSWindowButton.ZoomButton).Hidden = true;
+				if (MacSystemInformation.OsVersion <= MacSystemInformation.HighSierra)
+				{
+					StandardWindowButton(NSWindowButton.CloseButton).Hidden = true;
+					StandardWindowButton(NSWindowButton.MiniaturizeButton).Hidden = true;
+					StandardWindowButton(NSWindowButton.ZoomButton).Hidden = true;
+				}
+				else
+					StyleMask &= ~(NSWindowStyle.Titled);
 
 				if (windowType == PopupWindow.PopupType.Tooltip)
 					// NSWindowLevel.ScreenSaver overlaps menus, this allows showing tooltips above menus


### PR DESCRIPTION
backport #856 to `d15-9`

Previously there was no straightforward way to make an NSWindow transparent and hide the titlebar (unset NSWindowStyle.Titled style flag) without additional hacks. This has changed in Mojave in a way that unsetting the NSWindowStyle.Titled has the expected behaviour now (completely disables titlebar rendering).