### PR TITLE
[WPF] Fixes a crash for ArrowUp into treeview without selected row

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
@@ -313,6 +313,9 @@ namespace Xwt.WPFBackend
 
 		public void SelectItem(ExTreeViewItem item)
 		{
+			if (item == null)
+				return;
+
 			FocusItem(item);
 			if (!CtrlPressed)
 				SelectedItems.Clear();
@@ -446,7 +449,12 @@ namespace Xwt.WPFBackend
 			int indexOfP = items.IndexOf(p);
 			if (indexOfP == 0)
 				return p;
-			else
+			else if (indexOfP == -1) {
+				if (items.Count > 0)
+					return items [items.Count - 1];
+
+				return null;
+ 			} else
 				return items[indexOfP - 1];
 		}
 

--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
@@ -77,10 +77,7 @@ namespace Xwt.WPFBackend
 			if (!(DataContext is TreeStoreNode))
 				return;
 
-			var node = DataContext as TreeStoreNode;
-			if (node == null) {
-				return;
-			}
+			var node = (TreeStoreNode)DataContext;
 			if (!IsExpanded)
 				UnselectChildren((object o, ExTreeViewItem i) =>
 				{

--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
@@ -57,6 +57,9 @@ namespace Xwt.WPFBackend
 
 		protected override void OnExpanded (RoutedEventArgs e)
 		{
+			if (!(DataContext is TreeStoreNode))
+				return;
+
 			var node = (TreeStoreNode)DataContext;
 			view.Backend.Context.InvokeUserCode (delegate {
 				((ITreeViewEventSink)view.Backend.EventSink).OnRowExpanding (node);
@@ -71,6 +74,9 @@ namespace Xwt.WPFBackend
 
 		protected override void OnCollapsed(RoutedEventArgs e)
 		{
+			if (!(DataContext is TreeStoreNode))
+				return;
+
 			var node = DataContext as TreeStoreNode;
 			if (node == null) {
 				return;


### PR DESCRIPTION
Repro steps:
* Open the sample app -> Widgets -> TreeView -> Remove selection
* Shift-Tab until you get to the TreeView
* Press ArrowUp key
* Crash (out of bounds)