### PR TITLE
[Mac] Preserve the window location when resizing vertically

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -432,6 +432,13 @@ namespace Xwt.Mac
 			if (height == -1)
 				height = cr.Height;
 			var r = FrameRectFor (new CGRect ((nfloat)cr.X, (nfloat)cr.Y, (nfloat)width, (nfloat)height));
+
+			// preserve window location, FrameRectFor will not adjust the left-bottom corner automatically
+			var oldFrame = Frame;
+			if (!oldFrame.IsEmpty) {
+				r.Y = (oldFrame.Y + oldFrame.Height) - r.Height;
+			}
+
 			SetFrame (r, true);
 			LayoutWindow ();
 		}


### PR DESCRIPTION
Since the y-axis is inverted on Mac, we need to recalculate
the Y position to keep the window in place when it's being
resized vertically.