### PR TITLE
[Mac] Fix container focus being enabled by default

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/CanvasBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/CanvasBackend.cs
@@ -92,8 +92,28 @@ namespace Xwt.Mac
 			w.Frame = new CGRect ((nfloat)rect.X, (nfloat)rect.Y, (nfloat)rect.Width, (nfloat)rect.Height);;
 			w.NeedsDisplay = true;
 		}
+
+		bool canGetFocus;
+		public override bool CanGetFocus
+		{
+			get { return canGetFocus; }
+			set { canGetFocus = value; }
+		}
+
+		public override void SetFocus()
+		{
+			if (Widget.Window != null && CanGetFocus)
+				Widget.Window.MakeFirstResponder(Widget);
+		}
+
+		public override bool HasFocus
+		{
+			get {
+				return Widget.Window != null && Widget.Window.FirstResponder == Widget;
+			}
+		}
 	}
-	
+
 	class CanvasView: WidgetView
 	{
 		ICanvasEventSink eventSink;
@@ -127,6 +147,17 @@ namespace Xwt.Mac
 			set {
 				base.AccessibilityProxy = value;
 			}
+		}
+
+		public override bool AcceptsFirstResponder ()
+		{
+			return Backend?.CanGetFocus ?? false;
+		}
+
+		public override bool BecomeFirstResponder()
+		{
+			// this is really required
+			return base.BecomeFirstResponder();
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/LabelBackend.cs
@@ -43,6 +43,7 @@ namespace Xwt.Mac
 		protected LabelBackend (IViewObject view)
 		{
 			View = view;
+			view.Backend = this;
 		}
 
 		IViewObject View;
@@ -50,6 +51,7 @@ namespace Xwt.Mac
 		public override void Initialize ()
 		{
 			ViewObject = new CustomAlignedContainer (EventSink, ApplicationContext, (NSView)View);
+			CanGetFocus = false;
 			Widget.StringValue = string.Empty;
 			Widget.Editable = false;
 			Widget.Bezeled = false;
@@ -230,6 +232,11 @@ namespace Xwt.Mac
 				Child.Frame = new CGRect (0, (Frame.Height - Child.Frame.Height) / 2, Frame.Width, Child.Frame.Height);
 			}
 			Child.NeedsDisplay = true;
+		}
+
+		public override bool AcceptsFirstResponder()
+		{
+			return false;
 		}
 	}
 	

--- a/Xwt.XamMac/Xwt.Mac/SpinButtonBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/SpinButtonBackend.cs
@@ -104,6 +104,27 @@ namespace Xwt.Mac
 		{
 			Widget.SizeToFit ();
 		}
+
+		bool canGetFocus;
+		public override bool CanGetFocus
+		{
+			get { return canGetFocus; }
+			set { canGetFocus = value; }
+		}
+
+		public override void SetFocus()
+		{
+			if (Widget.Input.Window != null && CanGetFocus)
+				Widget.Input.Window.MakeFirstResponder(Widget.Input);
+		}
+
+		public override bool HasFocus
+		{
+			get
+			{
+				return Widget.Window != null && (Widget.Window.FirstResponder == Widget.Input || Widget.Window.FirstResponder == Widget.Stepper);
+			}
+		}
 	}
 
 	public sealed class MacSpinButton : WidgetView
@@ -111,6 +132,9 @@ namespace Xwt.Mac
 		NSStepper stepper;
 		NSTextField input;
 		NSNumberFormatter formater;
+
+		internal NSTextField Input { get { return input; } }
+		internal NSStepper Stepper { get { return stepper; } }
 
 		ISpinButtonEventSink eventSink;
 
@@ -325,6 +349,11 @@ namespace Xwt.Mac
 				case SpinButtonEvent.ValueChanged: enableValueChangedEvent = false; break;
 				}
 			}
+		}
+
+		public override bool AcceptsFirstResponder()
+		{
+			return false;
 		}
 
 		public override string AccessibilityLabel


### PR DESCRIPTION
By default internal alignment containers accept keyboard focus resulting in unexpected focus losses. This patch disables this behaviour (can be still enabled manually) and includes some additional minor accessibility fixes.