### PR TITLE
[d16-4][Gtk][WPF] A11y fixes for menus and popovers

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
@@ -175,7 +175,16 @@ namespace Xwt.GtkBackend
 
 				return base.OnDraw (cr);
 			}
-			
+
+			protected override bool OnKeyPressEvent (Gdk.EventKey evnt)
+			{
+				if (evnt.Key == Gdk.Key.Escape) {
+					Hide ();
+					return true;
+				}
+				else return base.OnKeyPressEvent (evnt);
+			}
+
 			void DrawTriangle (Context ctx)
 			{
 				var halfSide = arrowPadding;

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.cs
@@ -108,7 +108,14 @@ namespace Xwt.WPFBackend
 		public void Initialize(IMenuBackend parentMenu, IAccessibleEventSink eventSync)
 		{
 			var menuBackend = (MenuBackend)parentMenu;
-			Initialize(menuBackend.NativeMenu, eventSink);
+
+			// If the menu hasn't been creaetd yet (true for ContextMenus, generally created on demand
+			// when displayed), then instead set the a11y properties on the DummyAccessibilityUIElement;
+			// they'll be copied to the actual menu later when it's created
+			if (menuBackend.NativeMenu != null)
+				Initialize(menuBackend.NativeMenu, eventSink);
+			else if (menuBackend.DummyAccessibilityUIElement != null)
+				Initialize (menuBackend.DummyAccessibilityUIElement, eventSink);
 		}
 
 		public void Initialize (IMenuItemBackend parentMenuItem, IAccessibleEventSink eventSink)

--- a/Xwt.WPF/Xwt.WPFBackend/MenuBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/MenuBackend.cs
@@ -30,6 +30,7 @@
 
 using System.Collections.Generic;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
@@ -41,11 +42,13 @@ namespace Xwt.WPFBackend
 	{
 		List<MenuItemBackend> items;
 		FontData customFont;
+		UIElement dummyAccessibiltyUIElement;
 
 		public override void InitializeBackend (object frontend, ApplicationContext context)
 		{
 			base.InitializeBackend (frontend, context);
 			items = new List<MenuItemBackend> ();
+			dummyAccessibiltyUIElement = new UIElement ();
 		}
 
 		public IList<MenuItemBackend> Items {
@@ -65,6 +68,12 @@ namespace Xwt.WPFBackend
 		}
 
 		public ContextMenu NativeMenu => menu;
+
+		public UIElement DummyAccessibilityUIElement => dummyAccessibiltyUIElement;
+
+		new Menu Frontend {
+			get { return (Menu)base.frontend; }
+		}
 
 		public virtual object Font {
 			get {
@@ -149,8 +158,13 @@ namespace Xwt.WPFBackend
 		{
 			if (this.menu == null) {
 				this.menu = new ContextMenu ();
+
 				foreach (var item in Items)
 					this.menu.Items.Add (item.Item);
+
+				var accessibleBackend = (AccessibleBackend)Toolkit.GetBackend (Frontend.Accessible);
+				if (accessibleBackend != null)
+					accessibleBackend.InitAutomationProperties (menu);
 			}
 
 			return menu;


### PR DESCRIPTION
This is backport of https://github.com/mono/xwt/pull/992.
It contains two a11y fixes:

The Esc key now closes Gtk based popovers

Previously, setting a11y info (like the name) on a popup menu didn't work for WPF. This is now supported. Since the menu is actually created when it's first displayed, the a11y settings are remembered in the AccessibilityBackend members and then copied to the menu when first created, similar to how we already handle this for Popovers.