### PR TITLE
Add TextColor support to RichTextView component.

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/RichTextViewBackend.cs
@@ -91,6 +91,8 @@ namespace Xwt.GtkBackend
 			table.Add (new Gtk.TextTag ("p") {
 				SizePoints = Math.Max (LineSpacing, ParagraphSpacing),
 			});
+			
+			table.Add(new Gtk.TextTag ("textColor"));
 		}
 
 		private new GtkTextView Widget {
@@ -174,6 +176,19 @@ namespace Xwt.GtkBackend
 				Widget.PixelsBelowLines = value;
 				var tag = table.Lookup ("p");
 				tag.SizePoints = Math.Max (value, ParagraphSpacing);
+			}
+		}
+
+		public Drawing.Color TextColor {
+			get {
+				var tag = table.Lookup ("textColor");
+				return tag.ForegroundGdk.ToXwtValue ();
+			}
+			set {
+				var tag = table.Lookup ("textColor");
+				tag.ForegroundGdk = value.ToGtkValue ();
+				var buffer = Widget.Buffer;
+				buffer.ApplyTag (tag, buffer.StartIter, buffer.EndIter);
 			}
 		}
 

--- a/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
@@ -35,6 +35,7 @@ using System.Windows.Media;
 using System.Windows.Navigation;
 using Xwt.Backends;
 using Xwt.WPFBackend.Utilities;
+using SWM = System.Windows.Media;
 
 namespace Xwt.WPFBackend
 {
@@ -155,9 +156,20 @@ namespace Xwt.WPFBackend
 			}
 		}
 
-		//todo: Implement
-		public Drawing.Color TextColor { get; set; }
+		public Xwt.Drawing.Color TextColor {
+			get {
+				SWM.Color color = SystemColors.ControlColor;
 
+				if (Widget.Foreground != null)
+					color = ((SWM.SolidColorBrush) Widget.Foreground).Color;
+
+				return DataConverter.ToXwtColor (color);
+			}
+			set {
+				Widget.Foreground = ResPool.GetSolidBrush (value);
+			}
+		}
+		
 		class RichTextBuffer : IRichTextBuffer
 		{
 			const int FontSize = 16;

--- a/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/RichTextViewBackend.cs
@@ -155,6 +155,9 @@ namespace Xwt.WPFBackend
 			}
 		}
 
+		//todo: Implement
+		public Drawing.Color TextColor { get; set; }
+
 		class RichTextBuffer : IRichTextBuffer
 		{
 			const int FontSize = 16;

--- a/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
@@ -134,6 +134,11 @@ namespace Xwt.Mac
 			}
 		}
 
+		public Drawing.Color TextColor {
+			get { return Widget.TextColor.ToXwtColor (); }
+			set { Widget.TextColor = value.ToNSColor (); }
+		}
+
 		int? lineSpacing = null;
 		public int LineSpacing {
 			get {

--- a/Xwt/Xwt.Backends/IRichTextViewBackend.cs
+++ b/Xwt/Xwt.Backends/IRichTextViewBackend.cs
@@ -6,6 +6,7 @@
 //
 // Copyright (c) 2012 Xamarin, Inc.
 using System;
+using Xwt.Drawing;
 
 namespace Xwt.Backends
 {
@@ -32,6 +33,8 @@ namespace Xwt.Backends
 		int LineSpacing { get; set; }
 
 		IRichTextBuffer CurrentBuffer { get; }
+
+		Color TextColor { get; set; }
 	}
 
 	public interface IRichTextBuffer

--- a/Xwt/Xwt/RichTextView.cs
+++ b/Xwt/Xwt/RichTextView.cs
@@ -126,6 +126,15 @@ namespace Xwt
 			}
 		}
 
+		public Drawing.Color TextColor {
+			get {
+				return Backend.TextColor;
+			}
+			set {
+				Backend.TextColor = value;
+			}
+		}
+
 		protected override BackendHost CreateBackendHost ()
 		{
 			return new WidgetBackendHost ();


### PR DESCRIPTION
These changes are mainly needed to fix Mac issue with the `MarkdownView` text color in Dark Mode. The default text color in Dark Mode is white. But it resets to black once formatted text is added to the`MarkdownView`. Exposing the `TextColor` property would give a chance to a client to solve the issue on its side.

Related vsts bug #`612427`.

Even though the PR's changes were initially made to fix a specific Mac's issue, I think this `RichTextView.TextColor` API could be useful in general.

Wpf's `TextColor` code was copied from `LabelBackend`, what is not nice. Let me know if I have a better option here.