### PR TITLE
[Mac] Remove ThreadStatic from NSApplicationInitializer.initialized

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
@@ -32,7 +32,6 @@ namespace Xwt.Mac
 {
 	static class NSApplicationInitializer
 	{
-		[ThreadStatic]
 		static bool initialized;
 
 		public static void Initialize ()

--- a/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
@@ -24,21 +24,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
-
 using AppKit;
 
 namespace Xwt.Mac
 {
 	static class NSApplicationInitializer
 	{
-		static bool initialized;
-
 		public static void Initialize ()
 		{
-			if (!initialized) {
-				initialized = true;
-				NSApplication.IgnoreMissingAssembliesDuringRegistration = true;
+			var ds = System.Threading.Thread.GetNamedDataSlot ("NSApplication.Initialized");
+			if (System.Threading.Thread.GetData (ds) == null) {
+				System.Threading.Thread.SetData (ds, true);
+
+				// IgnoreMissingAssembliesDuringRegistration is only avalilable in Xamarin.Mac 3.4+
+				// Use reflection to not break builds with older Xamarin.Mac
+				var ignoreMissingAssemblies = typeof (NSApplication).GetField ("IgnoreMissingAssembliesDuringRegistration",
+				                                                               System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+				ignoreMissingAssemblies?.SetValue (null, true);
 				NSApplication.Init ();
 			}
 		}


### PR DESCRIPTION
This allowed NSApplication.Init () to be called several times
from different threads, causing random "System.InvalidOperationException:
Init has already been invoked; it can only be invoked once" exceptions.

Partially reverts 36b5c71a817b6e9c7874f2c0c2de5509c3db2cd0