### PR TITLE
[Mac] Fix image rendering on Catalina

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/MacSystemInformation.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacSystemInformation.cs
@@ -30,7 +30,8 @@ namespace Xwt.Mac
 {
 	class MacSystemInformation
 	{
-		public static readonly Version Mojave = new Version(10, 14);
+		public static readonly Version Catalina = new Version (10, 15);
+		public static readonly Version Mojave = new Version (10, 14);
 		public static readonly Version HighSierra = new Version(10, 13);
 		public static readonly Version Sierra = new Version (10, 12);
 		public static readonly Version ElCapitan = new Version (10, 11);


### PR DESCRIPTION
The Delegate based NSCustomImageRep is broken on Catalina
so that the selector never gets called. We need to use
fixed-size NSCustomImageRep instances for each requested
image size.

Fixes VSTS #983365