### PR TITLE
[GTK] Close dialog on EndLoop to be consistent with XamMac and WPF

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/DialogBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/DialogBackend.cs
@@ -157,6 +157,7 @@ namespace Xwt.GtkBackend
 		public void EndLoop ()
 		{
 			Window.Respond (Gtk.ResponseType.Ok);
+			Window.Hide ();
 		}
 
 		public override bool Close ()


### PR DESCRIPTION
https://github.com/mono/xwt/blob/master/Xwt.XamMac/Xwt.Mac/DialogBackend.cs#L181
https://github.com/mono/xwt/blob/master/Xwt.WPF/Xwt.WPFBackend/DialogBackend.cs#L166
