### PR TITLE
[Mac] Popover appearance on High Sierra and older

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -78,7 +78,7 @@ namespace Xwt.Mac
 				View.AddSubview (NativeChild);
 
 				if (!string.IsNullOrEmpty(appearance) && appearance.IndexOf ("Dark", StringComparison.Ordinal) >= 0)
-					View.Appearance = NSAppearance.GetAppearance (NSAppearance.NameDarkAqua);
+					View.Appearance = NSAppearance.GetAppearance (MacSystemInformation.OsVersion < MacSystemInformation.Mojave ? NSAppearance.NameVibrantDark : new NSString("NSAppearanceNameDarkAqua"));
 				else
 					View.Appearance = NSAppearance.GetAppearance (NSAppearance.NameAqua);
 


### PR DESCRIPTION
NSAppearanceNameDarkAqua is not available before Mojave.

This also fixes the build on systems with an older Xamarin.Mac
version (incl. our own CI)

Regressed in #941