### PR TITLE
[Windows] Fix AlertDialogBackend on Windows

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
@@ -61,17 +61,13 @@ namespace Xwt.WPFBackend
 				// Use a system message box
 				if (message.SecondaryText == null)
 					message.SecondaryText = String.Empty;
-				else {
-					message.Text = message.Text + "\r\n\r\n" + message.SecondaryText;
-					message.SecondaryText = String.Empty;
-				}
 				var parent =  context.Toolkit.GetNativeWindow(transientFor) as System.Windows.Window;
 				if (parent != null) {
-					this.dialogResult = MessageBox.Show (parent, message.Text, message.SecondaryText,
-														this.buttons, this.icon, this.defaultResult, this.options);
+					this.dialogResult = MessageBox.Show (parent, message.SecondaryText, message.Text,
+                                                        this.buttons, this.icon, this.defaultResult, this.options);
 				}
 				else {
-					this.dialogResult = MessageBox.Show (message.Text, message.SecondaryText, this.buttons,
+					this.dialogResult = MessageBox.Show (message.SecondaryText, message.Text, this.buttons,
 														this.icon, this.defaultResult, this.options);
 				}
 				return ConvertResultToCommand (this.dialogResult);
@@ -81,6 +77,7 @@ namespace Xwt.WPFBackend
 				Dialog dlg = new Dialog ();
 				dlg.Resizable = false;
 				dlg.Padding = 0;
+				dlg.Title = message.Text ?? String.Empty;
 				HBox mainBox = new HBox { Margin = 25 };
 
 				if (message.Icon != null) {
@@ -89,11 +86,7 @@ namespace Xwt.WPFBackend
 				}
 				VBox box = new VBox () { Margin = 3, MarginLeft = 8, Spacing = 15 };
 				mainBox.PackStart (box, true);
-				var text = new Label {
-					Text = message.Text ?? ""
-				};
 				Label stext = null;
-				box.PackStart (text);
 				if (!string.IsNullOrEmpty (message.SecondaryText)) {
 					stext = new Label {
 						Text = message.SecondaryText
@@ -110,7 +103,6 @@ namespace Xwt.WPFBackend
 				if (message.DefaultButton >= 0 && message.DefaultButton < message.Buttons.Count)
 					dlg.DefaultCommand = message.Buttons[message.DefaultButton];
 				if (mainBox.Surface.GetPreferredSize (true).Width > 480) {
-					text.Wrap = WrapMode.Word;
 					if (stext != null)
 						stext.Wrap = WrapMode.Word;
 					mainBox.WidthRequest = 480;


### PR DESCRIPTION
The result of working WPF backend was wrong and looked bad. I changed it to use Text as Title and SecondaryText as a base message of resulting dialog.

The system message box as backend:
![image](https://user-images.githubusercontent.com/5506989/62528558-3ca37b80-b867-11e9-8fe4-1a15c5d0e1a8.png)

The custom dialog as backend:
![image](https://user-images.githubusercontent.com/5506989/62528909-d3703800-b867-11e9-8ba1-bcf6de4c0bf5.png)
