### PR TITLE
[Gtk][a11y] Support a11y for combobox entry

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -59,7 +59,10 @@ namespace Xwt.GtkBackend
 		public void Initialize (IWidgetBackend parentWidget, IAccessibleEventSink eventSink)
 		{
 			var backend = parentWidget as WidgetBackend;
-			Initialize (backend?.Widget, eventSink);
+			if (backend is IComboBoxEntryBackend)
+				Initialize ((backend?.Widget as Gtk.Bin)?.Child, eventSink);
+			else
+				Initialize (backend?.Widget, eventSink);
 		}
 
 		public void Initialize (IPopoverBackend parentPopover, IAccessibleEventSink eventSink)

--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -24,7 +24,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
-using System.Linq;
 using Xwt.Accessibility;
 using Xwt.Backends;
 

--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -61,17 +61,21 @@ namespace Xwt.GtkBackend
 		{
 			var backend = parentWidget as WidgetBackend;
 			Gtk.Widget nativeWidget = null;
-			
-			// Gtk.ComboBox and Gtk.ComboBoxEntry are containers, so we apply a11y properties to their children.
-			// For Gtk.ComboBoxEntry it is Gtk.Entry, for Gtk.ComboBox -- Gtk.ToggleButton
-			
-			if (backend is IComboBoxEntryBackend) {
-				nativeWidget = (backend?.Widget as Gtk.Bin)?.Child;
-			} else if (backend is IComboBoxBackend) {
-				foreach (var child in ((Gtk.Container)backend.Widget).AllChildren) {
-					if (child is Gtk.ToggleButton) {
-						nativeWidget = (Gtk.Widget)child;
-						break;
+
+			// Needed only for AtkCocoa.
+			if (Platform.IsMac) {
+				// Gtk.ComboBox and Gtk.ComboBoxEntry a11y doesn't work with Gtk/AtkCocoa.
+				// Workaround:
+				// Set a11y properties to their children.
+				// For Gtk.ComboBoxEntry use its Gtk.Entry, for Gtk.ComboBox -- Gtk.ToggleButton.
+				if (backend is IComboBoxEntryBackend) {
+					nativeWidget = (backend?.Widget as Gtk.Bin)?.Child;
+				} else if (backend is IComboBoxBackend) {
+					foreach (var child in ((Gtk.Container)backend.Widget).AllChildren) {
+						if (child is Gtk.ToggleButton) {
+							nativeWidget = (Gtk.Widget)child;
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Setting Accessibility to `Xwt.ComboBoxEntry` doesn't work for `Gtk`, because `ComboBoxEntryBackend` uses `Gtk.Bin` as a container for entry ui element (https://github.com/mono/xwt/blob/master/Xwt.Gtk/Xwt.GtkBackend/ComboBoxEntryBackend.cs#L37).
So `Widget.Child` in this case is Entry element, which should be used as an a11y target.