### PR TITLE
[Gtk] Fix the focus order of widgets inside a Box

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/BoxBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/BoxBackend.cs
@@ -94,7 +94,12 @@ namespace Xwt.GtkBackend
 			Add (newWidget);
 			children [newWidget] = r;
 		}
-		
+
+		void UpdateFocusChain (Orientation orientation)
+		{
+			FocusChain = children.OrderBy ((arg) => orientation == Orientation.Horizontal ? arg.Value.Rect.X : arg.Value.Rect.Y).Select (arg => arg.Key).ToArray ();
+		}
+
 		public bool SetAllocation (Gtk.Widget w, Rectangle rect)
 		{
 			WidgetData r;
@@ -102,6 +107,7 @@ namespace Xwt.GtkBackend
 			if (r.Rect != rect) {
 				r.Rect = rect;
 				children [w] = r;
+				UpdateFocusChain (Backend.Frontend is HBox ? Orientation.Horizontal : Orientation.Vertical);
 				return true;
 			} else
 				return false;

--- a/Xwt.Gtk/Xwt.GtkBackend/BoxBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/BoxBackend.cs
@@ -97,7 +97,19 @@ namespace Xwt.GtkBackend
 
 		void UpdateFocusChain (Orientation orientation)
 		{
-			FocusChain = children.OrderBy ((arg) => orientation == Orientation.Horizontal ? arg.Value.Rect.X : arg.Value.Rect.Y).Select (arg => arg.Key).ToArray ();
+			var focusChain = children.Keys.ToArray();
+			Array.Sort (focusChain, (x, y) => {
+				int left, right;
+				if (orientation == Orientation.Horizontal) {
+					left = (int)children[x].Rect.X;
+					right = (int)children[y].Rect.X;
+				} else {
+					left = (int)children[x].Rect.Y;
+					right = (int)children[y].Rect.Y;
+				}
+				return left - right;
+			});
+			FocusChain = focusChain;
 		}
 
 		public bool SetAllocation (Gtk.Widget w, Rectangle rect)


### PR DESCRIPTION
We don't use HBox/VBox containers but let the frontend calculate
the widget allocation. This seems to confuse the Gtk focus order
calculation, especially if the widgets have additional alignemnt
requirements (vertical in HBox and horizontal in VBox).

Fixes VSTS #752833