### PR TITLE
[d15-9] Adds Size Attribute parsing in Span tags 

### DIFF
--- a/TestApps/Samples/Samples/Labels.cs
+++ b/TestApps/Samples/Samples/Labels.cs
@@ -77,7 +77,7 @@ namespace Samples
 			};
 			PackStart (la);
 
-			la = new Label () { Markup = "Label with <b>bold</b> and <span color='#ff0000'>red</span> text" };
+			la = new Label () { Markup = "Label with <b>bold</b> and <span size=\"smaller\" color='#ff0000'>red</span> text" };
 			PackStart (la);
 			
 			la = new Label () { Markup = "Label with a <a href='http://xamarin.com'>link</a> to a web site." };

--- a/TestApps/Samples/Samples/Labels.cs
+++ b/TestApps/Samples/Samples/Labels.cs
@@ -77,7 +77,7 @@ namespace Samples
 			};
 			PackStart (la);
 
-			la = new Label () { Markup = "Label with <b>bold</b> and <span size=\"smaller\" color='#ff0000'>red</span> text" };
+			la = new Label () { Markup = "Label with <b>bold</b> and <span size=\"xx-small\" font=\"Arial\" color='#ff0000'>red</span> <span size=\"xx-large\" font=\"Tahoma\" color='#00ff00'>green</span> <span size=\"10720\" font=\"Tahoma\" color='#0000ff'>blue</span> text" };
 			PackStart (la);
 			
 			la = new Label () { Markup = "Label with a <a href='http://xamarin.com'>link</a> to a web site." };

--- a/TestApps/Samples/Samples/Labels.cs
+++ b/TestApps/Samples/Samples/Labels.cs
@@ -77,7 +77,7 @@ namespace Samples
 			};
 			PackStart (la);
 
-			la = new Label () { Markup = "Label with <b>bold</b> and <span size=\"xx-small\" font=\"Arial\" color='#ff0000'>red</span> <span size=\"xx-large\" font=\"Tahoma\" color='#00ff00'>green</span> <span size=\"10720\" font=\"Tahoma\" color='#0000ff'>blue</span> text" };
+			la = new Label () { Markup = "Label with <b>bold</b> and <span size=\"xx-small\" font=\"Arial\" color='#ff0000'>red</span> <span size=\"xx-large\" font=\"Tahoma\" color='#00ff00'>green</span> <span size=\"7.3\" color='#0000ff'>blue PT</span> <span size=\"10720\" font=\"Tahoma\" color='#ff0000'>Red Pango</span> text" };
 			PackStart (la);
 			
 			la = new Label () { Markup = "Label with a <a href='http://xamarin.com'>link</a> to a web site." };

--- a/Testing/Tests/FormattedTextTests.cs
+++ b/Testing/Tests/FormattedTextTests.cs
@@ -70,41 +70,37 @@ namespace Xwt
 		public void ParseFontSize ()
 		{
 			//relative checks
-			string currentSpan;
-			FormattedText ft;
-			FontSizeTextAttribute at;
-			float currentSizeValue;
-
 			foreach (var item in new string[] { "smaller", "larger" }) {
-				currentSpan = $"<span size='{item}'>(support-v7)</span>";
-				ft = FormattedText.FromMarkup (currentSpan);
-				Assert.AreEqual (1, ft.Attributes.Count);
-				Assert.IsAssignableFrom<FontSizeTextAttribute> (ft.Attributes[0]);
-				at = (FontSizeTextAttribute)ft.Attributes[0];
-				Assert.AreEqual ((float) Xwt.Drawing.Font.SystemFont.Size, at.Size);
+				AssertFirstAttribute (item, (float)Xwt.Drawing.Font.SystemFont.Size);
 			}
 
+			float currentSizeValue;
 			//absolute size check
 			foreach (var currentSize in FontSizeTextAttribute.SizeAbsoluteValues.Keys) {
 				currentSizeValue = FontSizeTextAttribute.SizeAbsoluteValues[currentSize];
-				currentSpan = $"<span size='{currentSize}'>(support-v7)</span>";
-				ft = FormattedText.FromMarkup (currentSpan);
-				Assert.AreEqual (1, ft.Attributes.Count);
-				Assert.IsAssignableFrom<FontSizeTextAttribute> (ft.Attributes[0]);
-				at = (FontSizeTextAttribute)ft.Attributes[0];
-				Assert.AreEqual (currentSizeValue, at.Size);
+				AssertFirstAttribute (currentSize, currentSizeValue);
 			}
 
-			//numeric value
+			//pango size values
 			currentSizeValue = 14.5f;
-			var pagoSizeValue = currentSizeValue * FontSizeTextAttribute.MaxSize;
-			currentSpan = $"<span size='{pagoSizeValue}'>(support-v7)</span>";
-			ft = FormattedText.FromMarkup (currentSpan);
+			var pagoSizeValue = currentSizeValue * PangoScale;
+			AssertFirstAttribute (pagoSizeValue.ToString (), currentSizeValue);
+
+			//pt values
+			AssertFirstAttribute (currentSizeValue.ToString (), currentSizeValue);
+		}
+
+		void AssertFirstAttribute (string size, float resultSize)
+		{
+			var currentSpan = $"<span size='{size}'>(support-v7)</span>";
+			var ft = FormattedText.FromMarkup (currentSpan);
 			Assert.AreEqual (1, ft.Attributes.Count);
 			Assert.IsAssignableFrom<FontSizeTextAttribute> (ft.Attributes[0]);
-			at = (FontSizeTextAttribute)ft.Attributes[0];
-			Assert.AreEqual (currentSizeValue, at.Size);
+			var at = (FontSizeTextAttribute)ft.Attributes[0];
+			Assert.AreEqual (resultSize, at.Size);
 		}
+
+		const int PangoScale = 1024;
 
 		[Test]
 		public void ParseFontWeight ()

--- a/Testing/Tests/FormattedTextTests.cs
+++ b/Testing/Tests/FormattedTextTests.cs
@@ -67,6 +67,46 @@ namespace Xwt
 		}
 
 		[Test]
+		public void ParseFontSize ()
+		{
+			//relative checks
+			string currentSpan;
+			FormattedText ft;
+			FontSizeTextAttribute at;
+			float currentSizeValue;
+
+			foreach (var item in new string[] { "smaller", "larger" }) {
+				currentSpan = $"<span size='{item}'>(support-v7)</span>";
+				ft = FormattedText.FromMarkup (currentSpan);
+				Assert.AreEqual (1, ft.Attributes.Count);
+				Assert.IsAssignableFrom<FontSizeTextAttribute> (ft.Attributes[0]);
+				at = (FontSizeTextAttribute)ft.Attributes[0];
+				Assert.AreEqual ((float) Xwt.Drawing.Font.SystemFont.Size, at.Size);
+			}
+
+			//absolute size check
+			foreach (var currentSize in FontSizeTextAttribute.SizeAbsoluteValues.Keys) {
+				currentSizeValue = FontSizeTextAttribute.SizeAbsoluteValues[currentSize];
+				currentSpan = $"<span size='{currentSize}'>(support-v7)</span>";
+				ft = FormattedText.FromMarkup (currentSpan);
+				Assert.AreEqual (1, ft.Attributes.Count);
+				Assert.IsAssignableFrom<FontSizeTextAttribute> (ft.Attributes[0]);
+				at = (FontSizeTextAttribute)ft.Attributes[0];
+				Assert.AreEqual (currentSizeValue, at.Size);
+			}
+
+			//numeric value
+			currentSizeValue = 14.5f;
+			var pagoSizeValue = currentSizeValue * FontSizeTextAttribute.MaxSize;
+			currentSpan = $"<span size='{pagoSizeValue}'>(support-v7)</span>";
+			ft = FormattedText.FromMarkup (currentSpan);
+			Assert.AreEqual (1, ft.Attributes.Count);
+			Assert.IsAssignableFrom<FontSizeTextAttribute> (ft.Attributes[0]);
+			at = (FontSizeTextAttribute)ft.Attributes[0];
+			Assert.AreEqual (currentSizeValue, at.Size);
+		}
+
+		[Test]
 		public void ParseFontWeight ()
 		{
 			var s = "0<b>12</b><span weight='ultrabold'>34</span><span font-weight='Light'>56</span>";

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkInterop.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkInterop.cs
@@ -61,6 +61,8 @@ namespace Xwt.GtkBackend
 	/// </summary>
 	internal class FastPangoAttrList : IDisposable
 	{
+		const float PangoScale = 1024;
+
 		IntPtr list;
 		public Gdk.Color DefaultLinkColor = Toolkit.CurrentEngine.Defaults.FallbackLinkColor.ToGtkValue ();
 
@@ -91,7 +93,11 @@ namespace Xwt.GtkBackend
 			else if (attr is FontWeightTextAttribute) {
 				var xa = (FontWeightTextAttribute)attr;
 				AddWeightAttribute ((Pango.Weight)(int)xa.Weight, start, end);
-			}
+			} 
+			else if (attr is FontSizeTextAttribute) {
+				var xa = (FontSizeTextAttribute)attr;
+				AddFontSizeAttribute ((int) (xa.Size * PangoScale), start, end);
+			} 
 			else if (attr is FontStyleTextAttribute) {
 				var xa = (FontStyleTextAttribute)attr;
 				AddStyleAttribute ((Pango.Style)(int)xa.Style, start, end);
@@ -149,6 +155,11 @@ namespace Xwt.GtkBackend
 			Add (pango_attr_strikethrough_new (strikethrough), start, end);
 		}
 
+		public void AddFontSizeAttribute (int size, uint start, uint end)
+		{
+			Add (pango_attr_size_new_absolute (size), start, end);
+		}
+
 		public void AddFontAttribute (Pango.FontDescription font, uint start, uint end)
 		{
 			Add (pango_attr_font_desc_new (font.Handle), start, end);
@@ -163,6 +174,9 @@ namespace Xwt.GtkBackend
 			}
 			pango_attr_list_insert (list, attribute);
 		}
+
+		[DllImport (GtkInterop.LIBPANGO, CallingConvention = CallingConvention.Cdecl)]
+		static extern IntPtr pango_attr_size_new_absolute (int size);
 
 		[DllImport (GtkInterop.LIBPANGO, CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr pango_attr_style_new (Pango.Style style);

--- a/Xwt.XamMac/Xwt.Mac/TextLayoutBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextLayoutBackendHandler.cs
@@ -216,9 +216,17 @@ namespace Xwt.Mac
 				else if (attribute is StrikethroughTextAttribute)
 				{
 					var xa = (StrikethroughTextAttribute)attribute;
-					var style = xa.Strikethrough ? NSUnderlineStyle.Single : NSUnderlineStyle.None;
+					var style = xa.Strikethrough ? NSUnderlineStyle.Single : NSUnderlineStyle.None; 
 					TextStorage.AddAttribute (NSStringAttributeKey.StrikethroughStyle, NSNumber.FromInt32 ((int)style), r);
-				}
+				} 
+				else if (attribute is FontSizeTextAttribute) 
+				{
+					var xa = (FontSizeTextAttribute)attribute;
+					NSRange er;
+					var ft = TextStorage.GetAttribute (NSStringAttributeKey.Font, attribute.StartIndex, out er, r) as NSFont;
+					ft = ft.WithSize (xa.Size);
+					TextStorage.AddAttribute (NSStringAttributeKey.Font, ft, r);
+				} 
 				else if (attribute is FontTextAttribute)
 				{
 					var xa = (FontTextAttribute)attribute;

--- a/Xwt/Xwt.Drawing/FontSizeTextAttribute.cs
+++ b/Xwt/Xwt.Drawing/FontSizeTextAttribute.cs
@@ -32,8 +32,15 @@ namespace Xwt.Drawing
 	public sealed class FontSizeTextAttribute : TextAttribute
 	{
 		const float PangoScale = 1024;
-		public const string XXSmall = "xx-small", XSmall = "x-small", Small = "small", Medium = "medium", Large = "large", XLarge = "x-large", XXLarge = "xx-large",
-			Smaller = "smaller", Larger = "larger";
+		public const string XXSmall = "xx-small",
+			XSmall = "x-small", 
+			Small = "small", 
+			Medium = "medium", 
+			Large = "large", 
+			XLarge = "x-large", 
+			XXLarge = "xx-large",
+			Smaller = "smaller", 
+			Larger = "larger";
 
 		public float Size { get; private set; }
 		public string OriginalSizeStringValue { get; private set; }

--- a/Xwt/Xwt.Drawing/FontSizeTextAttribute.cs
+++ b/Xwt/Xwt.Drawing/FontSizeTextAttribute.cs
@@ -1,0 +1,87 @@
+﻿//
+// FontWeightTextAttribute.cs
+//
+// Author:
+//       Lluis Sanchez <lluis@xamarin.com>
+//
+// Copyright (c) 2013 Xamarin Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Xwt.Drawing
+{
+	public sealed class FontSizeTextAttribute : TextAttribute
+	{
+		public const float MaxSize = 1024;
+		public const string XXSmall = "xx-small", XSmall = "x-small", Small = "small", Medium = "medium", Large = "large", XLarge = "x-large", XXLarge = "xx-large",
+			Smaller = "smaller", Larger = "larger";
+
+		public float Size { get; private set; }
+		public string OriginalSizeStringValue { get; private set; }
+
+		public static Dictionary<string, float> SizeAbsoluteValues = GetAbsoluteSizeValues ();
+		static Dictionary<string, float> GetAbsoluteSizeValues ()
+		{
+			var mediumSize = (float)Font.SystemFont.Size;
+			var result = new Dictionary<string, float> {
+				{ XXLarge, mediumSize + 3 },
+				{ XLarge, mediumSize + 2 },
+				{ Large, mediumSize + 1 },
+				{ Medium, mediumSize },
+				{ Small, mediumSize - 1 },
+				{ XSmall, mediumSize - 2 },
+				{ XXSmall, mediumSize - 3 }
+			};
+			return result;
+		}
+
+		public override bool Equals (object t)
+		{
+			var ot = t as FontSizeTextAttribute;
+			return ot != null && Size.Equals (ot.Size) && base.Equals (t);
+		}
+
+		public void SetSize (string value)
+		{
+			OriginalSizeStringValue = value;
+
+			var currentSize = Font.SystemFont.Size;
+
+			float size;
+			if (float.TryParse (value, out size)) {
+				Size = size / MaxSize; //we need convert this to pt. values
+				return;
+			}
+			if (SizeAbsoluteValues.TryGetValue (value,out size)) {
+				Size = size;
+				return;
+			}
+			//we don't cover relative values (smaller/larger) we set medium as default
+			Size = SizeAbsoluteValues[Medium];
+		}
+
+		public override int GetHashCode ()
+		{
+			return base.GetHashCode () ^ Size.GetHashCode ();
+		}
+	}
+}

--- a/Xwt/Xwt.Drawing/FontSizeTextAttribute.cs
+++ b/Xwt/Xwt.Drawing/FontSizeTextAttribute.cs
@@ -31,7 +31,7 @@ namespace Xwt.Drawing
 {
 	public sealed class FontSizeTextAttribute : TextAttribute
 	{
-		public const float MaxSize = 1024;
+		const float PangoScale = 1024;
 		public const string XXSmall = "xx-small", XSmall = "x-small", Small = "small", Medium = "medium", Large = "large", XLarge = "x-large", XXLarge = "xx-large",
 			Smaller = "smaller", Larger = "larger";
 
@@ -63,12 +63,13 @@ namespace Xwt.Drawing
 		public void SetSize (string value)
 		{
 			OriginalSizeStringValue = value;
-
-			var currentSize = Font.SystemFont.Size;
-
 			float size;
 			if (float.TryParse (value, out size)) {
-				Size = size / MaxSize; //we need convert this to pt. values
+				if (size >= PangoScale) {
+					Size = size / PangoScale; //we need convert this to pt. values
+				} else {
+					Size = size;
+				}
 				return;
 			}
 			if (SizeAbsoluteValues.TryGetValue (value,out size)) {

--- a/Xwt/Xwt.Drawing/FontSizeTextAttribute.cs
+++ b/Xwt/Xwt.Drawing/FontSizeTextAttribute.cs
@@ -43,13 +43,13 @@ namespace Xwt.Drawing
 		{
 			var mediumSize = (float)Font.SystemFont.Size;
 			var result = new Dictionary<string, float> {
-				{ XXLarge, mediumSize + 3 },
-				{ XLarge, mediumSize + 2 },
-				{ Large, mediumSize + 1 },
+				{ XXLarge, mediumSize + 16 },
+				{ XLarge, mediumSize + 8 },
+				{ Large, mediumSize + 4 },
 				{ Medium, mediumSize },
-				{ Small, mediumSize - 1 },
-				{ XSmall, mediumSize - 2 },
-				{ XXSmall, mediumSize - 3 }
+				{ Small, mediumSize - 2 },
+				{ XSmall, mediumSize - 4 },
+				{ XXSmall, mediumSize - 8 }
 			};
 			return result;
 		}

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -360,6 +360,7 @@
     <Compile Include="Xwt\UtilityWindow.cs" />
     <Compile Include="Xwt.Backends\IUtilityWindowBackend.cs" />
     <Compile Include="Xwt\TextChangedEventArgs.cs" />
+    <Compile Include="Xwt.Drawing\FontSizeTextAttribute.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt/FormattedText.cs
+++ b/Xwt/Xwt/FormattedText.cs
@@ -223,13 +223,11 @@ namespace Xwt
 			case "font_desc":
 				return new FontTextAttribute () { Font = Font.FromName (val) };
 
-/*			case "size":
+			case "size":
 			case "font_size":
-				double s;
-				if (!double.TryParse (val, NumberStyles.Any, CultureInfo.InvariantCulture, out s))
-					return null;
-				return new FontSizeTextAttribute () { Size = s };
-*/
+				var fontSize = new FontSizeTextAttribute ();
+				fontSize.SetSize (val);
+				return fontSize;
 			case "font_weight":
 			case "font-weight":
 			case "weight":


### PR DESCRIPTION
This PR adds implementations  to cover "size" attribute in span tags in Gtk and Cocoa backends,

Example:

`<span size=\"10720\" font=\"Tahoma\" color='#0000ff'>blue</span>`

`<span size=\"xx-small\" font=\"Arial\" color='#ff0000'>red</span>`

`<span size=\"xx-large\" font=\"Tahoma\" color='#00ff00'>green</span>`

![image](https://user-images.githubusercontent.com/1587480/49081557-8901da80-f247-11e8-8dfa-f303e79c0268.png)

![image-2](https://user-images.githubusercontent.com/1587480/49105908-106c3f80-f282-11e8-8310-ff42c38475eb.png)



