### PR TITLE
[Mac] Fix AccessibilityFocusedWindow when parenting windows

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -180,8 +180,12 @@ namespace Xwt.Mac
 			OrderOut (this);
 			Close();
 			NSApplication.SharedApplication.StopModal ();
-			if (parent != null)
+			if (parent != null) {
 				parent.MakeKeyAndOrderFront (parent);
+				if (parent.AccessibilityFocusedWindow != parent) {
+					parent.AccessibilityFocusedWindow = parent;
+				}
+			}
 		}
 
 		#endregion

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -130,6 +130,9 @@ namespace Xwt.Mac
 					bounds.Y = parentBounds.Center.Y - (Frame.Height / 2);
 					((IWindowFrameBackend)this).Bounds = bounds;
 				}
+				if (AccessibilityFocusedWindow == ParentWindow) {
+					AccessibilityFocusedWindow = this;
+				}
 			}
 		}
 		


### PR DESCRIPTION
Sometimes VO does not follow the current active window.
Manually checking and setting AccessibilityFocusedWindow
sometimes fixes this issue.