### PR TITLE
[Mac] Don't use NSControl to layout margins

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -804,7 +804,7 @@ namespace Xwt.Mac
 		#endregion
 	}
 
-	sealed class WidgetPlacementWrapper: NSControl, IViewObject
+	sealed class WidgetPlacementWrapper: NSView, IViewObject
 	{
 		NSView child;
 		Widget w;
@@ -866,11 +866,6 @@ namespace Xwt.Mac
 				cheight = s.Height;
 			}
 			child.Frame = new CGRect ((nfloat)cx, (nfloat)cy, (nfloat)cwidth, (nfloat)cheight);
-		}
-
-		public override void SizeToFit ()
-		{
-			base.SizeToFit ();
 		}
 	}
 }


### PR DESCRIPTION
NSControl is not meant to be used as a container and has special restrictive a11y behavior. Using a simple NSView as a layout container makes its content magically accessible.

Simple repro steps: Add a margin to the table inside the dialog example and enable VO: https://github.com/mono/xwt/blob/master/TestApps/Samples/Samples/Windows.cs#L61

Fixes VSTS #965764