### PR TITLE
[XamMac] Fix NSTextView text color bug.

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
@@ -148,7 +148,7 @@ namespace Xwt.Mac
 				lineSpacing = value;
 
 				if (currentBuffer != null)
-					Widget.TextStorage.SetString (currentBuffer.ToAttributedString (font, lineSpacing));
+					Widget.SetAttributedString (currentBuffer.ToAttributedString (font, lineSpacing));
 			}
 		}
 
@@ -173,7 +173,8 @@ namespace Xwt.Mac
 			if (tview == null)
 				return;
 
-			tview.TextStorage.SetString (macBuffer.ToAttributedString (font, lineSpacing));
+
+			tview.SetAttributedString (macBuffer.ToAttributedString (font, lineSpacing));
 		}
 
 		public override void EnableEvent (object eventId)

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -58,6 +58,28 @@ namespace Xwt.Mac
 			}
 		}
 
+		public static void SetAttributedString (this NSTextView view, NSAttributedString str)
+		{
+			var textColor = view.TextColor;
+			view.TextStorage.SetString (str);
+			
+			// Workaround:
+			// Check if we have ForegroundColor attribute
+			// And if we don't, then apply the previous view's TextColor,
+			// otherwise it would be reset to Black by the line above.
+			var hasForegroundAttr = false;
+			view.TextStorage.EnumerateAttributes (new NSRange (0, view.TextStorage.Length), NSAttributedStringEnumeration.None, (NSDictionary attrs, NSRange range, ref bool stop) => {
+					stop = false;
+					if (attrs.ContainsKey (NSStringAttributeKey.ForegroundColor)) {
+						hasForegroundAttr = true;
+						stop = true;
+					}
+			});
+
+			if (!hasForegroundAttr && textColor != null)
+				view.TextColor = textColor;
+		}
+
 		public static double WidgetX (this NSView v)
 		{
 			return (double) v.Frame.X;
@@ -407,8 +429,6 @@ namespace Xwt.Mac
 			ns.EndEditing ();
 			return ns;
 		}
-
-
 
 		public static NSMutableAttributedString WithAlignment (this NSMutableAttributedString ns, NSTextAlignment alignment)
 		{


### PR DESCRIPTION
Setting the text color to its previous value after applying
an attributed string. Otherwise the text color resets to Black
no matter of what color it was before.

VSTS Bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/612427