### PR TITLE
[Mac] Replace a PInvoke which logs an error at runtime

### DIFF
--- a/Xwt.Gtk.Mac/Carbon.cs
+++ b/Xwt.Gtk.Mac/Carbon.cs
@@ -40,18 +40,6 @@ namespace Xwt.Gtk.Mac
 		public const string CarbonLib = "/System/Library/Frameworks/Carbon.framework/Versions/Current/Carbon";
 		
 		[DllImport (CarbonLib)]
-		static extern int Gestalt (int selector, out int result);
-		
-		public static int Gestalt (string selector)
-		{
-			int cc = ConvertCharCode (selector);
-			int result;
-			int ret = Gestalt (cc, out result);
-			CheckReturn (ret);
-			return result;
-		}
-		
-		[DllImport (CarbonLib)]
 		public static extern IntPtr GetApplicationEventTarget ();
 		
 		[DllImport (CarbonLib)]

--- a/Xwt.Gtk.Mac/GtkMacDesktopBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacDesktopBackend.cs
@@ -30,6 +30,7 @@ using System.Drawing;
 using System.IO;
 using GTK = global::Gtk;
 using CoreGraphics;
+using Foundation;
 
 namespace Xwt.Gtk.Mac
 {
@@ -37,11 +38,11 @@ namespace Xwt.Gtk.Mac
 	{
 		//this is a BCD value of the form "xxyz", where x = major, y = minor, z = bugfix
 		//eg. 0x1071 = 10.7.1
-		int systemVersion;
+		NSOperatingSystemVersion systemVersion;
 
 		public GtkMacDesktopBackend ()
 		{
-			systemVersion = Carbon.Gestalt ("sysv");
+			systemVersion = NSProcessInfo.ProcessInfo.OperatingSystemVersion;
 		}
 
 		public static Gdk.Pixbuf GetPixbufFromNSImage (NSImage icon, int width, int height)
@@ -103,7 +104,7 @@ namespace Xwt.Gtk.Mac
 		public override object GetFileIcon (string filename)
 		{
 			//this only works on MacOS 10.6.0 and greater
-			if (systemVersion < 0x1060)
+			if (systemVersion.Major <= 10 && systemVersion.Minor < 6)
 				return base.GetFileIcon (filename);
 
 			NSImage icon = null;

--- a/Xwt.Gtk.Mac/GtkMacDesktopBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacDesktopBackend.cs
@@ -30,19 +30,11 @@ using System.Drawing;
 using System.IO;
 using GTK = global::Gtk;
 using CoreGraphics;
-using Foundation;
 
 namespace Xwt.Gtk.Mac
 {
 	public class GtkMacDesktopBackend: GtkDesktopBackend
 	{
-		NSOperatingSystemVersion systemVersion;
-
-		public GtkMacDesktopBackend ()
-		{
-			systemVersion = NSProcessInfo.ProcessInfo.OperatingSystemVersion;
-		}
-
 		public static Gdk.Pixbuf GetPixbufFromNSImage (NSImage icon, int width, int height)
 		{
 			var rect = new CGRect (0, 0, width, height);
@@ -101,10 +93,6 @@ namespace Xwt.Gtk.Mac
 
 		public override object GetFileIcon (string filename)
 		{
-			//this only works on MacOS 10.6.0 and greater
-			if (systemVersion.Major <= 10 && systemVersion.Minor < 6)
-				return base.GetFileIcon (filename);
-
 			NSImage icon = null;
 
 			if (Path.IsPathRooted (filename) && File.Exists (filename)) {

--- a/Xwt.Gtk.Mac/GtkMacDesktopBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacDesktopBackend.cs
@@ -36,8 +36,6 @@ namespace Xwt.Gtk.Mac
 {
 	public class GtkMacDesktopBackend: GtkDesktopBackend
 	{
-		//this is a BCD value of the form "xxyz", where x = major, y = minor, z = bugfix
-		//eg. 0x1071 = 10.7.1
 		NSOperatingSystemVersion systemVersion;
 
 		public GtkMacDesktopBackend ()


### PR DESCRIPTION
```
WARNING: The Gestalt selector gestaltSystemVersion is returning 10.9.5 instead of 10.14.5. This is not a bug in Gestalt -- it is a documented limitation. Use NSProcessInfo's operatingSystemVersion property to get correct system version number.
```

Fixes https://github.com/mono/monodevelop/issues/7745