### PR TITLE
Remove call to label.Destroy()

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/MenuItemBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/MenuItemBackend.cs
@@ -280,7 +280,6 @@ namespace Xwt.GtkBackend
 			if (label != null) {
 				label.Realized -= HandleStyleUpdate;
 				label.StyleSet -= HandleStyleUpdate;
-				label.Destroy ();
 				label = null;
 			}
 		}


### PR DESCRIPTION
The MenuItemBackend calls Destroy on a Gtk object it did not create. 