### PR TITLE
Menu support for cross-toolkit targets

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/MenuBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/MenuBackend.cs
@@ -126,7 +126,10 @@ namespace Xwt.GtkBackend
 		
 		public void Popup (IWidgetBackend widget, double x, double y)
 		{
-			GtkWorkarounds.ShowContextMenu (Menu, ((WidgetBackend)widget).Widget, new Gdk.Rectangle ((int)x, (int)y, 0, 0));
+			var target = widget as WidgetBackend;
+			if (target == null)
+				throw new ArgumentException ("Widget belongs to an unsupported Toolkit", nameof (widget));
+			GtkWorkarounds.ShowContextMenu (Menu, target.Widget, new Gdk.Rectangle ((int)x, (int)y, 0, 0));
 		}
 	}
 }

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -320,7 +320,7 @@ namespace Xwt.GtkBackend
 			int x = 0, y = 0;
 			if (RootWidget?.Parent != null)
 				Widget.TranslateCoordinates (RootWidget.Parent, x, y, out x, out y);
-			return new Point (x, y);
+			return new Point (x + widgetCoordinates.X, y + widgetCoordinates.Y);
 		}
 
 		public Point ConvertToWindowCoordinates (Point widgetCoordinates)
@@ -328,7 +328,7 @@ namespace Xwt.GtkBackend
 			int x = 0, y = 0;
 			if (RootWidget?.Toplevel != null)
 				Widget.TranslateCoordinates (RootWidget.Toplevel, x, y, out x, out y);
-			return new Point (x, y);
+			return new Point (x + widgetCoordinates.X, y + widgetCoordinates.Y);
 		}
 		
 		public Point ConvertToScreenCoordinates (Point widgetCoordinates)

--- a/Xwt.WPF/Xwt.WPFBackend/MenuBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/MenuBackend.cs
@@ -124,7 +124,10 @@ namespace Xwt.WPFBackend
 		public void Popup (IWidgetBackend widget, double x, double y)
 		{
 			var menu = CreateContextMenu ();
-			menu.PlacementTarget = (UIElement) widget.NativeWidget;
+			var target = widget.NativeWidget as UIElement;
+			if (target == null)
+				throw new System.ArgumentException ("Widget belongs to an unsupported Toolkit", nameof (widget));
+			menu.PlacementTarget = target;
 			menu.Placement = PlacementMode.Relative;
 
 			double hratio = 1;

--- a/Xwt/Xwt/Menu.cs
+++ b/Xwt/Xwt/Menu.cs
@@ -100,7 +100,7 @@ namespace Xwt
 		/// <param name="y">The y coordinate, relative to the widget origin</param>
 		public void Popup (Widget parentWidget, double x, double y)
 		{
-			Backend.Popup ((IWidgetBackend)BackendHost.ToolkitEngine.GetSafeBackend (parentWidget), x, y);
+			Backend.Popup (parentWidget.GetBackend (), x, y);
 		}
 		
 		/// <summary>


### PR DESCRIPTION
Allows menus to be shown relative to a target from a different toolkit. Only Cocoa above Gtk for now.