### PR TITLE
[16.4][WPF][XamMac][GtkMac] A11y helper

### DIFF
--- a/TestApps/Samples/Samples/ProgressBarSample.cs
+++ b/TestApps/Samples/Samples/ProgressBarSample.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Diagnostics;
 using System.Timers;
 using Xwt;
 using Xwt.Drawing;
@@ -33,7 +34,7 @@ namespace Samples
 {
 	public class ProgressBarSample : VBox
 	{
-		Timer timer = new Timer (100);
+		Timer timer = new Timer (3000);
 		ProgressBar determinateProgressBar;
 		ProgressBar indeterminateProgressBar;
 
@@ -49,12 +50,20 @@ namespace Samples
 			timer.Elapsed += Increase;
 			determinateProgressBar = new ProgressBar ();
 			determinateProgressBar.Fraction = 0.0;
+
+			determinateProgressBar.Accessible.AccessibilityInUseChanged += Accessible_AccessibilityInUseChanged;
+
 			PackStart(determinateProgressBar, true);
 			timer.Start ();
 
 			var spinner = new Spinner ();
 			spinner.Animate = true;
 			PackStart (spinner);
+		}
+
+		private void Accessible_AccessibilityInUseChanged (object sender, EventArgs e)
+		{
+			Console.WriteLine ($"Accessible_AccessibilityInUseChanged now the value is {determinateProgressBar.Accessible.AccessibilityInUse}");
 		}
 
 		public void Increase (object sender, ElapsedEventArgs args)
@@ -66,7 +75,12 @@ namespace Samples
 			} else {
 				nextFraction = 0.0;
 			}
-			Application.Invoke ( () => determinateProgressBar.Fraction = nextFraction );
+			Application.Invoke ( () =>
+			{
+				determinateProgressBar.Fraction = nextFraction;
+				determinateProgressBar.Accessible.MakeAnnouncement($"My progress is now {nextFraction * 100} percents");
+				Debug.WriteLine($"AccessibilityInUse: {determinateProgressBar.Accessible.AccessibilityInUse}");
+			} );
 		}
 	}
 }

--- a/TestApps/WpfTest/Directory.Build.targets
+++ b/TestApps/WpfTest/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <InMonoDevelopTree>true</InMonoDevelopTree>
+    <TargetFrameworks>net472</TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/TestApps/WpfTest/WpfTest.csproj
+++ b/TestApps/WpfTest/WpfTest.csproj
@@ -9,7 +9,8 @@
     <RootNamespace>WpfTest</RootNamespace>
     <AssemblyName>WpfTest</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>True</DebugSymbols>
@@ -84,6 +85,9 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/TestApps/WpfTest/app.config
+++ b/TestApps/WpfTest/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/Xwt.Gtk.Mac/GtkMacAccessibleBackend.AccessibilityHelper.cs
+++ b/Xwt.Gtk.Mac/GtkMacAccessibleBackend.AccessibilityHelper.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Xwt.GtkBackend;
+using Xwt.Mac;
+
+namespace Xwt.Gtk.Mac
+{
+	public partial class GtkMacAccessibleBackend : AccessibleBackend
+	{
+		static AccerssibilityHelper a11yHelper;
+		static GtkMacAccessibleBackend ()
+		{
+			a11yHelper = new AccerssibilityHelper ();
+		}
+
+		public override void MakeAnnouncement (string message, bool polite = false)
+		{
+			a11yHelper.MakeAnnouncement (message, polite);
+		}
+
+		public override bool AccessibilityInUse => a11yHelper.AccessibilityInUse;
+
+		public override event EventHandler AccessibilityInUseChanged
+		{
+			add
+			{
+				a11yHelper.AccessibilityInUseChanged += value;
+			}
+			remove
+			{
+				a11yHelper.AccessibilityInUseChanged -= value;
+			}
+		}
+	}
+}

--- a/Xwt.Gtk.Mac/GtkMacAccessibleBackend.cs
+++ b/Xwt.Gtk.Mac/GtkMacAccessibleBackend.cs
@@ -34,7 +34,7 @@ using GtkWidget = Gtk.Widget;
 
 namespace Xwt.Gtk.Mac
 {
-	public class GtkMacAccessibleBackend : AccessibleBackend
+	public partial class GtkMacAccessibleBackend : AccessibleBackend
 	{
 		public GtkMacAccessibleBackend ()
 		{

--- a/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
+++ b/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
@@ -66,6 +66,10 @@
       <Link>NSApplicationInitializer.cs</Link>
     </Compile>
     <Compile Include="GtkMacAccessibleBackend.cs" />
+    <Compile Include="GtkMacAccessibleBackend.AccessibilityHelper.cs" />
+    <Compile Include="..\Xwt.XamMac\Xwt.Mac\AccerssibilityHelper.cs">
+      <Link>AccerssibilityHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="..\BuildHelpers.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/AccessibleBackend.cs
@@ -49,6 +49,12 @@ namespace Xwt.GtkBackend
 		IAccessibleEventSink eventSink;
 		ApplicationContext context;
 
+		public virtual event EventHandler AccessibilityInUseChanged;
+		protected virtual void OnAccessibilityInUseChanged (object sender, EventArgs eventArgs)
+		{
+			AccessibilityInUseChanged?.Invoke (sender, eventArgs);
+		}
+
 		public AccessibleBackend ()
 		{
 		}
@@ -199,6 +205,8 @@ namespace Xwt.GtkBackend
 			}
 		}
 
+		public virtual bool AccessibilityInUse => false;
+
 		public virtual void AddChild (object nativeChild)
 		{
 			// TODO
@@ -226,6 +234,11 @@ namespace Xwt.GtkBackend
 
 		public void EnableEvent (object eventId)
 		{
+		}
+
+		public virtual void MakeAnnouncement (string message, bool polite = false)
+		{
+			// TODO
 		}
 	}
 }

--- a/Xwt.WPF/Directory.Build.props
+++ b/Xwt.WPF/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(InMonoDevelopTree)' == 'true' ">net461;net40;net47</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(InMonoDevelopTree)' == 'true' ">net461;net40;net472</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;net47</TargetFrameworks>
+    <TargetFrameworks>net40;net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
@@ -11,7 +11,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40'">
     <DefineConstants>DEBUG;NETFRAMEWORK;NET40</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net47'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
     <DefineConstants>DEBUG;NETFRAMEWORK;NET47</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.AccessibilityHelper.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.AccessibilityHelper.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using Xwt.Backends;
+
+#if NET47
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Threading;
+#endif
+
+namespace Xwt.WPFBackend
+{
+	partial class AccessibleBackend : IAccessibleBackend
+	{
+		[DllImport ("user32.dll")]
+		static extern bool SystemParametersInfo (int iAction, int iParam, out bool bActive, int iUpdate);
+
+		static bool Is3rdPartyScreenReaderActive ()
+		{
+			int iAction = 70; // SPI_GETSCREENREADER constant;
+			int iParam = 0;
+			int iUpdate = 0;
+			bool bActive = false;
+			bool bReturn = SystemParametersInfo (iAction, iParam, out bActive, iUpdate);
+			return bReturn && bActive;
+		}
+
+		static bool IsSystemNarratorActive {
+			get {
+#if NET47
+				// AutomationEvents.AutomationFocusChanged returns false sometimes when the application loses
+				// accessibility focus. So LiveRegionChanged plays fallback role here (it comes as true more reliable).
+				return AutomationPeer.ListenerExists(AutomationEvents.AutomationFocusChanged)
+					|| AutomationPeer.ListenerExists(AutomationEvents.LiveRegionChanged);
+#else
+				return false;
+#endif
+			}
+		}
+
+		public bool AccessibilityInUse {
+			get {
+				return IsSystemNarratorActive || Is3rdPartyScreenReaderActive ();
+			}
+		}
+
+		public void MakeAnnouncement (string message, bool polite = false)
+		{
+#if NET47
+			string previousAccessibleLabel = Label;
+
+			var announcementResetTimer = new DispatcherTimer ();
+			announcementResetTimer.Interval = new TimeSpan (0, 0, 5);
+			announcementResetTimer.Tick += (sender, args) => {
+				element?.Dispatcher.BeginInvoke ((Action) (() => {
+					AutomationProperties.SetLiveSetting (element, AutomationLiveSetting.Off);
+					Label = previousAccessibleLabel;
+				}), DispatcherPriority.Normal);
+
+				announcementResetTimer.Stop ();
+			};
+
+			element.Dispatcher.BeginInvoke ((Action) (() => {
+				AutomationProperties.SetLiveSetting (element, polite ? AutomationLiveSetting.Polite : AutomationLiveSetting.Assertive);
+
+				Label = message;
+				var peer = FrameworkElementAutomationPeer.FromElement (element);
+				if (peer != null) {
+					peer.RaiseAutomationEvent (AutomationEvents.LiveRegionChanged);
+
+					// HACK: Giving some time to announce the message
+					announcementResetTimer.Start ();
+				}
+			}), DispatcherPriority.Normal);
+#else
+			return;
+#endif
+		}
+
+		// TODO: AccessibilityInUseChanged event would require listening for a top-level window' events in WndProc
+		public event EventHandler AccessibilityInUseChanged;
+	}
+}

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
@@ -12,7 +12,7 @@ using Xwt.Backends;
 
 namespace Xwt.WPFBackend
 {
-	class AccessibleBackend : IAccessibleBackend
+	partial class AccessibleBackend : IAccessibleBackend
 	{
 		UIElement element;
 		IAccessibleEventSink eventSink;

--- a/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/WPFEngine.cs
@@ -146,7 +146,12 @@ namespace Xwt.WPFBackend
 			if (action == null)
 				throw new ArgumentNullException ("action");
 
-			application.Dispatcher.BeginInvoke (action, new object [0]);
+			try {
+				application.Dispatcher.BeginInvoke (action, new object [0]);
+			} catch (Exception ex) {
+
+				throw;
+			}
 		}
 
 		public override object TimerInvoke (Func<bool> action, TimeSpan timeSpan)

--- a/Xwt.XamMac/Xwt.Mac/AccerssibilityHelper.cs
+++ b/Xwt.XamMac/Xwt.Mac/AccerssibilityHelper.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using AppKit;
+using CoreFoundation;
+using Foundation;
+using ObjCRuntime;
+
+namespace Xwt.Mac
+{
+	public class AccerssibilityHelper
+	{
+		public event EventHandler AccessibilityInUseChanged;
+
+		static bool a11yHelperInitialized;
+		static AccerssibilityHelper a11yHelperInstance;
+		public void InitializeAccessibilityHelper()
+		{
+			// Don't swizzle twice if we have both XamMac and GtkMac running
+			if (a11yHelperInstance != null)
+				return;
+
+			a11yHelperInstance = this;
+			// TODO: Test if this works with VSM swizzle
+			SwizzleNSApplicationAccessibilitySetter();
+		}
+
+		[DllImport("/usr/lib/libobjc.dylib")]
+		private static extern IntPtr class_getInstanceMethod(IntPtr classHandle, IntPtr Selector);
+
+		[DllImport("/usr/lib/libobjc.dylib")]
+		private static extern IntPtr method_getImplementation(IntPtr method);
+
+		[DllImport("/usr/lib/libobjc.dylib")]
+		private static extern IntPtr imp_implementationWithBlock(ref BlockLiteral block);
+
+		[DllImport("/usr/lib/libobjc.dylib")]
+		private static extern void method_setImplementation(IntPtr method, IntPtr imp);
+
+		[MonoNativeFunctionWrapper]
+		delegate void AccessibilitySetValueForAttributeDelegate(IntPtr self, IntPtr selector, IntPtr valueHandle, IntPtr attributeHandle);
+		delegate void SwizzledAccessibilitySetValueForAttributeDelegate(IntPtr block, IntPtr self, IntPtr valueHandle, IntPtr attributeHandle);
+
+		static IntPtr originalAccessibilitySetValueForAttributeMethod;
+		void SwizzleNSApplicationAccessibilitySetter()
+		{
+			// Swizzle accessibilitySetValue:forAttribute: so that we can detect when VoiceOver gets enabled
+			var nsApplicationClassHandle = Class.GetHandle("NSApplication");
+
+			// This happens if GtkMac is loaded before XamMac
+			if (nsApplicationClassHandle == IntPtr.Zero)
+				return;
+
+			var accessibilitySetValueForAttributeSelector = Selector.GetHandle("accessibilitySetValue:forAttribute:");
+
+			var accessibilitySetValueForAttributeMethod = class_getInstanceMethod(nsApplicationClassHandle, accessibilitySetValueForAttributeSelector);
+			originalAccessibilitySetValueForAttributeMethod = method_getImplementation(accessibilitySetValueForAttributeMethod);
+
+			var block = new BlockLiteral();
+
+			SwizzledAccessibilitySetValueForAttributeDelegate d = accessibilitySetValueForAttribute;
+			block.SetupBlock(d, null);
+			var imp = imp_implementationWithBlock(ref block);
+			method_setImplementation(accessibilitySetValueForAttributeMethod, imp);
+
+			accessibilityInUse = CFPreferences.GetAppBooleanValue("voiceOverOnOffKey", "com.apple.universalaccess");
+			a11yHelperInitialized = true;
+		}
+
+		[MonoPInvokeCallback(typeof(SwizzledAccessibilitySetValueForAttributeDelegate))]
+		static void accessibilitySetValueForAttribute(IntPtr block, IntPtr self, IntPtr valueHandle, IntPtr attributeHandle)
+		{
+			var d = Marshal.GetDelegateForFunctionPointer(originalAccessibilitySetValueForAttributeMethod, typeof(AccessibilitySetValueForAttributeDelegate));
+			d.DynamicInvoke(self, Selector.GetHandle("accessibilitySetValue:forAttribute:"), valueHandle, attributeHandle);
+
+			var val = (NSNumber)ObjCRuntime.Runtime.GetNSObject(valueHandle);
+
+			bool previousValue = accessibilityInUse;
+			accessibilityInUse = val.BoolValue;
+			if (accessibilityInUse != previousValue)
+				a11yHelperInstance.OnAccessibilityInUseChanged(a11yHelperInstance, EventArgs.Empty);
+		}
+
+		void OnAccessibilityInUseChanged(object sender, EventArgs eventArgs)
+		{
+			AccessibilityInUseChanged?.Invoke(sender, eventArgs);
+		}
+
+		static bool accessibilityInUse;
+		public bool AccessibilityInUse
+		{
+			get
+			{
+				if (!a11yHelperInitialized)
+					InitializeAccessibilityHelper();
+
+				return accessibilityInUse;
+			}
+		}
+
+		public void MakeAnnouncement(string message, bool polite = false)
+		{
+			if (!a11yHelperInitialized)
+				return;
+
+			var nsObject = NSApplication.SharedApplication?.AccessibilityFocusedWindow;
+			if (nsObject == null)
+				return;
+			var dictionary =
+				new NSDictionary(NSAccessibilityNotificationUserInfoKeys.AnnouncementKey, new NSString(message),
+					NSAccessibilityNotificationUserInfoKeys.PriorityKey, polite ? NSAccessibilityPriorityLevel.Medium : NSAccessibilityPriorityLevel.High);
+			NSAccessibility.PostNotification(nsObject, NSAccessibilityNotifications.AnnouncementRequestedNotification, dictionary);
+		}
+	}
+}

--- a/Xwt.XamMac/Xwt.Mac/AccessibleBackend.AccessibilityHelper.cs
+++ b/Xwt.XamMac/Xwt.Mac/AccessibleBackend.AccessibilityHelper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Xwt.Backends;
+
+namespace Xwt.Mac
+{
+	public partial class AccessibleBackend : IAccessibleBackend
+	{
+		static AccerssibilityHelper a11yHelper;
+		static AccessibleBackend ()
+		{
+			a11yHelper = new AccerssibilityHelper ();
+		}
+
+		public void MakeAnnouncement (string message, bool polite = false)
+		{
+			a11yHelper.MakeAnnouncement (message, polite);
+		}
+
+		public bool AccessibilityInUse => a11yHelper.AccessibilityInUse;
+
+		public event EventHandler AccessibilityInUseChanged
+		{
+			add
+			{
+				a11yHelper.AccessibilityInUseChanged += value;
+			}
+			remove
+			{
+				a11yHelper.AccessibilityInUseChanged -= value;
+			}
+		}
+	}
+}

--- a/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
@@ -37,7 +37,7 @@ namespace Xwt.Mac
 		Func<bool> PerformAccessiblePressDelegate { get; set; }
 	}
 
-	public class AccessibleBackend : IAccessibleBackend
+	public partial class AccessibleBackend : IAccessibleBackend
 	{
 		INSAccessibleEventSource eventProxy;
 		INSAccessibility widget;

--- a/Xwt.XamMac/Xwt.XamMac.csproj
+++ b/Xwt.XamMac/Xwt.XamMac.csproj
@@ -142,6 +142,8 @@
     <Compile Include="Xwt.Mac\PopupWindowBackend.cs" />
     <Compile Include="Xwt.Mac\SearchTextEntryBackend.cs" />
     <Compile Include="Xwt.Mac\WindowFrameBackend.cs" />
+    <Compile Include="Xwt.Mac\AccessibleBackend.AccessibilityHelper.cs" />
+    <Compile Include="Xwt.Mac\AccerssibilityHelper.cs" />
   </ItemGroup>
   <Import Project="..\BuildHelpers.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Xwt/Xwt.Accessibility/Accessible.cs
+++ b/Xwt/Xwt.Accessibility/Accessible.cs
@@ -260,6 +260,37 @@ namespace Xwt.Accessibility
 				backendHost.OnAfterEventRemove (AccessibleEvent.Press, press);
 			}
 		}
+
+		/// <param name="polite">(WPF, XamMac, GtkMac) will use AutomationLiveSetting.Polite/NSAccessibilityPriorityLevel.Medium
+		/// if true and AutomationLiveSetting.Assertive/NSAccessibilityPriorityLevel.High otherwise (default)</param>
+		public void MakeAnnouncement (string message, bool polite = false)
+		{
+			Backend.MakeAnnouncement (message, polite);
+		}
+
+		/// <summary>
+		/// Returns true if Narrator, VoiceOver or a third-party accessibility means are in use
+		/// </summary>
+		public bool AccessibilityInUse {
+			get {
+				return Backend.AccessibilityInUse;
+			}
+		}
+
+		/// <summary>
+		/// Supported on XamMac and GtkMac only
+		/// </summary>
+		public event EventHandler AccessibilityInUseChanged
+		{
+			add
+			{
+				Backend.AccessibilityInUseChanged += value;
+			}
+			remove
+			{
+				Backend.AccessibilityInUseChanged -= value;
+			}
+		}
 	}
 
 	class DefaultNoOpAccessibleBackend : IAccessibleBackend
@@ -285,6 +316,12 @@ namespace Xwt.Accessibility
 		public Uri Uri { get; set; }
 
 		public bool IsAccessible { get; set; }
+
+		public bool AccessibilityInUse { get; }
+
+#pragma warning disable 067
+		public event EventHandler AccessibilityInUseChanged;
+#pragma warning restore 067
 
 		public void AddChild (object nativeChild)
 		{
@@ -333,6 +370,10 @@ namespace Xwt.Accessibility
 		}
 
 		public void InitializeBackend (object frontend, ApplicationContext context)
+		{
+		}
+
+		public void MakeAnnouncement(string message, bool polite = false)
 		{
 		}
 	}

--- a/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
+++ b/Xwt/Xwt.Accessibility/IAccessibleBackend.cs
@@ -66,6 +66,10 @@ namespace Xwt.Backends
 		void RemoveChild (object nativeChild);
 		void RemoveAllChildren ();
 		IEnumerable<object> GetChildren ();
+
+		void MakeAnnouncement (string message, bool polite = false);
+		bool AccessibilityInUse { get; }
+		event EventHandler AccessibilityInUseChanged;
 	}
 
 	public interface IAccessibleEventSink

--- a/Xwt/Xwt.Accessibility/XwtAccessibleBackend.cs
+++ b/Xwt/Xwt.Accessibility/XwtAccessibleBackend.cs
@@ -37,6 +37,10 @@ namespace Xwt.Accessibility
 		IAccessibleEventSink eventSink;
 		ApplicationContext context;
 
+#pragma warning disable 067
+		public event EventHandler AccessibilityInUseChanged;
+#pragma warning restore 067
+
 		public XwtAccessibleBackend ()
 		{
 		}
@@ -216,6 +220,17 @@ namespace Xwt.Accessibility
 		public IEnumerable<object> GetChildren()
 		{
 			return nativeBackend.GetChildren ();
+		}
+
+		public void MakeAnnouncement (string message, bool polite = false)
+		{
+			nativeBackend.MakeAnnouncement (message, polite);
+		}
+
+		public bool AccessibilityInUse {
+			get {
+				return nativeBackend.AccessibilityInUse;
+			}
 		}
 	}
 }


### PR DESCRIPTION
* Allows to check whether accessibility means are in use (Narrator/3rd party tools on Windows, VoiceOver on macOS)
* Adds Accessible.MakeAnnouncement (string message, bool polite = false) method for making a custom announcement for user per request (uses LiveRegion on Windows and NSAccessibility.PostNotification on macOS)

WPF version requires target framework version .NET 4.7.2

(cherry picked from commit 0893ad38d87373d65320f47c458d8bd46858ae0c)
Backport of #935