### PR TITLE
[a11y][WPF][Mac] Add Accessibility API to CellView

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
+++ b/Xwt.WPF/Xwt.WPFBackend.Utilities/CellUtil.cs
@@ -28,7 +28,9 @@ using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Automation;
 using Xwt.Backends;
+using Xwt.Accessibility;
 using SWC = System.Windows.Controls;
 using SWM = System.Windows.Media;
 
@@ -56,6 +58,8 @@ namespace Xwt.WPFBackend.Utilities
 				}
 				else if (!view.Visible)
 					factory.SetValue(UIElement.VisibilityProperty, Visibility.Collapsed);
+
+				BindAccessibleFields (factory, view.AccessibleFields, dataPath);
 
 				factory.SetValue (FrameworkElement.HorizontalAlignmentProperty, view.Expands ? HorizontalAlignment.Stretch : HorizontalAlignment.Left);
 				factory.SetValue (Grid.ColumnProperty, i);
@@ -185,6 +189,18 @@ namespace Xwt.WPFBackend.Utilities
 			}
 
 			throw new NotImplementedException ();
+		}
+
+		static void BindAccessibleFields (FrameworkElementFactory factory, AccessibleFields accessibleFields, string dataPath)
+		{
+			if (accessibleFields == null)
+				return;
+			if (accessibleFields.Label != null)
+				factory.SetBinding(AutomationProperties.NameProperty, new Binding(dataPath + "[" + accessibleFields.Label.Index + "]"));
+			if (accessibleFields.Identifier != null)
+				factory.SetBinding(AutomationProperties.AutomationIdProperty, new Binding(dataPath + "[" + accessibleFields.Identifier.Index + "]"));
+			if (accessibleFields.Description != null)
+				factory.SetBinding(AutomationProperties.HelpTextProperty, new Binding(dataPath + "[" + accessibleFields.Description.Index + "]"));
 		}
 	}
 

--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
@@ -261,12 +261,18 @@ namespace Xwt.WPFBackend
 				if (defaultChildren == null)
 					return null;
 
-				// We only want to include TreeView items in the a11y tree, not their constituent image/text/etc controls -
-				// for one thing including all controls messes up the "item 3 of 5" style counts announced by the
-				// narrator, as those controls would be include
-				List<AutomationPeer> children = defaultChildren.Where (
-					child => child is TreeViewItemAutomationPeer || child is TreeViewDataItemAutomationPeer).ToList ();
-				return children;
+				if (((TreeViewItem)Owner).IsExpanded)
+				{
+					// When expanded,
+					// We only want to include TreeView items in the a11y tree, not their constituent image/text/etc controls -
+					// for one thing including all controls messes up the "item 3 of 5" style counts announced by the
+					// narrator, as those controls would be include
+					return defaultChildren.Where (child => child is TreeViewItemAutomationPeer || child is TreeViewDataItemAutomationPeer).ToList ();
+				}
+				else
+				{
+					return defaultChildren;
+				}
 			}
 		}
 	}

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CanvasTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CanvasTableCell.cs
@@ -53,6 +53,7 @@ namespace Xwt.Mac
 		public void Fill ()
 		{
 			Hidden = !Frontend.Visible;
+			TableCellUtil.ApplyAcessibilityProperties (this, Frontend);
 		}
 		
 		ICanvasCellViewFrontend Frontend {

--- a/Xwt.XamMac/Xwt.Mac.CellViews/CheckBoxTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/CheckBoxTableCell.cs
@@ -103,6 +103,7 @@ namespace Xwt.Mac
 			base.State = cellView.State.ToMacState ();
 			Enabled = cellView.Editable;
 			Hidden = !cellView.Visible;
+			TableCellUtil.ApplyAcessibilityProperties (this, Frontend);
 		}
 		
 		public virtual NSBackgroundStyle BackgroundStyle {

--- a/Xwt.XamMac/Xwt.Mac.CellViews/ICellRenderer.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/ICellRenderer.cs
@@ -28,7 +28,7 @@ using AppKit;
 
 namespace Xwt.Mac
 {
-	interface ICellRenderer: ICopiableObject
+	interface ICellRenderer: ICopiableObject, INSAccessibility
 	{
 		CellViewBackend Backend { get; set; }
 		CompositeCell CellContainer { get; set; }

--- a/Xwt.XamMac/Xwt.Mac.CellViews/ImageTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/ImageTableCell.cs
@@ -53,6 +53,7 @@ namespace Xwt.Mac
 			} else
 				SetFrameSize (CoreGraphics.CGSize.Empty);
 			Hidden = !Frontend.Visible;
+			TableCellUtil.ApplyAcessibilityProperties (this, Frontend);
 		}
 
 		public override CoreGraphics.CGSize FittingSize {

--- a/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/RadioButtonTableCell.cs
@@ -88,6 +88,7 @@ namespace Xwt.Mac
 			base.State = cellView.Active ? NSCellStateValue.On : NSCellStateValue.Off;
 			Enabled = cellView.Editable;
 			Hidden = !cellView.Visible;
+			TableCellUtil.ApplyAcessibilityProperties (this, Frontend);
 		}
 
 		public void CopyFrom (object other)

--- a/Xwt.XamMac/Xwt.Mac.CellViews/TableCellUtil.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/TableCellUtil.cs
@@ -1,0 +1,70 @@
+using System;
+using AppKit;
+using Foundation;
+using Xwt.Accessibility;
+using Xwt.Backends;
+
+namespace Xwt.Mac
+{
+	static class TableCellUtil
+	{
+		public static void ApplyAcessibilityProperties (ICellRenderer cell, ICellViewFrontend frontend)
+		{
+			if (frontend.AccessibleFields == null)
+				return;
+
+			INSAccessibility accessibleCell = cell as INSAccessibility;
+			if (accessibleCell == null)
+				return;
+
+			ICellDataSource source = cell.CellContainer;
+			var label = GetValue (source, frontend.AccessibleFields.Label);
+			if (label != null)
+				accessibleCell.AccessibilityLabel = (string)label;
+			var identifier = GetValue (source, frontend.AccessibleFields.Identifier);
+			if (identifier != null)
+				accessibleCell.AccessibilityIdentifier = (string)identifier;
+			var description = GetValue (source, frontend.AccessibleFields.Description);
+			if (description != null)
+				accessibleCell.AccessibilityHelp = (string)description;
+			var title = GetValue (source, frontend.AccessibleFields.Title);
+			if (title != null)
+				accessibleCell.AccessibilityTitle = (string)title;
+			var isAccessible = GetValue (source, frontend.AccessibleFields.IsAccessible);
+			if (isAccessible != null)
+				accessibleCell.AccessibilityElement = (bool)isAccessible;
+			var value = GetValue (source, frontend.AccessibleFields.Value);
+			if (value != null)
+				accessibleCell.AccessibilityValue = new NSString ((string)value);
+			var uri = GetValue (source, frontend.AccessibleFields.Uri);
+			if (uri != null)
+				accessibleCell.AccessibilityUrl = new NSUrl (((Uri)uri).AbsoluteUri);
+			var bounds = GetValue (source, frontend.AccessibleFields.Bounds);
+			if (bounds != null)
+				accessibleCell.AccessibilityFrame = ((Rectangle)bounds).ToCGRect ();
+			
+			var role = GetValue (source, frontend.AccessibleFields.Role);
+			if (role != null) {
+				if ((Role)role == Role.Filler) {
+					accessibleCell.AccessibilityElement = false;
+				} else {
+					accessibleCell.AccessibilityElement = true;
+					accessibleCell.AccessibilityRole = ((Role)role).GetMacRole ();
+					accessibleCell.AccessibilitySubrole = ((Role)role).GetMacSubrole ();
+				}
+			}
+			var roleDescription = GetValue (source, frontend.AccessibleFields.RoleDescription);
+			if (roleDescription != null)
+				accessibleCell.AccessibilityRoleDescription = (string)roleDescription;
+		}
+
+		static object GetValue (ICellDataSource source, IDataField field)
+		{
+			if (field == null)
+				return null;
+			return source.GetValue (field);
+		}
+	}
+
+}
+

--- a/Xwt.XamMac/Xwt.Mac.CellViews/TextTableCell.cs
+++ b/Xwt.XamMac/Xwt.Mac.CellViews/TextTableCell.cs
@@ -66,6 +66,7 @@ namespace Xwt.Mac
 			else
 				StringValue = Frontend.Text ?? "";
 			Hidden = !Frontend.Visible;
+			TableCellUtil.ApplyAcessibilityProperties (this, Frontend);
 		}
 		
 		public virtual NSBackgroundStyle BackgroundStyle {

--- a/Xwt.XamMac/Xwt.XamMac.csproj
+++ b/Xwt.XamMac/Xwt.XamMac.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Xwt.Mac\AccessibleBackend.cs" />
     <Compile Include="Xwt.Mac\PopupWindowBackend.cs" />
     <Compile Include="Xwt.Mac\SearchTextEntryBackend.cs" />
+    <Compile Include="Xwt.Mac.CellViews\TableCellUtil.cs" />
   </ItemGroup>
   <Import Project="..\BuildHelpers.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Xwt/Xwt.Accessibility/AccessibleFields.cs
+++ b/Xwt/Xwt.Accessibility/AccessibleFields.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Xwt.Accessibility
+{
+	public class AccessibleFields
+	{
+
+		public IDataField<string> Label { get; set; }
+		public IDataField<string> Identifier { get; set; }
+		public IDataField<bool> IsAccessible { get; set; }
+		public IDataField<string> Title { get; set; }
+		public IDataField<string> Description { get; set; }
+		public IDataField<string> Value { get; set; }
+		public IDataField<Uri> Uri { get; set; }
+		public IDataField<Role> Role { get; set; }
+		public IDataField<string> RoleDescription { get; set; }
+		public IDataField<Rectangle> Bounds { get; set; }
+		
+		public AccessibleFields ()
+		{
+
+		}
+	}
+}

--- a/Xwt/Xwt.Backends/ICellViewFrontend.cs
+++ b/Xwt/Xwt.Backends/ICellViewFrontend.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using Xwt.Accessibility;
 
 namespace Xwt.Backends
 {
@@ -35,6 +36,7 @@ namespace Xwt.Backends
 		void Unload ();
 		bool Visible { get; }
 		bool Expands { get; }
+		AccessibleFields AccessibleFields { get; }
 	}
 
 	public interface ICellViewProvider

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -361,6 +361,7 @@
     <Compile Include="Xwt.Backends\IUtilityWindowBackend.cs" />
     <Compile Include="Xwt\TextChangedEventArgs.cs" />
     <Compile Include="Xwt.Drawing\FontSizeTextAttribute.cs" />
+    <Compile Include="Xwt.Accessibility\AccessibleFields.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt/CellView.cs
+++ b/Xwt/Xwt/CellView.cs
@@ -27,6 +27,7 @@
 using System;
 using Xwt.Drawing;
 using Xwt.Backends;
+using Xwt.Accessibility;
 using System.ComponentModel;
 using System.Collections.Generic;
 
@@ -164,6 +165,8 @@ namespace Xwt
 			get { return GetValue (VisibleField, visible); }
 			set { visible = value; }
 		}
+
+		public AccessibleFields AccessibleFields { get; set; }
 
 		ICellViewEventSink ICellViewFrontend.Load (ICellDataSource dataSource)
 		{


### PR DESCRIPTION
Moved from https://github.com/mono/xwt/pull/867.

Xwt.Gtk is not supported. Gtk.CellRenderer doesn't provide a11y API.