### PR TITLE
Fix hyperlinks not highlighted in labels

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/Util.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/Util.cs
@@ -283,6 +283,7 @@ namespace Xwt.GtkBackend
 
 		internal static TextIndexer ApplyFormattedText(this Gtk.Label label, FormattedText text)
 		{
+			TextIndexer indexer = null;
 			var list = new FastPangoAttrList ();
 			if (text != null) {
 				if (label.IsRealized) {
@@ -293,14 +294,12 @@ namespace Xwt.GtkBackend
 					if (!color.Equals (Gdk.Color.Zero))
 						list.DefaultLinkColor = color;
 				}
-				var indexer = new TextIndexer (text.Text);
+				indexer = new TextIndexer (text.Text);
 				list.AddAttributes (indexer, text.Attributes);
-
-				return indexer;
 			}
 			gtk_label_set_attributes (label.Handle, list.Handle);
 
-			return null;
+			return indexer;
 		}
 	}
 }


### PR DESCRIPTION
Using markup to define a hyperlink in a label was not highlighting
the hyperlink with blue text and the underline. The problem was that
the FastPangoAttrList was not being applied to the label.