### PR TITLE
[a11y][Gtk] Revert combobox fix.

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -59,27 +59,7 @@ namespace Xwt.GtkBackend
 		public void Initialize (IWidgetBackend parentWidget, IAccessibleEventSink eventSink)
 		{
 			var backend = parentWidget as WidgetBackend;
-			Gtk.Widget nativeWidget = null;
-
-			// Needed only for AtkCocoa.
-			if (Platform.IsMac) {
-				// Gtk.ComboBox and Gtk.ComboBoxEntry a11y doesn't work with Gtk/AtkCocoa.
-				// Workaround:
-				// Set a11y properties to their children.
-				// For Gtk.ComboBoxEntry use its Gtk.Entry, for Gtk.ComboBox -- Gtk.ToggleButton.
-				if (backend is IComboBoxEntryBackend) {
-					nativeWidget = (backend?.Widget as Gtk.Bin)?.Child;
-				} else if (backend is IComboBoxBackend) {
-					foreach (var child in ((Gtk.Container)backend.Widget).AllChildren) {
-						if (child is Gtk.ToggleButton) {
-							nativeWidget = (Gtk.Widget)child;
-							break;
-						}
-					}
-				}
-			}
-
-			Initialize (nativeWidget ?? backend?.Widget, eventSink);
+			Initialize (backend?.Widget, eventSink);
 		}
 
 		public void Initialize (IPopoverBackend parentPopover, IAccessibleEventSink eventSink)


### PR DESCRIPTION
ComboBox a11y was fixed in AtkCocoa:
https://github.com/xamarin/AtkCocoa/commit/fda79fda389ce0843fa3577153e9843896b2ce6f
https://github.com/xamarin/AtkCocoa/commit/04244aa58bdf43e61e9194aa2455498f6da267ae
https://github.com/xamarin/AtkCocoa/commit/f23cbca7707c21eb954d2c86a86b56c2c458e3bf