### PR TITLE
Fix tag filtering when reloading tagged images

### DIFF
--- a/Xwt/Xwt.Drawing/Image.cs
+++ b/Xwt/Xwt.Drawing/Image.cs
@@ -244,13 +244,15 @@ namespace Xwt.Drawing
 			}
 		}
 
+		static readonly char [] tagDelimiters = { '@', '~' };
+
 		static bool ParseImageHints (string baseName, string fileName, string ext, out int scale, out ImageTagSet tags)
 		{
 			scale = 1;
 			tags = ImageTagSet.Empty;
-			var firstDelimiter = fileName.IndexOfAny (new [] { '@', '~' });
+			var firstDelimiter = fileName.IndexOfAny (tagDelimiters);
 
-			if (!fileName.StartsWith (baseName, StringComparison.Ordinal) || fileName.Length <= baseName.Length + 1 || firstDelimiter <= 0)
+			if (firstDelimiter <= 0 || fileName.Length <= baseName.Length + 1 || !fileName.StartsWith (baseName, StringComparison.Ordinal))
 				return false;
 
 			fileName = fileName.Substring (0, fileName.Length - ext.Length);


### PR DESCRIPTION
A ThemedImage consists of a set of Images with different tags
and the single child images can have several resolutions loaded
from different files.
When switching between toolkits, NativeImageRef.LoadForToolkit
reloads the images for the new toolkit based on NativeImageSource
which holds all data sufficient to reconstruct a ThemedImage.

When performing the actual loading using Image.LoadImage,
several issues occurred:

* NativeImageRef.LoadForToolkit did not pass the tags specified
  for the given source when loading images directly from resources
  or files
* Image.LoadImage always added the base image file even if
  the tag filter did not match. This resulted in creation
  of another nested ThemedImage (with an image group for the specified
  tag and the untagged base image), instead of a simple Image
  with frames for the requested tag.
* ParseImageHints did not detect tags included in the basename
  resulting in missing frames, if the client requested a file
  with tags included.

Fixes VSTS #991543