### PR TITLE
[Mac] Fix Popover backend disposing

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -43,6 +43,7 @@ namespace Xwt.Mac
 		public IPopoverEventSink EventSink { get; set; }
 		internal bool EnableCloseEvent { get; private set; }
 		NSPopover popover;
+		FactoryViewController controller;
 
 		class FactoryViewController : NSViewController, INSPopoverDelegate
 		{
@@ -247,7 +248,7 @@ namespace Xwt.Mac
 			popover = new NSAppearanceCustomizationPopover {
 				Behavior = NSPopoverBehavior.Transient
 			};
-			var controller = new FactoryViewController (this, child, popover) { BackgroundColor = backgroundColor };
+			controller = new FactoryViewController (this, child, popover) { BackgroundColor = backgroundColor };
 			popover.ContentViewController = controller;
 			popover.Delegate = controller;
 
@@ -279,13 +280,12 @@ namespace Xwt.Mac
 		{
 			if (popover != null) {
 				popover.Close ();
-				var controller = popover.Delegate as FactoryViewController;
-				if (controller != null) {
-					popover.Delegate = null;
-					controller.Dispose ();
-				}
 				popover.Dispose ();
 				popover = null;
+			}
+			if (controller != null) {
+				controller.Dispose ();
+				controller = null;
 			}
 		}
 


### PR DESCRIPTION
If the popover has already been closed, it's delegate
might have been released, so that accessing it would cause
unsupported NSObject resurrection.

Fixes VSTS #803040

(cherry picked from commit b92cc0268e4e7d6c899d181fc7abb759a6f2cdc9)

Backport of #964