### PR TITLE
[16.4] Make ThemedImage style selection less unpredictable

### DIFF
--- a/Xwt/Xwt.Drawing/Context.cs
+++ b/Xwt/Xwt.Drawing/Context.cs
@@ -480,8 +480,15 @@ namespace Xwt.Drawing
 			}
 		}
 
+		internal static int GlobalStylesVersion {
+			get { return stylesVersion; }
+		}
+
+		static int stylesVersion;
+
 		static void NotifyGlobalStylesChanged ()
 		{
+			stylesVersion++;
 			if (GlobalStylesChanged != null)
 				GlobalStylesChanged (null, EventArgs.Empty);
 		}

--- a/Xwt/Xwt.Drawing/ThemedImage.cs
+++ b/Xwt/Xwt.Drawing/ThemedImage.cs
@@ -31,7 +31,9 @@ namespace Xwt.Drawing
 {
 	public class ThemedImage: DrawingImage
 	{
-		List<Tuple<Image, string []>> images;
+		readonly List<Tuple<Image, string []>> images;
+
+		int globalStylesVersion = -1;
 
 		public ThemedImage (List<Tuple<Image, string []>> images, Size size = default (Size))
 		{
@@ -54,6 +56,11 @@ namespace Xwt.Drawing
 
 		public Image GetImage (IEnumerable<string> tags)
 		{
+			// sort the images only if global styles changed
+			if (globalStylesVersion != Context.GlobalStylesVersion) {
+				images.Sort (StylePriorityComparison);
+				globalStylesVersion = Context.GlobalStylesVersion;
+			}
 			Image best = null;
 			int bestMatches = -1;
 			int bestNoMatches = int.MaxValue;
@@ -72,6 +79,32 @@ namespace Xwt.Drawing
 				}
 			}
 			return best;
+		}
+
+		/// <summary>
+		/// Sort images by global style
+		/// </summary>
+		/// <remarks>
+		/// <see cref="GetImage(IEnumerable{string})"/> is optimized for performace and therefore
+		/// just loops over the images and selects the first best matching one based on given styles.
+		/// The result is not predictable if the image list is not sorted and several alternatives
+		/// match different global and explicit styles.
+		/// Since we want to prioritize explicit styles first (<see cref="Image.WithStyles(string[])"/>),
+		/// we need to make sure that we don't select an image with a given global style
+		/// (<see cref="Context.SetGlobalStyle(string)"/>) but without an explicit match.
+		/// The simplest approach without slowing down rendering by a sophisticated lookup is to
+		/// sort images matching global styles last, so that <see cref="GetImage(IEnumerable{string})"/>
+		/// would always select an alternative with an explicit rather than a global style.
+		/// </remarks>
+		static int StylePriorityComparison (Tuple<Image, string []> img1, Tuple<Image, string []> img2)
+		{
+			var hasGlobal1 = img1.Item2.Any (style => Context.HasGlobalStyle (style));
+			var hasGlobal2 = img2.Item2.Any (style => Context.HasGlobalStyle (style));
+			if (hasGlobal1 && hasGlobal2)
+				return 0;
+			if (hasGlobal1)
+				return 1; // sort global styles last
+			return -1; // explicit styles go first
 		}
 	}
 }


### PR DESCRIPTION
GetImage is optimized for performace and therefore just loops over
the images and selects the first best matching one based on given styles.
The result is not predictable if the image list is not sorted and several alternatives
match different global and explicit styles.
Since we want to prioritize explicit styles first, we need to make sure that we
don't select an image with a given global style but without an explicit match first.
The simplest approach without slowing down rendering by a sophisticated lookup is to
sort images matching global styles last, so that GetImage would always select
an alternative with an explicit rather than a global style.

(cherry picked from commit 11fc060e02b6c0c2e3ad24c203247aaab0a4e943)
Backport of #1021