### PR TITLE
[Mac] Fix crash due to a missing IntPtr ctor in NSAppearanceCustomizationPopover

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -301,6 +301,11 @@ namespace Xwt.Mac
 
 		public class NSAppearanceCustomizationPopover : NSPopover, INSAppearanceCustomization
 		{
+			public NSAppearanceCustomizationPopover ()
+			{ }
+
+			protected NSAppearanceCustomizationPopover (IntPtr handle) : base (handle)
+			{ }
 		}
 	}
 }


### PR DESCRIPTION
Fixes VSTS #935131