### PR TITLE
[Mac] Enforce NSAccessible window focus

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -176,8 +176,11 @@ namespace Xwt.Mac
 			OrderOut (this);
 			Close();
 			NSApplication.SharedApplication.StopModal ();
-			if (parent != null)
+			if (parent != null) {
 				parent.MakeKeyAndOrderFront (parent);
+				NSApplication.SharedApplication.AccessibilityFocusedWindow = parent;
+				parent.AccessibilityFocused = true;
+			}
 		}
 
 		#endregion

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -116,6 +116,10 @@ namespace Xwt.Mac
 				if (!ParentWindow.ChildWindows.Contains(this))
 					ParentWindow.AddChildWindow(this, NSWindowOrderingMode.Above);
 
+				ParentWindow.AccessibilityFocused = false;
+				NSApplication.SharedApplication.AccessibilityFocusedWindow = this;
+				AccessibilityFocused = true;
+
 				// always use NSWindow for alignment when running in guest mode and
 				// don't rely on AddChildWindow to position the window correctly
 				if (frontend.InitialLocation == WindowLocation.CenterParent && !(ParentWindow is WindowBackend))


### PR DESCRIPTION
This is similar to what we do with Alerts in MD: https://github.com/mono/monodevelop/blob/3d90ba1e74780c725dc44ba260b9e61dc9f7a572/main/src/addins/MacPlatform/Dialogs/MacAlertDialogHandler.cs#L193-L205