### PR TITLE
[Mac] Fixed bug with Popover where the TextEntry is gray.

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -71,8 +71,16 @@ namespace Xwt.Mac
 			public override void LoadView ()
 			{
 				View = new ContainerView (this);
+
+				string appearance = NativeChild.EffectiveAppearance?.Name;
+
 				NativeChild.RemoveFromSuperview ();
 				View.AddSubview (NativeChild);
+
+				if (!string.IsNullOrEmpty(appearance) && appearance.IndexOf ("Dark", StringComparison.Ordinal) >= 0)
+					View.Appearance = NSAppearance.GetAppearance (NSAppearance.NameDarkAqua);
+				else
+					View.Appearance = NSAppearance.GetAppearance (NSAppearance.NameAqua);
 
 				WidgetSpacing padding = 0;
 				if (Backend != null)


### PR DESCRIPTION
* There is is a bug on AppKit where if you don't set the `Appearance` for you view, the `NSTextField` will be displayed with gray background

https://stackoverflow.com/questions/29074724/how-to-change-nstextfield-background-color-in-nspopover