### PR TITLE
[WPF] Respect TreeView column Expands flag

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
@@ -48,7 +48,6 @@ namespace Xwt.WPFBackend
 		{
 			Loaded += OnLoaded;
 			HorizontalContentAlignment = HorizontalAlignment.Stretch;
-			
 		}
 
 		public ExTreeViewItem (ExTreeView view)

--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
@@ -48,6 +48,7 @@ namespace Xwt.WPFBackend
 		{
 			Loaded += OnLoaded;
 			HorizontalContentAlignment = HorizontalAlignment.Stretch;
+			
 		}
 
 		public ExTreeViewItem (ExTreeView view)
@@ -224,6 +225,11 @@ namespace Xwt.WPFBackend
 
 				column.Width = Double.NaN;
 			}
+		}
+
+		public void ExpandColumnWidth (int columnIndex, double toWidth)
+		{
+			this.view.View.Columns [columnIndex].Width = toWidth;
 		}
 
 		protected override void OnKeyDown(System.Windows.Input.KeyEventArgs e)

--- a/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeStoreBackend.cs
@@ -96,7 +96,7 @@ namespace Xwt.WPFBackend
 			var node = (TreeStoreNode) pos;
 			node[column] = value;
 
-			OnNodeChanged (new TreeNodeEventArgs (pos));
+			OnNodeChanged (new TreeNodeEventArgs (pos, -1, column));
 		}
 
 		public TreePosition InsertBefore (TreePosition pos)

--- a/Xwt/Xwt/ITreeDataSource.cs
+++ b/Xwt/Xwt/ITreeDataSource.cs
@@ -49,14 +49,18 @@ namespace Xwt
 	
 	public class TreeNodeEventArgs: EventArgs
 	{
-		public TreeNodeEventArgs (TreePosition node): this (node, -1)
+		public TreeNodeEventArgs (TreePosition node): this (node, -1, -1)
+		{
+		}
+		public TreeNodeEventArgs(TreePosition node, int childIndex) : this (node, childIndex, -1)
 		{
 		}
 
-		public TreeNodeEventArgs (TreePosition node, int childIndex)
+		public TreeNodeEventArgs (TreePosition node, int childIndex, int changedCellIndex)
 		{
 			Node = node;
 			ChildIndex = childIndex;
+			ChangedCellIndex = changedCellIndex;
 		}
 		
 		public TreePosition Node {
@@ -68,6 +72,8 @@ namespace Xwt
 			get;
 			private set;
 		}
+
+		public int ChangedCellIndex { get; private set; }
 	}
 	
 	public class TreeNodeChildEventArgs: TreeNodeEventArgs


### PR DESCRIPTION
This will automatically expand the columns marked with Expands flag when their content changes.
Shift cell views column index and global cell indexes following the removed TreeView column.
^ This also fixes ArgumentOutOfRangeException in TreeViewBackend->GetCellBounds