### PR TITLE
[Mac] Fix ref count bug when disposing windows

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -475,6 +475,8 @@ namespace Xwt.Mac
 
 		static Selector closeSel = new Selector ("close");
 
+		static readonly bool XamMacDangerousDispose = Version.Parse(Constants.Version) < new Version(5, 6);
+
 		bool disposing, disposed;
 
 		protected override void Dispose(bool disposing)
@@ -486,17 +488,19 @@ namespace Xwt.Mac
 				{
 					if (VisibilityEventsEnabled() && ContentView != null)
 						ContentView.RemoveObserver(this, HiddenProperty);
-					
-					// HACK: Xamarin.Mac/MonoMac limitation: no direct way to release a window manually
-					// A NSWindow instance will be removed from NSApplication.SharedApplication.Windows
-					// only if it is being closed with ReleasedWhenClosed set to true but not on Dispose
-					// and there is no managed way to tell Cocoa to release the window manually (and to
-					// remove it from the active window list).
-					// see also: https://bugzilla.xamarin.com/show_bug.cgi?id=45298
-					// WORKAROUND:
-					// bump native reference count by calling DangerousRetain()
-					// base.Dispose will now unref the window correctly without crashing
-					DangerousRetain();
+
+					if (XamMacDangerousDispose) {
+						// HACK: Xamarin.Mac/MonoMac limitation: no direct way to release a window manually
+						// A NSWindow instance will be removed from NSApplication.SharedApplication.Windows
+						// only if it is being closed with ReleasedWhenClosed set to true but not on Dispose
+						// and there is no managed way to tell Cocoa to release the window manually (and to
+						// remove it from the active window list).
+						// see also: https://bugzilla.xamarin.com/show_bug.cgi?id=45298
+						// WORKAROUND:
+						// bump native reference count by calling DangerousRetain()
+						// base.Dispose will now unref the window correctly without crashing
+						DangerousRetain();
+					}
 					// tell Cocoa to release the window on Close
 					ReleasedWhenClosed = true;
 					// Close the window (Cocoa will do its job even if the window is already closed)


### PR DESCRIPTION
The fix introduced in 1af157a05698b084882519099e92a4f2b55d881c
is not required since Xamarin.Mac version 5.6 and has
the opposite effect.

Fixes VSTS #756962