### PR TITLE
Fix Xwt driven backend accessibility support

### DIFF
--- a/Xwt/Xwt.Accessibility/Accessible.cs
+++ b/Xwt/Xwt.Accessibility/Accessible.cs
@@ -93,6 +93,8 @@ namespace Xwt.Accessibility
 			parentComponent = parent;
 			backendHost = new AccessibleBackendHost ();
 			backendHost.Parent = this;
+			if (parent.GetBackend () is XwtWidgetBackend)
+				backendHost.SetCustomBackend (new XwtAccessibleBackend());
 
 		}
 

--- a/Xwt/Xwt.Accessibility/XwtAccessibleBackend.cs
+++ b/Xwt/Xwt.Accessibility/XwtAccessibleBackend.cs
@@ -1,0 +1,215 @@
+﻿//
+// XwtAccessibleBackend.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2019 (c) Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using Xwt.Backends;
+
+namespace Xwt.Accessibility
+{
+	public class XwtAccessibleBackend : IAccessibleBackend
+	{
+		protected Widget widget;
+		protected XwtWidgetBackend widgetBackend;
+		private IAccessibleBackend nativeBackend;
+		IAccessibleEventSink eventSink;
+		ApplicationContext context;
+
+		public XwtAccessibleBackend ()
+		{
+		}
+
+		public void Initialize (IAccessibleEventSink eventSink)
+		{
+			this.eventSink = eventSink;
+		}
+
+		public void Initialize (IWidgetBackend parentWidget, IAccessibleEventSink eventSink)
+		{
+			widgetBackend = parentWidget as XwtWidgetBackend;
+			Initialize (widgetBackend?.Frontend, eventSink);
+		}
+
+		public void Initialize (IPopoverBackend parentPopover, IAccessibleEventSink eventSink)
+		{
+		}
+
+		public void Initialize (IMenuBackend parentMenu, IAccessibleEventSink eventSync)
+		{
+		}
+
+		public void Initialize (IMenuItemBackend parentMenuItem, IAccessibleEventSink eventSink)
+		{
+		}
+
+		public void Initialize (object parentWidget, IAccessibleEventSink eventSink)
+		{
+			this.eventSink = eventSink;
+			widget = parentWidget as Widget;
+			if (widgetBackend == null)
+				widgetBackend = widget?.GetBackend () as XwtWidgetBackend;
+			if (widgetBackend == null)
+				throw new ArgumentException ("The widget is not a custom Xwt.Widget", nameof(parentWidget));
+			nativeBackend = context.Toolkit.Backend.CreateBackendForFrontend (typeof(Accessible)) as IAccessibleBackend;
+			nativeBackend.Initialize (widgetBackend.Content.Surface.NativeWidget, eventSink);
+		}
+
+		public void InitializeBackend(object frontend, ApplicationContext context)
+		{
+			this.context = context;
+		}
+
+		public Rectangle Bounds
+		{
+			get {
+				return nativeBackend.Bounds;
+			}
+			set {
+				nativeBackend.Bounds = value;
+			}
+		}
+
+		public string Description
+		{
+			get {
+				return nativeBackend.Description;
+			}
+			set {
+				nativeBackend.Description = value;
+			}
+		}
+
+		public virtual string Label
+		{
+			get {
+				return nativeBackend.Label;
+			}
+			set {
+				nativeBackend.Label = value;
+			}
+		}
+
+		public string Identifier
+		{
+			get {
+				return nativeBackend.Identifier;
+			}
+			set {
+				nativeBackend.Identifier = value;
+			}
+		}
+
+		public Role Role
+		{
+			get {
+				return nativeBackend.Role;
+			}
+			set {
+				nativeBackend.Role = value;
+			}
+		}
+
+		public string RoleDescription
+		{
+			get {
+				return nativeBackend.RoleDescription;
+			}
+			set {
+				nativeBackend.RoleDescription = value;
+			}
+		}
+
+		public string Title
+		{
+			get {
+				return nativeBackend.Title;
+			}
+			set {
+				nativeBackend.Title = value;
+			}
+		}
+
+		public string Value
+		{
+			get {
+				return nativeBackend.Value;
+			}
+			set {
+				nativeBackend.Value = value;
+			}
+		}
+
+		public Widget LabelWidget
+		{
+			set {
+				nativeBackend.LabelWidget = value;
+			}
+		}
+
+		public virtual Uri Uri
+		{
+			get {
+				return nativeBackend.Uri;
+			}
+			set {
+				nativeBackend.Uri = value;
+			}
+		}
+
+		public bool IsAccessible
+		{
+			get {
+				return nativeBackend.IsAccessible;
+			}
+			set {
+				nativeBackend.IsAccessible = value;
+			}
+		}
+
+		public virtual void AddChild (object nativeChild)
+		{
+			nativeBackend.AddChild (nativeChild);
+		}
+
+		public virtual void RemoveChild (object nativeChild)
+		{
+			nativeBackend.RemoveChild (nativeChild);
+		}
+
+		public virtual void RemoveAllChildren ()
+		{
+			nativeBackend.RemoveAllChildren ();
+		}
+
+		public void DisableEvent (object eventId)
+		{
+			nativeBackend.DisableEvent (eventId);
+		}
+
+		public void EnableEvent (object eventId)
+		{
+			nativeBackend.EnableEvent (eventId);
+		}
+	}
+}

--- a/Xwt/Xwt.Backends/XwtWidgetBackend.cs
+++ b/Xwt/Xwt.Backends/XwtWidgetBackend.cs
@@ -39,7 +39,7 @@ namespace Xwt.Backends
 	/// </remarks>
 	public class XwtWidgetBackend: Widget, IWidgetBackend
 	{
-		protected Widget Frontend {
+		internal protected Widget Frontend {
 			get; private set;
 		}
 		

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -362,6 +362,7 @@
     <Compile Include="Xwt\TextChangedEventArgs.cs" />
     <Compile Include="Xwt.Drawing\FontSizeTextAttribute.cs" />
     <Compile Include="Xwt.Accessibility\AccessibleFields.cs" />
+    <Compile Include="Xwt.Accessibility\XwtAccessibleBackend.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup />

--- a/Xwt/Xwt/Widget.cs
+++ b/Xwt/Xwt/Widget.cs
@@ -634,7 +634,7 @@ namespace Xwt
 		/// Gets or sets the content of this <see cref="Xwt.Widget"/>.
 		/// </summary>
 		/// <value>The content of the widget.</value>
-		protected Widget Content {
+		internal protected Widget Content {
 			get { return contentWidget; }
 			set {
 				ICustomWidgetBackend bk = Backend as ICustomWidgetBackend;


### PR DESCRIPTION
This adds accessibility support to Xwt based default backends like `DefaultFileSelectorBackend`.
The XwtAccessibleBackend proxies accessibility from the xwt driven custom backend to the native backend of the content widget.