### PR TITLE
FIxed `Pack` to use `PackOrigin` parameter instead `PackOrigin.Start`.

### DIFF
--- a/Xwt/Xwt/Box.cs
+++ b/Xwt/Xwt/Box.cs
@@ -195,7 +195,7 @@ namespace Xwt
 				widget.MarginRight = marginRight;
 			if (marginBottom != -1)
 				widget.MarginBottom = marginBottom;
-			Pack (widget, expand, align, PackOrigin.Start);
+			Pack (widget, expand, align, ptype);
 		}
 
 		void Pack (Widget widget, bool? expand, WidgetPlacement align, PackOrigin ptype)


### PR DESCRIPTION
A couple of overloads for `PackEnd` are broken, because they pass `PackOrigin.End` to the `Pack` but the value is never used.