### PR TITLE
Gtk.ComboBoxBackend: set Widget.RowSeparatorFunc to null on dispose

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/ComboBoxBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ComboBoxBackend.cs
@@ -188,6 +188,12 @@ namespace Xwt.GtkBackend
 		{
 		}
 
+		protected override void Dispose(bool disposing)
+		{
+			Widget.RowSeparatorFunc = null;
+			base.Dispose(disposing);
+		}
+
 		#endregion
 	}
 }


### PR DESCRIPTION
in some situations i get a 

CallbackOnCollectedDelegate - Error for 
gtk-sharp!GtkSharp.TreeViewRowSeparatorFuncNative::Invoke

running xwt.gtk on windows (win7, win 10).

stack trace:
 at Gtk.Application.gtk_main()
   at Gtk.Application.Run()
   at Xwt.GtkBackend.GtkEngine.RunApplication()
   at Xwt.Application.<>c.<Run>b__21_0()
   at Xwt.Toolkit.InvokePlatformCode(Action a)
   at Xwt.Application.Run()

after this patch the error doesn't occur any more so far.

Info: Visual - Studio - Message (sorry, german):

Assistent für verwaltetes Debuggen "CallbackOnCollectedDelegate"    Nachricht = Assistent für verwaltetes Debuggen "CallbackOnCollectedDelegate" : "Für den von der Garbage Collection gesammelten Delegaten vom Typ "gtk-sharp!GtkSharp.TreeViewRowSeparatorFuncNative::Invoke" wurde ein Rückruf durchgeführt. Dies kann Anwendungsabstürze, Datenbeschädigung und -verlust zur Folge haben. Beim Übergeben von Delegaten an nicht verwalteten Code müssen die Delegaten von der verwalteten Anwendung beibehalten werden, bis sichergestellt ist, dass sie nie aufgerufen werden."  