### PR TITLE
[Gtk] Fix NRE on LabelBackend's TextIndexer

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/LabelBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/LabelBackend.cs
@@ -39,7 +39,6 @@ namespace Xwt.GtkBackend
 	{
 		Color? textColor;
 		List<LabelLink> links;
-		TextIndexer indexer;
 
 		public LabelBackend ()
 		{
@@ -148,7 +147,6 @@ namespace Xwt.GtkBackend
 			get { return Label.Text; }
 			set {
 				links = null;
-				indexer = null;
 				Label.Text = value;
 			}
 		}
@@ -163,15 +161,15 @@ namespace Xwt.GtkBackend
 		{
 			Label.Text = text.Text;
 			formattedText = text;
-			Label.ApplyFormattedText (text);
+			var indexer = Label.ApplyFormattedText (text);
 
 			if (links != null)
 				links.Clear ();
 
 			foreach (var attr in text.Attributes.OfType<LinkTextAttribute> ()) {
 				LabelLink ll = new LabelLink () {
-					StartIndex = indexer.IndexToByteIndex (attr.StartIndex),
-					EndIndex = indexer.IndexToByteIndex (attr.StartIndex + attr.Count),
+					StartIndex = indexer != null ? indexer.IndexToByteIndex (attr.StartIndex) : attr.StartIndex,
+					EndIndex = indexer != null ? indexer.IndexToByteIndex (attr.StartIndex + attr.Count) : attr.StartIndex + attr.Count,
 					Target = attr.Target
 				};
 				if (links == null) {

--- a/Xwt.Gtk/Xwt.GtkBackend/Util.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Util.cs
@@ -281,7 +281,7 @@ namespace Xwt.GtkBackend
 		[DllImport (GtkInterop.LIBGTK, CallingConvention = CallingConvention.Cdecl)]
 		static extern void gtk_label_set_attributes (IntPtr label, IntPtr attrList);
 
-		internal static void ApplyFormattedText(this Gtk.Label label, FormattedText text)
+		internal static TextIndexer ApplyFormattedText(this Gtk.Label label, FormattedText text)
 		{
 			var list = new FastPangoAttrList ();
 			if (text != null) {
@@ -295,8 +295,12 @@ namespace Xwt.GtkBackend
 				}
 				var indexer = new TextIndexer (text.Text);
 				list.AddAttributes (indexer, text.Attributes);
+
+				return indexer;
 			}
 			gtk_label_set_attributes (label.Handle, list.Handle);
+
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
This broke with https://github.com/mono/xwt/commit/2102683398a84ee16094fc4bcae3dac44ba31872#diff-b2fc874d943bfbde146e59ed3a809b6f
which removed the assignment for TextIndexer, so trying to access it,
now that it is never assigned, results in a NRE.