### PR TITLE
Fix crash when finalizing ComboBoxBackend

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/ComboBoxBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/ComboBoxBackend.cs
@@ -188,9 +188,12 @@ namespace Xwt.GtkBackend
 		{
 		}
 
+		bool disposed;
 		protected override void Dispose(bool disposing)
 		{
-			Widget.RowSeparatorFunc = null;
+			if (disposing && !disposed)
+				Widget.RowSeparatorFunc = null;
+			disposed = true;
 			base.Dispose(disposing);
 		}
 


### PR DESCRIPTION
Fixes:

```** (VisualStudio:96397): WARNING **: Gtk operations should be done on the main Thread
  at System.Environment.get_StackTrace () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/mono-x64/mcs/class/corlib/System/Environment.cs:316 
  at Gtk.Application.AssertMainThread () [0x00023] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/gtk-sharp-None/gtk/Application.cs:124 
  at Gtk.ComboBox.set_RowSeparatorFunc (Gtk.TreeViewRowSeparatorFunc value) [0x00001] in /Users/builder/jenkins/workspace/build-package-osx-mono/2018-08/external/bockbuild/builds/gtk-sharp-None/gtk/generated/ComboBox.custom:66 
  at Xwt.GtkBackend.ComboBoxBackend.Dispose (System.Boolean disposing) [0x00000] in /Users/vsts/agent/2.146.0/work/1/s/monodevelop/main/external/xwt/Xwt.Gtk/Xwt.GtkBackend/ComboBoxBackend.cs:193 
  at Xwt.GtkBackend.WidgetBackend.Finalize () [0x00000] in /Users/vsts/agent/2.146.0/work/1/s/monodevelop/main/external/xwt/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs:264 ```

When finalizer runs on a non-ui thread.