### PR TITLE
[Mac] Add missing native ctor to dialog backend

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -55,6 +55,10 @@ namespace Xwt.Mac
 			}
 		}
 
+		public DialogBackend (IntPtr ptr) : base (ptr)
+		{
+		}
+
 		public DialogBackend ()
 		{
 		}


### PR DESCRIPTION
This is required in the rare case when the runtime decides to resurrect a managed object and crashes if this constructor is missing. We have this already in WindowBackend and many others, DialogBackend was missing.