### PR TITLE
Check for disposed windows

### DIFF
--- a/Xwt/Xwt/Widget.cs
+++ b/Xwt/Xwt/Widget.cs
@@ -1677,12 +1677,14 @@ namespace Xwt
 				foreach (var w in toReallocate) {
 					// The widget may already have been reallocated as a result of reallocating the parent
 					// so we have to check if it is still in the queue
-					if (reallocationQueue.Contains (w))
+					if (!w.IsDisposed && reallocationQueue.Contains (w))
 						w.Surface.Reallocate ();
 				}
 				foreach (var w in resizeWindows.ToArray ()) {
-					w.AdjustSize ();
-					w.Reallocate ();
+					if (!w.IsDisposed) {
+						w.AdjustSize();
+						w.Reallocate();
+					}
 				}
 			} finally {
 				resizeRequestQueue.Clear ();

--- a/Xwt/Xwt/XwtComponent.cs
+++ b/Xwt/Xwt/XwtComponent.cs
@@ -178,6 +178,14 @@ namespace Xwt
 		}
 
 		#endregion
+
+		public bool IsDisposed { get; private set; } = false;
+
+		protected override void Dispose (bool release_all)
+		{
+			base.Dispose (release_all);
+			IsDisposed = true;
+		}
 	}
 
 	class AsyncInvokeResult : IAsyncResult


### PR DESCRIPTION
This patch adds `XwtComponent.IsDisposed` and a check for the same when reallocating windows at the end of a UI loop.