### PR TITLE
[WPF][A11y] Make custom dialogs readable

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AlertDialogBackend.cs
@@ -96,12 +96,16 @@ namespace Xwt.WPFBackend
 				var text = new Label {
 					Text = message.Text ?? string.Empty
 				};
+				if (message.IsTextContentFocusable)
+					text.CanGetFocus = true;
 				Label stext = null;
 				box.PackStart (text);
 				if (!string.IsNullOrEmpty (message.SecondaryText)) {
 					stext = new Label {
 						Text = message.SecondaryText
 					};
+					if (message.IsTextContentFocusable)
+						stext.CanGetFocus = true;
 					box.PackStart (stext);
 				}
 				foreach (var option in message.Options) {

--- a/Xwt/Xwt/MessageDialog.cs
+++ b/Xwt/Xwt/MessageDialog.cs
@@ -337,7 +337,11 @@ namespace Xwt
 		public string SecondaryText { get; set; }
 		public bool AllowApplyToAll { get; set; }
 		public int DefaultButton { get; set; }
-		
+		/// <summary>
+		/// [WPF-only]
+		/// </summary>
+		public bool IsTextContentFocusable { get; set; } = false;
+
 		public void AddOption (string id, string text, bool setByDefault)
 		{
 			Options.Add (new AlertOption (id, text) { Value = setByDefault });


### PR DESCRIPTION
Adds IsTextContentFocusable flag allowing to go through the text content via Tab for accessibility
#1004230