### PR TITLE
Fixes current translations in buttons when TranslationCatalog it's not initialized

### DIFF
--- a/Xwt/Xwt/Application.cs
+++ b/Xwt/Xwt/Application.cs
@@ -37,7 +37,7 @@ namespace Xwt
 		static Toolkit toolkit;
 		static ToolkitEngineBackend engine;
 		static UILoop mainLoop;
-		static ITranslationCatalog translationCatalog;
+		static ITranslationCatalog translationCatalog = new DefaultTranslationCatalog ();
 
 		/// <summary>
 		/// Gets the task scheduler of the current engine.
@@ -65,8 +65,6 @@ namespace Xwt
 
 		public static ITranslationCatalog TranslationCatalog {
 			get {
-				if (translationCatalog == null)
-					translationCatalog = new DefaultTranslationCatalog();
 				return translationCatalog;
 			}
 			set {


### PR DESCRIPTION
Fixes VSTS #975047 - "New folder" missing translation [Italian]


![image](https://user-images.githubusercontent.com/1587480/64613747-3446df00-d3d7-11e9-89a6-3acb28272333.png)
