### PR TITLE
[build] Add a Directory.Build.targets

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+
+  <!-- This is empty just to make sure we don't search above the Xwt tree for a Directory.Build.Targets -->
+
+</Project>


### PR DESCRIPTION
We have a Directory.Build.props so we should also add a .targets.

This is important because MSBuild searches upwards for both of
those files, so if we have a props and do not also have a targets
then it will be possible that we'll load up someone else's targets
*and not* also load up their props.

This affected the designer's build as Xwt skipped our props but took
our targets, and our targets depended on our props  :p