### PR TITLE
[16.4] Revert "[Gtk][a11y] Use toggle button in comboboxes for setting a11y."

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -61,27 +61,12 @@ namespace Xwt.GtkBackend
 		public void Initialize (IWidgetBackend parentWidget, IAccessibleEventSink eventSink)
 		{
 			var backend = parentWidget as WidgetBackend;
-			Gtk.Widget nativeWidget = null;
-
-			// Needed only for AtkCocoa.
-			if (Platform.IsMac) {
-				// Gtk.ComboBox and Gtk.ComboBoxEntry a11y doesn't work with Gtk/AtkCocoa.
-				// Workaround:
-				// Set a11y properties to their children.
-				// For Gtk.ComboBoxEntry use its Gtk.Entry, for Gtk.ComboBox -- Gtk.ToggleButton.
-				if (backend is IComboBoxEntryBackend) {
-					nativeWidget = (backend?.Widget as Gtk.Bin)?.Child;
-				} else if (backend is IComboBoxBackend) {
-					foreach (var child in ((Gtk.Container)backend.Widget).AllChildren) {
-						if (child is Gtk.ToggleButton) {
-							nativeWidget = (Gtk.Widget)child;
-							break;
-						}
-					}
-				}
-			}
-
-			Initialize (nativeWidget ?? backend?.Widget, eventSink);
+			if (Platform.IsMac && backend is IComboBoxEntryBackend) {
+				// Gtk.ComboBoxEntry a11y doesn't work with Gtk/AtkCocoa.
+				// Workaround: Set a11y properties to its Gtk.Entry
+				Initialize ((backend?.Widget as Gtk.Bin)?.Child, eventSink);
+			} else
+				Initialize (backend?.Widget, eventSink);
 		}
 
 		public void Initialize (IPopoverBackend parentPopover, IAccessibleEventSink eventSink)


### PR DESCRIPTION
This fix is not required with latest AtkCocoa

This reverts commit 2abba7b (part of #875).

(cherry picked from commit a1c22f197e67160372a1093f0b28f273d88e3e05)

Backport of #987