### PR TITLE
[WPF] Fixed the crash for TreeView range selection when no items were…

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
@@ -366,9 +366,8 @@ namespace Xwt.WPFBackend
 			var endIndex = allVisibleItems.IndexOf(endItem);
 
 			// Handle empty selection
-			if (startIndex == -1) {
+			if (startIndex == -1)
 				startIndex = 0;
-			}
 
 			if (endIndex == startIndex)
 				return new List<ExTreeViewItem> { endItem };

--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeView.cs
@@ -365,6 +365,11 @@ namespace Xwt.WPFBackend
 			var startIndex = allVisibleItems.IndexOf(startItem);
 			var endIndex = allVisibleItems.IndexOf(endItem);
 
+			// Handle empty selection
+			if (startIndex == -1) {
+				startIndex = 0;
+			}
+
 			if (endIndex == startIndex)
 				return new List<ExTreeViewItem> { endItem };
 			var filteredItems = new List<ExTreeViewItem>();


### PR DESCRIPTION
… selected initially
Repro steps:
* Open the sample -> Widgets -> TreeView
* Switch to Multiple selection
* Click Remove selection button
* Shift + Mouse click on a second row
-> Out of bounds exception