### PR TITLE
[Mac] Fix crash due to a missing IntPtr ctor in NSAppearanceCustomizationPopover

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PopoverBackend.cs
@@ -301,6 +301,11 @@ namespace Xwt.Mac
 
 		public class NSAppearanceCustomizationPopover : NSPopover, INSAppearanceCustomization
 		{
+			public NSAppearanceCustomizationPopover ()
+			{ }
+
+			protected NSAppearanceCustomizationPopover (IntPtr handle) : base (handle)
+			{ }
 		}
 	}
 }


### PR DESCRIPTION
Fixes VSTS #935131

(cherry picked from commit d91cb349916f04f75f3b4a1581ed67008e811dd7)