### PR TITLE
[XamMac] Updates https://github.com/mono/xwt/pull/925

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/RichTextViewBackend.cs
@@ -29,6 +29,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Xml;
+using System.Linq;
 using AppKit;
 using CoreGraphics;
 using Foundation;
@@ -148,7 +149,7 @@ namespace Xwt.Mac
 				lineSpacing = value;
 
 				if (currentBuffer != null)
-					Widget.SetAttributedString (currentBuffer.ToAttributedString (font, lineSpacing));
+					Widget.SetAttributedString (currentBuffer.ToAttributedString (font, lineSpacing), !currentBuffer.HasForegroundAttributes);
 			}
 		}
 
@@ -174,7 +175,7 @@ namespace Xwt.Mac
 				return;
 
 
-			tview.SetAttributedString (macBuffer.ToAttributedString (font, lineSpacing));
+			tview.SetAttributedString (macBuffer.ToAttributedString (font, lineSpacing), !macBuffer.HasForegroundAttributes);
 		}
 
 		public override void EnableEvent (object eventId)
@@ -350,6 +351,13 @@ namespace Xwt.Mac
 		readonly XmlWriter xmlWriter;
 		Stack <int> paragraphIndent;
 
+		/// <summary>
+		/// Used to identify whether we can safely update TextView's TextColor.
+		/// Otherwise such update can override all custom ForegroundColor attributes.
+		/// </summary>
+		/// <value></value>
+		public bool HasForegroundAttributes { get; private set; }
+
 		public MacRichTextBuffer ()
 		{
 			text = new StringBuilder ();
@@ -492,7 +500,6 @@ namespace Xwt.Mac
 			var d = s.GetData (new NSRange (0, s.Length), options, out err);
 			var str = (string)NSString.FromData (d, NSStringEncoding.UTF8);
 
-
 			//bool first = true;
 			foreach (string line in str.Split (lineSplitChars, StringSplitOptions.None)) {
 				//if (!first) {
@@ -502,6 +509,8 @@ namespace Xwt.Mac
 				//	first = false;
 				xmlWriter.WriteRaw (line);
 			}
+
+			HasForegroundAttributes |= text.Attributes.Any (a => a is Xwt.Drawing.ColorTextAttribute);
 		}
 
 		private static readonly IntPtr _AppKitHandle = Dlfcn.dlopen ("/System/Library/Frameworks/AppKit.framework/AppKit", 0);

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -58,25 +58,15 @@ namespace Xwt.Mac
 			}
 		}
 
-		public static void SetAttributedString (this NSTextView view, NSAttributedString str)
+		public static void SetAttributedString (this NSTextView view, NSAttributedString str, bool canOverrideTextColor)
 		{
 			var textColor = view.TextColor;
 			view.TextStorage.SetString (str);
 			
 			// Workaround:
-			// Check if we have ForegroundColor attribute
-			// And if we don't, then apply the previous view's TextColor,
+			// Apply the previous view's TextColor,
 			// otherwise it would be reset to Black by the line above.
-			var hasForegroundAttr = false;
-			view.TextStorage.EnumerateAttributes (new NSRange (0, view.TextStorage.Length), NSAttributedStringEnumeration.None, (NSDictionary attrs, NSRange range, ref bool stop) => {
-					stop = false;
-					if (attrs.ContainsKey (NSStringAttributeKey.ForegroundColor)) {
-						hasForegroundAttr = true;
-						stop = true;
-					}
-			});
-
-			if (!hasForegroundAttr && textColor != null)
+			if (canOverrideTextColor && textColor != null)
 				view.TextColor = textColor;
 		}
 


### PR DESCRIPTION
Fix the text color only if the initially applying formatted text
doesn't contain any ForegroundColor attributes.

Previous approach didn't work, because converting html attributes using
`initWithHTML:documentAttributes:` added default text color attribute
to each html attribute.
So `MacRichTextBuffer.CreateStringFromHTML` ended up building
an attributed string containing many ForegroundColor attributes.