### PR TITLE
[Mac] Dispose of images on the UI thread

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ImageBuilderBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageBuilderBackendHandler.cs
@@ -37,6 +37,8 @@ namespace Xwt.Mac
 		{
 		}
 
+		public override bool DisposeHandleOnUiThread => true;
+
 		#region IImageBuilderBackendHandler implementation
 		public override object CreateImageBuilder (int width, int height, ImageFormat format)
 		{

--- a/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
@@ -46,7 +46,9 @@ namespace Xwt.Mac
 		static readonly IntPtr cls_NSImage = new Class (typeof (NSImage)).Handle;
 
 		static Dictionary<string, NSImage> stockIcons = new Dictionary<string, NSImage> ();
-		
+
+		public override bool DisposeHandleOnUiThread => true;
+
 		public override object LoadFromStream (Stream stream)
 		{
 			using (NSData data = NSData.FromStream (stream)) {


### PR DESCRIPTION
Accessing the object's hashcode on a non-UI thread can cause problems
in native land

Fixes VSTS #731416 - VS for Mac crashes with "A fatal error has occurred" -  "System.NullReferenceException: at (wrapper managed-to-native) ObjCRuntime.Messaging.nuint_objc_msgSend(intptr,intptr)" at Xwt.Drawing.Image.Finalize () /external/xwt/Xwt/Xwt.Drawing/Image.cs:83