### PR TITLE
[7.7][Gtk] Fix text cell not being editable

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererText.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend.CellViews/CustomCellRendererText.cs
@@ -58,7 +58,8 @@ namespace Xwt.GtkBackend
 					cellRenderer.Attributes = new Pango.AttrList ();
 			}
 			cellRenderer.Editable = view.Editable;
-			cellRenderer.Mode = CellRendererMode.Activatable;
+			if (!cellRenderer.Editable)
+				cellRenderer.Mode = CellRendererMode.Activatable;
 			cellRenderer.Ellipsize = view.Ellipsize.ToGtkValue ();
 		}
 		


### PR DESCRIPTION
Setting CellRendererText.Editable to true would change the Mode
to Editable. However the code was then changing the Mode to
Activatable so the text cell could not be edited.