### PR TITLE
[Windows] Add support of Title for AlertDialogBackend on Windows

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
@@ -57,16 +57,16 @@ namespace Xwt.WPFBackend
 		public Command Run (WindowFrame transientFor, MessageDescription message)
 		{
 			this.icon = GetIcon (message.Icon);
-			if(string.IsNullOrEmpty(message.Title))
-				message.Title = (transientFor != null) ? transientFor.Title ?? String.Empty : String.Empty;
+			if (string.IsNullOrEmpty (message.Title))
+				message.Title = transientFor?.Title ?? string.Empty;
 
 			if (ConvertButtons (message.Buttons, out buttons) && message.Options.Count == 0) {
 				// Use a system message box
 				if (message.SecondaryText == null)
-					message.SecondaryText = String.Empty;
+					message.SecondaryText = string.Empty;
 				else {
 					message.Text = message.Text + "\r\n\r\n" + message.SecondaryText;
-					message.SecondaryText = String.Empty;
+					message.SecondaryText = string.Empty;
 				}
 				var parent =  context.Toolkit.GetNativeWindow(transientFor) as System.Windows.Window;
 				if (parent != null) {
@@ -94,7 +94,7 @@ namespace Xwt.WPFBackend
 				VBox box = new VBox () { Margin = 3, MarginLeft = 8, Spacing = 15 };
 				mainBox.PackStart (box, true);
 				var text = new Label {
-					Text = message.Text ?? String.Empty
+					Text = message.Text ?? string.Empty
 				};
 				Label stext = null;
 				box.PackStart (text);

--- a/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
@@ -57,6 +57,9 @@ namespace Xwt.WPFBackend
 		public Command Run (WindowFrame transientFor, MessageDescription message)
 		{
 			this.icon = GetIcon (message.Icon);
+			if(string.IsNullOrEmpty(message.Title))
+				message.Title = (transientFor != null) ? transientFor.Title ?? String.Empty : String.Empty;
+
 			if (ConvertButtons (message.Buttons, out buttons) && message.Options.Count == 0) {
 				// Use a system message box
 				if (message.SecondaryText == null)
@@ -67,11 +70,11 @@ namespace Xwt.WPFBackend
 				}
 				var parent =  context.Toolkit.GetNativeWindow(transientFor) as System.Windows.Window;
 				if (parent != null) {
-					this.dialogResult = MessageBox.Show (parent, message.Text, message.SecondaryText,
+					this.dialogResult = MessageBox.Show (parent, message.Text, message.Title,
 														this.buttons, this.icon, this.defaultResult, this.options);
 				}
 				else {
-					this.dialogResult = MessageBox.Show (message.Text, message.SecondaryText, this.buttons,
+					this.dialogResult = MessageBox.Show (message.Text, message.Title, this.buttons,
 														this.icon, this.defaultResult, this.options);
 				}
 				return ConvertResultToCommand (this.dialogResult);
@@ -81,6 +84,7 @@ namespace Xwt.WPFBackend
 				Dialog dlg = new Dialog ();
 				dlg.Resizable = false;
 				dlg.Padding = 0;
+				dlg.Title = message.Title;
 				HBox mainBox = new HBox { Margin = 25 };
 
 				if (message.Icon != null) {
@@ -90,7 +94,7 @@ namespace Xwt.WPFBackend
 				VBox box = new VBox () { Margin = 3, MarginLeft = 8, Spacing = 15 };
 				mainBox.PackStart (box, true);
 				var text = new Label {
-					Text = message.Text ?? ""
+					Text = message.Text ?? String.Empty
 				};
 				Label stext = null;
 				box.PackStart (text);

--- a/Xwt/Xwt/MessageDialog.cs
+++ b/Xwt/Xwt/MessageDialog.cs
@@ -49,10 +49,18 @@ namespace Xwt
 		}
 		public static void ShowError (WindowFrame parent, string primaryText, string secondaryText)
 		{
-			GenericAlert (parent, Toolkit.CurrentEngine.Defaults.MessageDialog.ErrorIcon, primaryText, secondaryText, Command.Ok);
+			ShowError(parent, primaryText, secondaryText, null);
+		}
+		public static void ShowError(string primaryText, string secondaryText, string title)
+		{
+			ShowError(RootWindow, primaryText, secondaryText, title);
+		}
+		public static void ShowError(WindowFrame parent, string primaryText, string secondaryText, string title)
+		{
+			GenericAlert(parent, Toolkit.CurrentEngine.Defaults.MessageDialog.ErrorIcon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
-		
+
 		#region ShowWarning
 		public static void ShowWarning (string primaryText)
 		{
@@ -68,11 +76,19 @@ namespace Xwt
 		}
 		public static void ShowWarning (WindowFrame parent, string primaryText, string secondaryText)
 		{
-			GenericAlert (parent, Toolkit.CurrentEngine.Defaults.MessageDialog.WarningIcon, primaryText, secondaryText, Command.Ok);
+			ShowWarning(RootWindow, primaryText, secondaryText, null);
+		}
+		public static void ShowWarning(string primaryText, string secondaryText, string title)
+		{
+			ShowWarning(RootWindow, primaryText, secondaryText, title);
+		}
+		public static void ShowWarning(WindowFrame parent, string primaryText, string secondaryText, string title)
+		{
+			GenericAlert(parent, Toolkit.CurrentEngine.Defaults.MessageDialog.WarningIcon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
-		
-		
+
+
 		#region ShowMessage
 		public static void ShowMessage (string primaryText)
 		{
@@ -86,20 +102,36 @@ namespace Xwt
 		{
 			ShowMessage (RootWindow, primaryText, secondaryText);
 		}
+		public static void ShowMessage(WindowFrame parent, string primaryText, string secondaryText)
+		{
+			ShowMessage(parent, primaryText, secondaryText, String.Empty);
+		}
+		public static void ShowMessage(string primaryText, string secondaryText, string title)
+		{
+			ShowMessage(RootWindow, primaryText, secondaryText, title);
+		}
+		public static void ShowMessage(WindowFrame parent, string primaryText, string secondaryText, string title)
+		{
+			ShowMessage(parent, primaryText, secondaryText, title, Toolkit.CurrentEngine.Defaults.MessageDialog.InformationIcon);
+		}
 		public static void ShowMessage (string primaryText, string secondaryText, Drawing.Image icon)
 		{
 			ShowMessage (RootWindow, primaryText, secondaryText, icon);
 		}
-		public static void ShowMessage (WindowFrame parent, string primaryText, string secondaryText)
-		{
-			GenericAlert (parent, Toolkit.CurrentEngine.Defaults.MessageDialog.InformationIcon, primaryText, secondaryText, Command.Ok);
-		}
 		public static void ShowMessage (WindowFrame parent, string primaryText, string secondaryText, Drawing.Image icon)
 		{
-			GenericAlert (parent, icon, primaryText, secondaryText, Command.Ok);
+			ShowMessage(RootWindow, primaryText, secondaryText, null, icon);
+		}
+		public static void ShowMessage(string primaryText, string secondaryText, string title, Drawing.Image icon)
+		{
+			ShowMessage(RootWindow, primaryText, secondaryText, title, icon);
+		}
+		public static void ShowMessage(WindowFrame parent, string primaryText, string secondaryText, string title, Drawing.Image icon)
+		{
+			GenericAlert(parent, icon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
-		
+
 		#region Confirm
 		public static bool Confirm (string primaryText, Command button)
 		{
@@ -111,6 +143,11 @@ namespace Xwt
 			return Confirm (RootWindow, primaryText, secondaryText, button);
 		}
 
+		public static bool Confirm(string primaryText, string secondaryText, string title, Command button)
+		{
+			return Confirm(RootWindow, primaryText, secondaryText, title, button);
+		}
+
 		public static bool Confirm (string primaryText, string secondaryText, Drawing.Image icon, Command button)
 		{
 			return Confirm (RootWindow, primaryText, secondaryText, icon, button);
@@ -118,12 +155,22 @@ namespace Xwt
 
 		public static bool Confirm (WindowFrame window, string primaryText, string secondaryText, Command button)
 		{
-			return GenericAlert (window, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, Command.Cancel, button) == button;
+			return Confirm(window, primaryText, secondaryText, String.Empty, button);
+
+		}
+		public static bool Confirm(WindowFrame window, string primaryText, string secondaryText, string title, Command button)
+		{
+			return GenericAlert(window, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, Command.Cancel, button) == button;
 		}
 
 		public static bool Confirm (WindowFrame window, string primaryText, string secondaryText, Drawing.Image icon, Command button)
 		{
-			return GenericAlert (window, icon, primaryText, secondaryText, Command.Cancel, button) == button;
+			return Confirm(window, primaryText, secondaryText, String.Empty, icon, button);
+
+		}
+		public static bool Confirm(WindowFrame window, string primaryText, string secondaryText, string title, Drawing.Image icon, Command button)
+		{
+			return GenericAlert(window, icon, primaryText, secondaryText, title, Command.Cancel, button) == button;
 		}
 
 		public static bool Confirm (string primaryText, Command button, bool confirmIsDefault)
@@ -133,14 +180,27 @@ namespace Xwt
 		
 		public static bool Confirm (string primaryText, string secondaryText, Command button, bool confirmIsDefault)
 		{
-			return GenericAlert (RootWindow, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, confirmIsDefault ? 0 : 1, Command.Cancel, button) == button;
+			return Confirm(primaryText, secondaryText, String.Empty, button, confirmIsDefault);
+		}
+
+		public static bool Confirm(string primaryText, string secondaryText, string title, Command button, bool confirmIsDefault)
+		{
+			return Confirm(RootWindow, primaryText, secondaryText, title, button, confirmIsDefault);
+		}
+		public static bool Confirm(WindowFrame window, string primaryText, string secondaryText, string title, Command button, bool confirmIsDefault)
+		{
+			return GenericAlert(window, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, confirmIsDefault ? 0 : 1, Command.Cancel, button) == button;
 		}
 
 		public static bool Confirm (string primaryText, string secondaryText, Drawing.Image icon, Command button, bool confirmIsDefault)
 		{
-			return GenericAlert (RootWindow, icon, primaryText, secondaryText, confirmIsDefault ? 0 : 1, Command.Cancel, button) == button;
+			return Confirm(primaryText, secondaryText, String.Empty, icon, button, confirmIsDefault);
 		}
-		
+		public static bool Confirm(string primaryText, string secondaryText, string title, Drawing.Image icon, Command button, bool confirmIsDefault)
+		{
+			return GenericAlert(RootWindow, icon, primaryText, secondaryText, title, confirmIsDefault ? 0 : 1, Command.Cancel, button) == button;
+		}
+
 		public static bool Confirm (ConfirmationMessage message)
 		{
 			return Confirm (RootWindow, message);
@@ -157,17 +217,22 @@ namespace Xwt
 		{
 			return AskQuestion (primaryText, null, buttons);
 		}
-		
 		public static Command AskQuestion (string primaryText, string secondaryText, params Command[] buttons)
 		{
-			return GenericAlert (RootWindow, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, buttons);
+			return AskQuestion(primaryText, secondaryText, String.Empty, buttons);
 		}
-
+		public static Command AskQuestion(string primaryText, string secondaryText, string title, params Command[] buttons)
+		{
+			return GenericAlert(RootWindow, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, buttons);
+		}
 		public static Command AskQuestion (string primaryText, string secondaryText, Drawing.Image icon, params Command [] buttons)
 		{
-			return GenericAlert (RootWindow, icon, primaryText, secondaryText, buttons);
+			return AskQuestion(primaryText, secondaryText, String.Empty, icon, buttons);
 		}
-
+		public static Command AskQuestion(string primaryText, string secondaryText, string title, Drawing.Image icon, params Command[] buttons)
+		{
+			return GenericAlert(RootWindow, icon, primaryText, secondaryText, title, buttons);
+		}
 		public static Command AskQuestion (string primaryText, int defaultButton, params Command[] buttons)
 		{
 			return AskQuestion (primaryText, null, defaultButton, buttons);
@@ -175,14 +240,21 @@ namespace Xwt
 		
 		public static Command AskQuestion (string primaryText, string secondaryText, int defaultButton, params Command[] buttons)
 		{
-			return GenericAlert (RootWindow, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, defaultButton, buttons);
+			return AskQuestion(primaryText, secondaryText, String.Empty, defaultButton, buttons); 
 		}
-
+		public static Command AskQuestion(string primaryText, string secondaryText, string title, int defaultButton, params Command[] buttons)
+		{
+			return GenericAlert(RootWindow, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, defaultButton, buttons);
+		}
 		public static Command AskQuestion (string primaryText, string secondaryText, Drawing.Image icon, int defaultButton, params Command [] buttons)
 		{
-			return GenericAlert (RootWindow, icon, primaryText, secondaryText, defaultButton, buttons);
+			return AskQuestion(primaryText, secondaryText, String.Empty, icon, defaultButton, buttons);
 		}
-		
+		public static Command AskQuestion(string primaryText, string secondaryText, string title, Drawing.Image icon, int defaultButton, params Command[] buttons)
+		{
+			return GenericAlert(RootWindow, icon, primaryText, secondaryText, title, defaultButton, buttons);
+		}
+
 		public static Command AskQuestion (QuestionMessage message)
 		{
 			return AskQuestion (RootWindow, message);
@@ -194,15 +266,16 @@ namespace Xwt
 		}
 		#endregion
 		
-		static Command GenericAlert (WindowFrame parent, Xwt.Drawing.Image icon, string primaryText, string secondaryText, params Command[] buttons)
+		static Command GenericAlert (WindowFrame parent, Xwt.Drawing.Image icon, string primaryText, string secondaryText, string title, params Command[] buttons)
 		{
-			return GenericAlert (parent, icon, primaryText, secondaryText, buttons.Length - 1, buttons);
+			return GenericAlert (parent, icon, primaryText, secondaryText, title, buttons.Length - 1, buttons);
 		}
 		
-		static Command GenericAlert (WindowFrame parent, Xwt.Drawing.Image icon, string primaryText, string secondaryText, int defaultButton, params Command[] buttons)
+		static Command GenericAlert (WindowFrame parent, Xwt.Drawing.Image icon, string primaryText, string secondaryText, string title, int defaultButton, params Command[] buttons)
 		{
 			GenericMessage message = new GenericMessage () {
 				Icon = icon,
+				Title = title,
 				Text = primaryText,
 				SecondaryText = secondaryText,
 				DefaultButton = defaultButton
@@ -252,7 +325,8 @@ namespace Xwt
 		internal Command ApplyToAllButton { get; set; }
 		
 		public Xwt.Drawing.Image Icon { get; set; }
-		
+
+		public string Title { get; set; }
 		public string Text { get; set; }
 		public string SecondaryText { get; set; }
 		public bool AllowApplyToAll { get; set; }

--- a/Xwt/Xwt/MessageDialog.cs
+++ b/Xwt/Xwt/MessageDialog.cs
@@ -49,17 +49,17 @@ namespace Xwt
 		}
 		public static void ShowError (WindowFrame parent, string primaryText, string secondaryText)
 		{
-			ShowError(parent, primaryText, secondaryText, null);
+			ShowError (parent, primaryText, secondaryText, string.Empty);
 		}
-		public static void ShowError(string primaryText, string secondaryText, string title)
+		public static void ShowError (string primaryText, string secondaryText, string title)
 		{
-			ShowError(RootWindow, primaryText, secondaryText, title);
+			ShowError (RootWindow, primaryText, secondaryText, title);
 		}
-		public static void ShowError(WindowFrame parent, string primaryText, string secondaryText, string title)
+		public static void ShowError (WindowFrame parent, string primaryText, string secondaryText, string title)
 		{
-			if (string.IsNullOrEmpty(title))
+			if (string.IsNullOrEmpty (title))
 				title = parent?.Title ?? Application.TranslationCatalog.GetString ("Error");
-			GenericAlert(parent, Toolkit.CurrentEngine.Defaults.MessageDialog.ErrorIcon, primaryText, secondaryText, title, Command.Ok);
+			GenericAlert (parent, Toolkit.CurrentEngine.Defaults.MessageDialog.ErrorIcon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
 
@@ -78,17 +78,17 @@ namespace Xwt
 		}
 		public static void ShowWarning (WindowFrame parent, string primaryText, string secondaryText)
 		{
-			ShowWarning(RootWindow, primaryText, secondaryText, null);
+			ShowWarning (parent, primaryText, secondaryText, string.Empty);
 		}
-		public static void ShowWarning(string primaryText, string secondaryText, string title)
+		public static void ShowWarning (string primaryText, string secondaryText, string title)
 		{
-			ShowWarning(RootWindow, primaryText, secondaryText, title);
+			ShowWarning (RootWindow, primaryText, secondaryText, title);
 		}
-		public static void ShowWarning(WindowFrame parent, string primaryText, string secondaryText, string title)
+		public static void ShowWarning (WindowFrame parent, string primaryText, string secondaryText, string title)
 		{
 			if (string.IsNullOrEmpty(title))
 				title = parent?.Title ?? Application.TranslationCatalog.GetString ("Warning");
-			GenericAlert(parent, Toolkit.CurrentEngine.Defaults.MessageDialog.WarningIcon, primaryText, secondaryText, title, Command.Ok);
+			GenericAlert (parent, Toolkit.CurrentEngine.Defaults.MessageDialog.WarningIcon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
 
@@ -100,23 +100,23 @@ namespace Xwt
 		}
 		public static void ShowMessage (WindowFrame parent, string primaryText)
 		{
-			ShowMessage (parent, primaryText, null);
+			ShowMessage (parent, primaryText, string.Empty);
 		}
 		public static void ShowMessage (string primaryText, string secondaryText)
 		{
 			ShowMessage (RootWindow, primaryText, secondaryText);
 		}
-		public static void ShowMessage(WindowFrame parent, string primaryText, string secondaryText)
+		public static void ShowMessage (WindowFrame parent, string primaryText, string secondaryText)
 		{
-			ShowMessage(parent, primaryText, secondaryText, String.Empty);
+			ShowMessage (parent, primaryText, secondaryText, string.Empty);
 		}
-		public static void ShowMessage(string primaryText, string secondaryText, string title)
+		public static void ShowMessage (string primaryText, string secondaryText, string title)
 		{
-			ShowMessage(RootWindow, primaryText, secondaryText, title);
+			ShowMessage (RootWindow, primaryText, secondaryText, title);
 		}
-		public static void ShowMessage(WindowFrame parent, string primaryText, string secondaryText, string title)
+		public static void ShowMessage (WindowFrame parent, string primaryText, string secondaryText, string title)
 		{
-			ShowMessage(parent, primaryText, secondaryText, title, Toolkit.CurrentEngine.Defaults.MessageDialog.InformationIcon);
+			ShowMessage (parent, primaryText, secondaryText, title, Toolkit.CurrentEngine.Defaults.MessageDialog.InformationIcon);
 		}
 		public static void ShowMessage (string primaryText, string secondaryText, Drawing.Image icon)
 		{
@@ -124,17 +124,17 @@ namespace Xwt
 		}
 		public static void ShowMessage (WindowFrame parent, string primaryText, string secondaryText, Drawing.Image icon)
 		{
-			ShowMessage(RootWindow, primaryText, secondaryText, null, icon);
+			ShowMessage (parent, primaryText, secondaryText, string.Empty, icon);
 		}
-		public static void ShowMessage(string primaryText, string secondaryText, string title, Drawing.Image icon)
+		public static void ShowMessage (string primaryText, string secondaryText, string title, Drawing.Image icon)
 		{
-			ShowMessage(RootWindow, primaryText, secondaryText, title, icon);
+			ShowMessage (RootWindow, primaryText, secondaryText, title, icon);
 		}
 		public static void ShowMessage(WindowFrame parent, string primaryText, string secondaryText, string title, Drawing.Image icon)
 		{
-			if (string.IsNullOrEmpty(title))
+			if (string.IsNullOrEmpty (title))
 				title = parent?.Title ?? Application.TranslationCatalog.GetString ("Information");
-			GenericAlert(parent, icon, primaryText, secondaryText, title, Command.Ok);
+			GenericAlert (parent, icon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
 
@@ -149,9 +149,9 @@ namespace Xwt
 			return Confirm (RootWindow, primaryText, secondaryText, button);
 		}
 
-		public static bool Confirm(string primaryText, string secondaryText, string title, Command button)
+		public static bool Confirm (string primaryText, string secondaryText, string title, Command button)
 		{
-			return Confirm(RootWindow, primaryText, secondaryText, title, button);
+			return Confirm (RootWindow, primaryText, secondaryText, title, button);
 		}
 
 		public static bool Confirm (string primaryText, string secondaryText, Drawing.Image icon, Command button)
@@ -161,22 +161,22 @@ namespace Xwt
 
 		public static bool Confirm (WindowFrame window, string primaryText, string secondaryText, Command button)
 		{
-			return Confirm(window, primaryText, secondaryText, String.Empty, button);
+			return Confirm (window, primaryText, secondaryText, string.Empty, button);
 
 		}
-		public static bool Confirm(WindowFrame window, string primaryText, string secondaryText, string title, Command button)
+		public static bool Confirm (WindowFrame window, string primaryText, string secondaryText, string title, Command button)
 		{
-			return GenericAlert(window, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, Command.Cancel, button) == button;
+			return GenericAlert (window, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, Command.Cancel, button) == button;
 		}
 
 		public static bool Confirm (WindowFrame window, string primaryText, string secondaryText, Drawing.Image icon, Command button)
 		{
-			return Confirm(window, primaryText, secondaryText, String.Empty, icon, button);
+			return Confirm (window, primaryText, secondaryText, string.Empty, icon, button);
 
 		}
-		public static bool Confirm(WindowFrame window, string primaryText, string secondaryText, string title, Drawing.Image icon, Command button)
+		public static bool Confirm (WindowFrame window, string primaryText, string secondaryText, string title, Drawing.Image icon, Command button)
 		{
-			return GenericAlert(window, icon, primaryText, secondaryText, title, Command.Cancel, button) == button;
+			return GenericAlert (window, icon, primaryText, secondaryText, title, Command.Cancel, button) == button;
 		}
 
 		public static bool Confirm (string primaryText, Command button, bool confirmIsDefault)
@@ -186,25 +186,25 @@ namespace Xwt
 		
 		public static bool Confirm (string primaryText, string secondaryText, Command button, bool confirmIsDefault)
 		{
-			return Confirm(primaryText, secondaryText, String.Empty, button, confirmIsDefault);
+			return Confirm (primaryText, secondaryText, string.Empty, button, confirmIsDefault);
 		}
 
-		public static bool Confirm(string primaryText, string secondaryText, string title, Command button, bool confirmIsDefault)
+		public static bool Confirm (string primaryText, string secondaryText, string title, Command button, bool confirmIsDefault)
 		{
-			return Confirm(RootWindow, primaryText, secondaryText, title, button, confirmIsDefault);
+			return Confirm (RootWindow, primaryText, secondaryText, title, button, confirmIsDefault);
 		}
-		public static bool Confirm(WindowFrame window, string primaryText, string secondaryText, string title, Command button, bool confirmIsDefault)
+		public static bool Confirm (WindowFrame window, string primaryText, string secondaryText, string title, Command button, bool confirmIsDefault)
 		{
-			return GenericAlert(window, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, confirmIsDefault ? 0 : 1, Command.Cancel, button) == button;
+			return GenericAlert (window, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, confirmIsDefault ? 0 : 1, Command.Cancel, button) == button;
 		}
 
 		public static bool Confirm (string primaryText, string secondaryText, Drawing.Image icon, Command button, bool confirmIsDefault)
 		{
-			return Confirm(primaryText, secondaryText, String.Empty, icon, button, confirmIsDefault);
+			return Confirm (primaryText, secondaryText, string.Empty, icon, button, confirmIsDefault);
 		}
-		public static bool Confirm(string primaryText, string secondaryText, string title, Drawing.Image icon, Command button, bool confirmIsDefault)
+		public static bool Confirm (string primaryText, string secondaryText, string title, Drawing.Image icon, Command button, bool confirmIsDefault)
 		{
-			return GenericAlert(RootWindow, icon, primaryText, secondaryText, title, confirmIsDefault ? 0 : 1, Command.Cancel, button) == button;
+			return GenericAlert (RootWindow, icon, primaryText, secondaryText, title, confirmIsDefault ? 0 : 1, Command.Cancel, button) == button;
 		}
 
 		public static bool Confirm (ConfirmationMessage message)
@@ -225,19 +225,19 @@ namespace Xwt
 		}
 		public static Command AskQuestion (string primaryText, string secondaryText, params Command[] buttons)
 		{
-			return AskQuestion(primaryText, secondaryText, String.Empty, buttons);
+			return AskQuestion (primaryText, secondaryText, string.Empty, buttons);
 		}
-		public static Command AskQuestion(string primaryText, string secondaryText, string title, params Command[] buttons)
+		public static Command AskQuestion (string primaryText, string secondaryText, string title, params Command[] buttons)
 		{
-			return GenericAlert(RootWindow, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, buttons);
+			return GenericAlert (RootWindow, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, buttons);
 		}
 		public static Command AskQuestion (string primaryText, string secondaryText, Drawing.Image icon, params Command [] buttons)
 		{
-			return AskQuestion(primaryText, secondaryText, String.Empty, icon, buttons);
+			return AskQuestion (primaryText, secondaryText, string.Empty, icon, buttons);
 		}
-		public static Command AskQuestion(string primaryText, string secondaryText, string title, Drawing.Image icon, params Command[] buttons)
+		public static Command AskQuestion (string primaryText, string secondaryText, string title, Drawing.Image icon, params Command[] buttons)
 		{
-			return GenericAlert(RootWindow, icon, primaryText, secondaryText, title, buttons);
+			return GenericAlert (RootWindow, icon, primaryText, secondaryText, title, buttons);
 		}
 		public static Command AskQuestion (string primaryText, int defaultButton, params Command[] buttons)
 		{
@@ -246,19 +246,19 @@ namespace Xwt
 		
 		public static Command AskQuestion (string primaryText, string secondaryText, int defaultButton, params Command[] buttons)
 		{
-			return AskQuestion(primaryText, secondaryText, String.Empty, defaultButton, buttons); 
+			return AskQuestion (primaryText, secondaryText, string.Empty, defaultButton, buttons);
 		}
-		public static Command AskQuestion(string primaryText, string secondaryText, string title, int defaultButton, params Command[] buttons)
+		public static Command AskQuestion (string primaryText, string secondaryText, string title, int defaultButton, params Command[] buttons)
 		{
-			return GenericAlert(RootWindow, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, defaultButton, buttons);
+			return GenericAlert (RootWindow, Toolkit.CurrentEngine.Defaults.MessageDialog.QuestionIcon, primaryText, secondaryText, title, defaultButton, buttons);
 		}
 		public static Command AskQuestion (string primaryText, string secondaryText, Drawing.Image icon, int defaultButton, params Command [] buttons)
 		{
-			return AskQuestion(primaryText, secondaryText, String.Empty, icon, defaultButton, buttons);
+			return AskQuestion (primaryText, secondaryText, string.Empty, icon, defaultButton, buttons);
 		}
-		public static Command AskQuestion(string primaryText, string secondaryText, string title, Drawing.Image icon, int defaultButton, params Command[] buttons)
+		public static Command AskQuestion (string primaryText, string secondaryText, string title, Drawing.Image icon, int defaultButton, params Command[] buttons)
 		{
-			return GenericAlert(RootWindow, icon, primaryText, secondaryText, title, defaultButton, buttons);
+			return GenericAlert (RootWindow, icon, primaryText, secondaryText, title, defaultButton, buttons);
 		}
 
 		public static Command AskQuestion (QuestionMessage message)

--- a/Xwt/Xwt/MessageDialog.cs
+++ b/Xwt/Xwt/MessageDialog.cs
@@ -58,7 +58,7 @@ namespace Xwt
 		public static void ShowError(WindowFrame parent, string primaryText, string secondaryText, string title)
 		{
 			if (string.IsNullOrEmpty(title))
-				title = (parent != null) ? parent.Title ?? "Error" : "Error";
+				title = parent?.Title ?? Application.TranslationCatalog.GetString ("Error");
 			GenericAlert(parent, Toolkit.CurrentEngine.Defaults.MessageDialog.ErrorIcon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
@@ -87,7 +87,7 @@ namespace Xwt
 		public static void ShowWarning(WindowFrame parent, string primaryText, string secondaryText, string title)
 		{
 			if (string.IsNullOrEmpty(title))
-				title = (parent != null) ? parent.Title ?? "Warning" : "Warning";
+				title = parent?.Title ?? Application.TranslationCatalog.GetString ("Warning");
 			GenericAlert(parent, Toolkit.CurrentEngine.Defaults.MessageDialog.WarningIcon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
@@ -133,7 +133,7 @@ namespace Xwt
 		public static void ShowMessage(WindowFrame parent, string primaryText, string secondaryText, string title, Drawing.Image icon)
 		{
 			if (string.IsNullOrEmpty(title))
-				title = (parent != null) ? parent.Title ?? "Information" : "Information";
+				title = parent?.Title ?? Application.TranslationCatalog.GetString ("Information");
 			GenericAlert(parent, icon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion

--- a/Xwt/Xwt/MessageDialog.cs
+++ b/Xwt/Xwt/MessageDialog.cs
@@ -57,6 +57,8 @@ namespace Xwt
 		}
 		public static void ShowError(WindowFrame parent, string primaryText, string secondaryText, string title)
 		{
+			if (string.IsNullOrEmpty(title))
+				title = (parent != null) ? parent.Title ?? "Error" : "Error";
 			GenericAlert(parent, Toolkit.CurrentEngine.Defaults.MessageDialog.ErrorIcon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
@@ -84,6 +86,8 @@ namespace Xwt
 		}
 		public static void ShowWarning(WindowFrame parent, string primaryText, string secondaryText, string title)
 		{
+			if (string.IsNullOrEmpty(title))
+				title = (parent != null) ? parent.Title ?? "Warning" : "Warning";
 			GenericAlert(parent, Toolkit.CurrentEngine.Defaults.MessageDialog.WarningIcon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion
@@ -128,6 +132,8 @@ namespace Xwt
 		}
 		public static void ShowMessage(WindowFrame parent, string primaryText, string secondaryText, string title, Drawing.Image icon)
 		{
+			if (string.IsNullOrEmpty(title))
+				title = (parent != null) ? parent.Title ?? "Information" : "Information";
 			GenericAlert(parent, icon, primaryText, secondaryText, title, Command.Ok);
 		}
 		#endregion


### PR DESCRIPTION
The result of working WPF backend was wrong and looked bad. I added more
methods with parameter Title for MessageDialog and implemented using of
it for WPF backend.
Also, I added the setting Title by using parent window info for WPF
backend.

See screenshots at #961 

Sample of using Title from the parent window, if it wasn't set for MessageDilog:
![image](https://user-images.githubusercontent.com/5506989/62555041-6b881480-b89c-11e9-98ec-dab344ab3296.png)

Sample with the generic title:
![image](https://user-images.githubusercontent.com/5506989/62558031-63cb6e80-b8a2-11e9-8519-436181c7bee2.png)

