### PR TITLE
[Mac] Make boxes not take focus ever

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/BoxBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/BoxBackend.cs
@@ -40,6 +40,7 @@ namespace Xwt.Mac
 		public override void Initialize ()
 		{
 			ViewObject = new WidgetView (EventSink, ApplicationContext);
+			CanGetFocus = false;
 		}
 
 		public void Add (IWidgetBackend widget)


### PR DESCRIPTION
If not, they participate in the key view loop, which makes focus being lost
on TAB navigation when there are boxes in the window.