### PR TITLE
Port Xwt to netstandard2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <InMonoDevelopTree Condition="Exists('$(MSBuildThisFileDirectory)..\..\msbuild\MonoDevelop.AfterCommon.props')">true</InMonoDevelopTree>
-    <TargetFrameworkVersion Condition=" '$(InMonoDevelopTree)' == 'true' ">v4.7.2</TargetFrameworkVersion>
-    <TargetFrameworks Condition=" '$(InMonoDevelopTree)' == 'true' ">net472</TargetFrameworks>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <InMonoDevelopTree Condition="Exists('$(MSBuildThisFileDirectory)..\..\msbuild\MonoDevelop.AfterCommon.props')">true</InMonoDevelopTree>
-    <TargetFrameworks Condition=" '$(InMonoDevelopTree)' == 'true' ">net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
+++ b/Xwt.Gtk.Mac/Xwt.Gtk.Mac.csproj
@@ -11,6 +11,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xwt.Gtk.Windows/Xwt.Gtk.Windows.csproj
+++ b/Xwt.Gtk.Windows/Xwt.Gtk.Windows.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>Xwt.Gtk.Windows</AssemblyName>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xwt.Gtk/Xwt.Gtk.csproj
+++ b/Xwt.Gtk/Xwt.Gtk.csproj
@@ -11,6 +11,7 @@
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Xwt.Gtk/Xwt.Gtk3.csproj
+++ b/Xwt.Gtk/Xwt.Gtk3.csproj
@@ -10,6 +10,7 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
     <NoWarn>0612, 0618</NoWarn>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Xwt.WPF/Directory.Build.props
+++ b/Xwt.WPF/Directory.Build.props
@@ -1,7 +1,0 @@
-<Project>
-
-  <PropertyGroup>
-    <TargetFrameworks Condition=" '$(InMonoDevelopTree)' == 'true' ">net461;net40;net472</TargetFrameworks>
-  </PropertyGroup>
-
-</Project>

--- a/Xwt.WPF/Xwt.WPF.csproj
+++ b/Xwt.WPF/Xwt.WPF.csproj
@@ -1,18 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
     <RootNamespace>Xwt.WPF</RootNamespace>
     <AssemblyName>Xwt.WPF</AssemblyName>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40'">
-    <DefineConstants>DEBUG;NETFRAMEWORK;NET40</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472'">
-    <DefineConstants>DEBUG;NETFRAMEWORK;NET47</DefineConstants>
+    <DefineConstants>DEBUG;NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.AccessibilityHelper.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/AccessibleBackend.AccessibilityHelper.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using Xwt.Backends;
 
-#if NET47
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Threading;
-#endif
 
 namespace Xwt.WPFBackend
 {
@@ -13,20 +11,15 @@ namespace Xwt.WPFBackend
 	{
 		public bool AccessibilityInUse {
 			get {
-#if NET47
 				// AutomationEvents.AutomationFocusChanged returns false sometimes when the application loses
 				// accessibility focus. So LiveRegionChanged plays fallback role here (it comes as true more reliable).
 				return AutomationPeer.ListenerExists (AutomationEvents.AutomationFocusChanged)
 					|| AutomationPeer.ListenerExists (AutomationEvents.LiveRegionChanged);
-#else
-				return false;
-#endif
 			}
 		}
 
 		public void MakeAnnouncement (string message, bool polite = false)
 		{
-#if NET47
 			string previousAccessibleLabel = Label;
 
 			var announcementResetTimer = new DispatcherTimer ();
@@ -52,9 +45,6 @@ namespace Xwt.WPFBackend
 					announcementResetTimer.Start ();
 				}
 			}), DispatcherPriority.Normal);
-#else
-			return;
-#endif
 		}
 
 		// TODO: AccessibilityInUseChanged event would require listening for a top-level window' events in WndProc

--- a/Xwt.XamMac/Xwt.XamMac.csproj
+++ b/Xwt.XamMac/Xwt.XamMac.csproj
@@ -11,6 +11,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Xwt/Directory.Build.props
+++ b/Xwt/Directory.Build.props
@@ -1,7 +1,0 @@
-<Project>
-
-  <PropertyGroup>
-    <TargetFrameworks Condition=" '$(InMonoDevelopTree)' == 'true' ">net461;net40</TargetFrameworks>
-  </PropertyGroup>
-
-</Project>

--- a/Xwt/Xwt.Design/DesignerSurface.cs
+++ b/Xwt/Xwt.Design/DesignerSurface.cs
@@ -27,7 +27,6 @@
 using System;
 using Xwt.Backends;
 using System.Xml;
-using System.Xaml;
 using Xwt.Drawing;
 
 namespace Xwt.Design
@@ -43,14 +42,11 @@ namespace Xwt.Design
 		IDesignerSurfaceBackend Backend {
 			get { return (IDesignerSurfaceBackend) BackendHost.Backend; }
 		}
-		
+
+		[Obsolete("Xaml loading is not supported", error: true)]
 		public void Load (XmlReader r)
 		{
-			object o = XamlServices.Load (r);
-			if (!(o is Widget))
-				throw new InvalidOperationException ("Invalid object type. Expected Xwt.Widget, found: " + o.GetType ());
-			widget = (Widget)o;
-			Backend.Load (widget);
+			throw new InvalidOperationException("This support was removed, due to System.Xaml not being available");
 		}
 		
 		public void Load (Widget widget)
@@ -59,10 +55,10 @@ namespace Xwt.Design
 			Backend.Load (widget);
 		}
 		
+		[Obsolete("Xaml loading is not supported", error: true)]
 		public void Save (XmlWriter w)
 		{
-			XamlServices.Save (w, widget);
+			throw new InvalidOperationException("This support was removed, due to System.Xaml not being available");
 		}
 	}
 }
-

--- a/Xwt/Xwt.Drawing/Color.cs
+++ b/Xwt/Xwt.Drawing/Color.cs
@@ -26,14 +26,12 @@
 
 using System;
 using System.ComponentModel;
-using System.Windows.Markup;
 using System.Collections.Generic;
 using System.Globalization;
 
 namespace Xwt.Drawing
 {
 	[TypeConverter (typeof(ColorValueConverter))]
-	[ValueSerializer (typeof(ColorValueSerializer))]
 	[Serializable]
 	public struct Color : IEquatable<Color>
 	{
@@ -323,8 +321,6 @@ namespace Xwt.Drawing
 
 	class ColorValueConverter: TypeConverter
 	{
-		static readonly ColorValueSerializer serializer = new ColorValueSerializer ();
-
 		public override bool CanConvertTo (ITypeDescriptorContext context, Type destinationType)
 		{
 			return destinationType == typeof(string);
@@ -337,40 +333,17 @@ namespace Xwt.Drawing
 
 		public override object ConvertTo (ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
 		{
-			return serializer.ConvertToString (value, null);
+			Color s = (Color)value;
+			return s.ToHexString();
 		}
 
 		public override object ConvertFrom (ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
 		{
-			return serializer.ConvertFromString ((string)value, null);
-		}
-	}
-	
-	class ColorValueSerializer: ValueSerializer
-	{
-		public override bool CanConvertFromString (string value, IValueSerializerContext context)
-		{
-			return true;
-		}
-		
-		public override bool CanConvertToString (object value, IValueSerializerContext context)
-		{
-			return true;
-		}
-		
-		public override string ConvertToString (object value, IValueSerializerContext context)
-		{
-			Color s = (Color) value;
-			return s.ToHexString ();
-		}
-		
-		public override object ConvertFromString (string value, IValueSerializerContext context)
-		{
 			Color c;
-			if (Color.TryParse (value, out c))
+			if (Color.TryParse((string)value, out c))
 				return c;
 			else
-				throw new InvalidOperationException ("Could not parse color value: " + value);
+				throw new InvalidOperationException("Could not parse color value: " + value);
 		}
 	}
 }

--- a/Xwt/Xwt.Drawing/Font.cs
+++ b/Xwt/Xwt.Drawing/Font.cs
@@ -26,7 +26,6 @@
 
 using System;
 using Xwt.Backends;
-using System.Windows.Markup;
 using System.ComponentModel;
 using System.Text;
 using System.Globalization;
@@ -38,7 +37,6 @@ using System.Linq;
 namespace Xwt.Drawing
 {
 	[TypeConverter (typeof(FontValueConverter))]
-	[ValueSerializer (typeof(FontValueSerializer))]
 	public sealed class Font: XwtObject
 	{
 		FontBackendHandler handler;
@@ -558,29 +556,6 @@ namespace Xwt.Drawing
 		public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
 		{
 			return sourceType == typeof(string);
-		}
-	}
-	
-	class FontValueSerializer: ValueSerializer
-	{
-		public override bool CanConvertFromString (string value, IValueSerializerContext context)
-		{
-			return true;
-		}
-		
-		public override bool CanConvertToString (object value, IValueSerializerContext context)
-		{
-			return true;
-		}
-		
-		public override string ConvertToString (object value, IValueSerializerContext context)
-		{
-			return value.ToString ();
-		}
-		
-		public override object ConvertFromString (string value, IValueSerializerContext context)
-		{
-			return Font.FromName (value);
 		}
 	}
 }

--- a/Xwt/Xwt.csproj
+++ b/Xwt/Xwt.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\xwt.snk</AssemblyOriginatorKeyFile>
@@ -32,11 +32,8 @@ Xwt works by exposing one unified API across all environments that is mapped to 
 The framework consists of the frontend (Xwt core) and platform specific backends. Additionally to this core Xwt package you need to add an Xwt toolkit package (Xwt.*) for every platform you want your application to target.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Xaml" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\LICENSE.txt" Pack="true" PackagePath=""/>
-    <None Include="..\README.markdown" Pack="true" PackagePath=""/>
+    <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />
+    <None Include="..\README.markdown" Pack="true" PackagePath="" />
   </ItemGroup>
   <ProjectExtensions>
     <MonoDevelop>

--- a/Xwt/Xwt/Box.cs
+++ b/Xwt/Xwt/Box.cs
@@ -30,7 +30,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 
 using Xwt.Backends;
-using System.Windows.Markup;
 
 namespace Xwt
 {
@@ -415,7 +414,6 @@ namespace Xwt
 		FillAndExpand = 3
 	}
 	
-	[ContentProperty("Child")]
 	public class BoxPlacement
 	{
 		IContainerEventSink<BoxPlacement> parent;

--- a/Xwt/Xwt/Canvas.cs
+++ b/Xwt/Xwt/Canvas.cs
@@ -28,7 +28,6 @@ using System;
 using System.Collections.Generic;
 using Xwt.Backends;
 using Xwt.Drawing;
-using System.Windows.Markup;
 using System.ComponentModel;
 using System.Linq;
 

--- a/Xwt/Xwt/CheckBox.cs
+++ b/Xwt/Xwt/CheckBox.cs
@@ -26,12 +26,10 @@
 using System;
 using System.ComponentModel;
 using Xwt.Backends;
-using System.Windows.Markup;
 
 namespace Xwt
 {
 	[BackendType (typeof(ICheckBoxBackend))]
-	[ContentProperty("Content")]
 	public class CheckBox: Widget
 	{
 		Widget content;

--- a/Xwt/Xwt/CursorType.cs
+++ b/Xwt/Xwt/CursorType.cs
@@ -25,13 +25,11 @@
 // THE SOFTWARE.
 using System;
 using System.ComponentModel;
-using System.Windows.Markup;
 using System.Collections.Generic;
 
 namespace Xwt
 {
 	[TypeConverter (typeof(CursorTypeValueConverter))]
-	[ValueSerializer (typeof(CursorTypeValueSerializer))]
 	public class CursorType
 	{
 		string id;
@@ -77,32 +75,6 @@ namespace Xwt
 			public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
 			{
 				return sourceType == typeof(string);
-			}
-		}
-		
-		class CursorTypeValueSerializer: ValueSerializer
-		{
-			public override bool CanConvertFromString (string value, IValueSerializerContext context)
-			{
-				return true;
-			}
-			
-			public override bool CanConvertToString (object value, IValueSerializerContext context)
-			{
-				return true;
-			}
-			
-			public override string ConvertToString (object value, IValueSerializerContext context)
-			{
-				CursorType s = (CursorType) value;
-				return s.id;
-			}
-			
-			public override object ConvertFromString (string value, IValueSerializerContext context)
-			{
-				CursorType ct;
-				cursors.TryGetValue (value, out ct);
-				return ct;
 			}
 		}
 

--- a/Xwt/Xwt/Expander.cs
+++ b/Xwt/Xwt/Expander.cs
@@ -2,12 +2,10 @@ using System;
 using Xwt.Backends;
 using System.ComponentModel;
 using Xwt.Drawing;
-using System.Windows.Markup;
 
 namespace Xwt
 {
 	[BackendType (typeof(IExpanderBackend))]
-	[ContentProperty("Content")]
 	public class Expander: Widget
 	{
 		EventHandler expandChanged;

--- a/Xwt/Xwt/Frame.cs
+++ b/Xwt/Xwt/Frame.cs
@@ -27,12 +27,10 @@ using System;
 using Xwt.Backends;
 using System.ComponentModel;
 using Xwt.Drawing;
-using System.Windows.Markup;
 
 namespace Xwt
 {
 	[BackendType (typeof(IFrameBackend))]
-	[ContentProperty("Content")]
 	public class Frame: Widget
 	{
 		Widget child;

--- a/Xwt/Xwt/FrameBox.cs
+++ b/Xwt/Xwt/FrameBox.cs
@@ -27,11 +27,9 @@ using System;
 using Xwt.Backends;
 using System.ComponentModel;
 using Xwt.Drawing;
-using System.Windows.Markup;
 
 namespace Xwt
 {
-	[ContentProperty("Content")]
 	public class FrameBox: Widget
 	{
 		WidgetSpacing borderWidth;

--- a/Xwt/Xwt/Notebook.cs
+++ b/Xwt/Xwt/Notebook.cs
@@ -26,7 +26,6 @@
 
 using System;
 using Xwt.Backends;
-using System.Windows.Markup;
 
 namespace Xwt
 {
@@ -159,7 +158,6 @@ namespace Xwt
 		}
 	}
 	
-	[ContentProperty("Child")]
 	public class NotebookTab
 	{
 		IContainerEventSink<NotebookTab> parent;

--- a/Xwt/Xwt/Paned.cs
+++ b/Xwt/Xwt/Paned.cs
@@ -26,7 +26,6 @@
 
 using System;
 using Xwt.Backends;
-using System.Windows.Markup;
 
 namespace Xwt
 {
@@ -199,7 +198,6 @@ namespace Xwt
 		}
 	}
 	
-	[ContentProperty("Child")]
 	public class Panel
 	{
 		IContainerEventSink<Panel> parent;

--- a/Xwt/Xwt/RadioButton.cs
+++ b/Xwt/Xwt/RadioButton.cs
@@ -26,14 +26,12 @@
 using System;
 using System.ComponentModel;
 using Xwt.Backends;
-using System.Windows.Markup;
 using System.Linq;
 using System.Collections.Generic;
 
 namespace Xwt
 {
 	[BackendType (typeof(IRadioButtonBackend))]
-	[ContentProperty("Content")]
 	public class RadioButton: Widget
 	{
 		Widget content;

--- a/Xwt/Xwt/Size.cs
+++ b/Xwt/Xwt/Size.cs
@@ -26,13 +26,11 @@
 
 using System;
 using System.ComponentModel;
-using System.Windows.Markup;
 using System.Globalization;
 
 namespace Xwt {
 	
 	[TypeConverter (typeof(SizeValueConverter))]
-	[ValueSerializer (typeof(SizeValueSerializer))]
 	[Serializable]
 	public struct Size : IEquatable<Size>
 	{		
@@ -145,38 +143,6 @@ namespace Xwt {
 		public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
 		{
 			return sourceType == typeof(string);
-		}
-	}
-	
-	class SizeValueSerializer: ValueSerializer
-	{
-		public override bool CanConvertFromString (string value, IValueSerializerContext context)
-		{
-			return true;
-		}
-		
-		public override bool CanConvertToString (object value, IValueSerializerContext context)
-		{
-			return true;
-		}
-		
-		public override string ConvertToString (object value, IValueSerializerContext context)
-		{
-			Size s = (Size) value;
-			return s.Width.ToString () + "," + s.Height.ToString ();
-		}
-		
-		public override object ConvertFromString (string value, IValueSerializerContext context)
-		{
-			int i = value.IndexOf (',');
-			if (i == -1)
-				return Size.Zero;
-			double w, h;
-			if (!double.TryParse (value.Substring (0, i), NumberStyles.Any, CultureInfo.InvariantCulture, out w))
-				return Size.Zero;
-			if (!double.TryParse (value.Substring (i+1), NumberStyles.Any, CultureInfo.InvariantCulture, out h))
-				return Size.Zero;
-			return new Size (w, h);
 		}
 	}
 }

--- a/Xwt/Xwt/Table.cs
+++ b/Xwt/Xwt/Table.cs
@@ -30,7 +30,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 
 using Xwt.Backends;
-using System.Windows.Markup;
 using Xwt.Drawing;
 
 namespace Xwt
@@ -271,7 +270,6 @@ namespace Xwt
 		}
 	}
 	
-	[ContentProperty("Child")]
 	public class TablePlacement
 	{
 		IContainerEventSink<TablePlacement> parent;

--- a/Xwt/Xwt/Widget.cs
+++ b/Xwt/Xwt/Widget.cs
@@ -33,7 +33,6 @@ using Xwt.Backends;
 
 using Xwt.Drawing;
 using System.Reflection;
-using System.Xaml;
 using System.Linq;
 using Xwt.Motion;
 using Xwt.Accessibility;

--- a/Xwt/Xwt/WidgetSpacing.cs
+++ b/Xwt/Xwt/WidgetSpacing.cs
@@ -31,9 +31,7 @@ using Xwt.Backends;
 
 using Xwt.Drawing;
 using System.Reflection;
-using System.Xaml;
 using System.Linq;
-using System.Windows.Markup;
 using System.Text;
 using System.Globalization;
 
@@ -43,7 +41,6 @@ namespace Xwt
 	/// Spacing/Margin around a widget.
 	/// </summary>
 	[TypeConverter (typeof(WidgetSpacingValueConverter))]
-	[ValueSerializer (typeof(WidgetSpacingValueSerializer))]
 	public struct WidgetSpacing : IEquatable<WidgetSpacing>
 	{
 		public static WidgetSpacing Zero = new WidgetSpacing ();
@@ -167,56 +164,6 @@ namespace Xwt
 		public override bool CanConvertFrom (ITypeDescriptorContext context, Type sourceType)
 		{
 			return sourceType == typeof(string);
-		}
-	}
-	
-	class WidgetSpacingValueSerializer: ValueSerializer
-	{
-		public override bool CanConvertFromString (string value, IValueSerializerContext context)
-		{
-			return true;
-		}
-		
-		public override bool CanConvertToString (object value, IValueSerializerContext context)
-		{
-			return true;
-		}
-		
-		public override string ConvertToString (object value, IValueSerializerContext context)
-		{
-			WidgetSpacing s = (WidgetSpacing) value;
-			if (s.Left == s.Right && s.Right == s.Top && s.Top == s.Bottom)
-				return s.Left.ToString (CultureInfo.InvariantCulture);
-			if (s.Bottom != 0)
-				return s.Left.ToString (CultureInfo.InvariantCulture) + " " + s.Top.ToString (CultureInfo.InvariantCulture) + " " + s.Right.ToString (CultureInfo.InvariantCulture) + " " + s.Bottom.ToString (CultureInfo.InvariantCulture);
-			if (s.Right != 0)
-				return s.Left.ToString (CultureInfo.InvariantCulture) + " " + s.Top.ToString (CultureInfo.InvariantCulture) + " " + s.Right.ToString (CultureInfo.InvariantCulture);
-			return s.Left.ToString (CultureInfo.InvariantCulture) + " " + s.Top.ToString (CultureInfo.InvariantCulture);
-		}
-		
-		public override object ConvertFromString (string value, IValueSerializerContext context)
-		{
-			WidgetSpacing c = new WidgetSpacing ();
-			string[] values = value.Split (new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-			if (values.Length == 0)
-				return c;
-
-			double v;
-			if (double.TryParse (values [0], NumberStyles.Any, CultureInfo.InvariantCulture, out v))
-				c.Left = v;
-
-			if (value.Length == 1) {
-				c.Top = c.Right = c.Bottom = v;
-				return c;
-			}
-
-			if (value.Length >= 2 && double.TryParse (values [1], NumberStyles.Any, CultureInfo.InvariantCulture, out v))
-				c.Top = v;
-			if (value.Length >= 3 && double.TryParse (values [2], NumberStyles.Any, CultureInfo.InvariantCulture, out v))
-				c.Right = v;
-			if (value.Length >= 4 && double.TryParse (values [3], NumberStyles.Any, CultureInfo.InvariantCulture, out v))
-				c.Bottom = v;
-			return c;
 		}
 	}
 }


### PR DESCRIPTION
This removes System.Xaml reference which was only used to serialize/deserialize xaml.

Port Xwt to ns2.0, and platform assemblies to net472.