### PR TITLE
Add support for composed images

### DIFF
--- a/Xwt/Xwt.Drawing/ComposedImage.cs
+++ b/Xwt/Xwt.Drawing/ComposedImage.cs
@@ -1,0 +1,67 @@
+﻿//
+// ComposedImage.cs
+//
+// Author:
+//       Vsevolod Kukol <sevoku@microsoft.com>
+//
+// Copyright (c) 2019 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xwt.Drawing
+{
+	class ComposedImage : DrawingImage
+	{
+		readonly Image [] images;
+
+		public ComposedImage (IEnumerable<Image> images, Size size = default (Size))
+		{
+			if (images == null)
+				throw new ArgumentNullException (nameof (images));
+			this.images = images.ToArray ();
+			if (this.images.Length == 0)
+				throw new ArgumentException ("The enumeration does not contain any images", nameof (images));
+			Size = size;
+		}
+
+		protected override void OnDraw (Context ctx, Rectangle bounds)
+		{
+			var size = !Size.IsZero ? Size : images [0].Size;
+
+			ctx.Save ();
+			ctx.Translate (bounds.Location);
+			if (!size.IsZero) {
+				ctx.Scale (bounds.Width / size.Width, bounds.Height / size.Height);
+			}
+
+			for (int n = 0; n < images.Length; n++) {
+				var image = images [n];
+				if (image.Size != size)
+					image = image.WithSize (size);
+				ctx.DrawImage (image, 0, 0);
+			}
+
+			ctx.Restore ();
+		}
+	}
+}
+

--- a/Xwt/Xwt.Drawing/Image.cs
+++ b/Xwt/Xwt.Drawing/Image.cs
@@ -339,6 +339,23 @@ namespace Xwt.Drawing
 			return new Image (Toolkit.CurrentEngine.ImageBackendHandler.CreateMultiResolutionImage (images.Select (ExtensionMethods.GetBackend)));
 		}
 
+		/// <summary>
+		/// Create a composed image
+		/// </summary>
+		/// <param name="images">Images to compose to a single image</param>
+		/// <param name="size">Optional size of the new image</param>
+		/// <remarks>
+		/// The images will be rendered on top of eachother aligned to the
+		/// upper left corner.
+		/// With a fixed image size (<see cref="WithSize(Size)"/>) all images will be scaled.
+		/// The size of the first image will be used, if no size is given (<see cref="Size.Zero"/>).
+		/// If the size of the first image is <see cref="Size.Zero"/> too, no scaling will be applied.
+		/// </remarks>
+		public static Image CreateComposedImage (IEnumerable<Image> images, Size size = default (Size))
+		{
+			return new ComposedImage (images, size);
+		}
+
 		public static Image FromFile (string file)
 		{
 			return FromFile (file, null);


### PR DESCRIPTION
The new ComposedImage type renders several Images as one.

The only way to create composed images is to use `ImageBuilder` to draw several images to a `VectorImage`, like we do in MonoDevelop: https://github.com/mono/monodevelop/blob/11bd01f8a6260e0ef9c9f5fb6b7fbc7a0e47c191/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ImageService.cs#L579-L603

Unfortunately, the ImageBuilder (and so VectorImage) is not cross-tookit capable, because it uses the native [`ContextBackendHandler`](https://github.com/mono/xwt/blob/master/Xwt/Xwt.Backends/ContextBackendHandler.cs#L64) API, by recording native rendering steps (`ImageDescription` for images). This means that a new ImageBuilder needs to be created in the context of each toolkit being used separately.

ComposedImage adds a simple way to workaround this limitation, by storing solely the images and getting the native image backends on demand when drawing, it can be used with any toolkit context.