### PR TITLE
[d16.3] [Mac] Fix ObjectDisposedException with TouchBar

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AlertDialogBackend.cs
@@ -108,6 +108,7 @@ namespace Xwt.Mac
 			}
 
 			var win = Context.Toolkit.GetNativeWindow (transientFor) as NSWindow;
+			Window.ReleasedWhenClosed = true;
 			if (win != null)
 				return sortedButtons [(int)this.RunSheetModal (win) - 1000];
 			return sortedButtons [(int)this.RunModal () - 1000];
@@ -115,5 +116,23 @@ namespace Xwt.Mac
 
 		public bool ApplyToAll { get; set; }
 		#endregion
+
+		public override bool ConformsToProtocol (IntPtr protocol)
+		{
+			// HACK: for some reason on systems with a TouchBar this might be called
+			//       after the window has been closed and released, resulting in
+			//       an ObjectDisposedException followed by a crash
+			if (isDisposed)
+				return false;
+
+			return base.ConformsToProtocol (protocol);
+		}
+
+		bool isDisposed;
+		protected override void Dispose (bool disposing)
+		{
+			isDisposed = true;
+			base.Dispose (disposing);
+		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -556,6 +556,17 @@ namespace Xwt.Mac
 				childView.Frame = frame;
 			}
 		}
+
+		public override bool ConformsToProtocol (IntPtr protocol)
+		{
+			// HACK: for some reason on systems with a TouchBar this might be called
+			//       after the window has been closed and released, resulting in
+			//       an ObjectDisposedException followed by a crash
+			if (disposed)
+				return false;
+
+			return base.ConformsToProtocol (protocol);
+		}
 	}
 	
 	public partial class WindowBackendController : NSWindowController


### PR DESCRIPTION
This is a hack, macOS seems to be calling conformsToProtocol:
after a window has been released, resulting in a crash.

Fixes VSTS #935146

(cherry picked from commit 41f29ad6848b07e64d8da9699118613e668d44bf)

Backport of #952