### PR TITLE
MacEngine: support custom NSApplicationDelegate, improve init

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacEngine.cs
@@ -36,6 +36,8 @@ namespace Xwt.Mac
 {
 	public class MacEngine: Xwt.Backends.ToolkitEngineBackend
 	{
+		public static Func<bool, AppDelegate> AppDelegateFactory;
+
 		static AppDelegate appDelegate;
 		static NSAutoreleasePool pool;
 		
@@ -51,7 +53,7 @@ namespace Xwt.Mac
 			if (pool != null)
 				pool.Dispose ();
 			pool = new NSAutoreleasePool ();
-			appDelegate = new AppDelegate (IsGuest);
+			appDelegate = AppDelegateFactory?.Invoke(IsGuest) ?? new AppDelegate (IsGuest);
 			NSApplication.SharedApplication.Delegate = appDelegate;
 
 			// If NSPrincipalClass is not set, set it now. This allows running

--- a/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
@@ -24,23 +24,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System;
+
 using AppKit;
 
 namespace Xwt.Mac
 {
 	static class NSApplicationInitializer
 	{
+		[ThreadStatic]
+		static bool initialized;
+
 		public static void Initialize ()
 		{
-			var ds = System.Threading.Thread.GetNamedDataSlot ("NSApplication.Initialized");
-			if (System.Threading.Thread.GetData (ds) == null) {
-				System.Threading.Thread.SetData (ds, true);
-
-				// IgnoreMissingAssembliesDuringRegistration is only avalilable in Xamarin.Mac 3.4+
-				// Use reflection to not break builds with older Xamarin.Mac
-				var ignoreMissingAssemblies = typeof (NSApplication).GetField ("IgnoreMissingAssembliesDuringRegistration",
-				                                                               System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-				ignoreMissingAssemblies?.SetValue (null, true);
+			if (!initialized) {
+				initialized = true;
+				NSApplication.IgnoreMissingAssembliesDuringRegistration = true;
 				NSApplication.Init ();
 			}
 		}


### PR DESCRIPTION
1. Clean up `NSApplicationInitializer`:
    1. by using `[ThreadStatic]` which is 2-3x faster than `Thread. GetNamedDataSlot` etc
    2. stop using reflection to set `IgnoreMissingAssembliesDuringRegistration` (I think we're far enough into the future to stop paying for this reflection cost on every startup).

2. Support instantiating custom subclasses of XWT's `AppDelegate` so other standard macOS app delegate methods can be handled by the application using XWT. This is necessary, for example, to support OSA scripting.