### PR TITLE
[WPF] Expand and CanResize support for TreeView columns

### DIFF
--- a/Xwt.WPF/Xwt.WPFBackend/ExGridViewColumn.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExGridViewColumn.cs
@@ -1,0 +1,80 @@
+using System;
+using System.ComponentModel;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace Xwt.WPFBackend
+{
+	public class ExGridViewColumn
+		: GridViewColumn
+	{
+		private readonly BindingSource bindingSource;
+
+		public ExGridViewColumn (Action onWidthUpdated)
+		{
+			bindingSource = new BindingSource (onWidthUpdated);
+
+			var widthBinding = new Binding (BindingSource.WidthPropertyName) {
+				Mode = BindingMode.TwoWay,
+				Source = bindingSource,
+			};
+			BindingOperations.SetBinding (this, WidthProperty, widthBinding);
+		}
+
+		public bool Expands { get; set; }
+
+		public bool CanResize {
+			get { return bindingSource.CanResize; }
+			set { bindingSource.CanResize = value; }
+		}
+
+		public void SetWidthForced (double width)
+		{
+			bindingSource.SetWidthForced (width);
+		}
+
+		class BindingSource
+			: INotifyPropertyChanged
+		{
+			public const string WidthPropertyName = nameof (Width);
+
+			private readonly Action onWidthUpdated;
+			private double width = double.NaN;
+
+			public BindingSource (Action onWidthUpdated)
+			{
+				this.onWidthUpdated = onWidthUpdated;
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public bool CanResize { get; set; }
+
+			public double Width {
+				get {
+					return width;
+				}
+				set {
+					if (CanResize) {
+						width = value;
+						onWidthUpdated ();
+					}
+					OnPropertyChanged (WidthPropertyName);
+				}
+			}
+
+			public void SetWidthForced (double width)
+			{
+				bool savedCanResize = CanResize;
+				CanResize = true;
+				Width = width;
+				CanResize = savedCanResize;
+			}
+
+			private void OnPropertyChanged (string name)
+			{
+				PropertyChanged?.Invoke (this, new PropertyChangedEventArgs (name));
+			}
+		}
+	}
+}

--- a/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/ExTreeViewItem.cs
@@ -43,10 +43,8 @@ namespace Xwt.WPFBackend
 	public class ExTreeViewItem
 		: TreeViewItem
 	{
-
-		public ExTreeViewItem()
+		public ExTreeViewItem ()
 		{
-			Loaded += OnLoaded;
 			HorizontalContentAlignment = HorizontalAlignment.Stretch;
 		}
 
@@ -205,24 +203,6 @@ namespace Xwt.WPFBackend
 			while (this.view == null && e != null) {
 				this.view = e.Parent as ExTreeView;
 				e = (FrameworkElement)e.Parent;
-			}
-		}
-
-		private void OnLoaded (object sender, RoutedEventArgs routedEventArgs)
-		{
-			ItemsControl parent = ItemsControlFromItemContainer (this);
-			if (parent == null)
-				return;
-
-			int index = parent.Items.IndexOf (DataContext);
-			if (index != parent.Items.Count - 1)
-				return;
-
-			foreach (var column in this.view.View.Columns) {
-				if (Double.IsNaN (column.Width))
-					column.Width = column.ActualWidth;
-
-				column.Width = Double.NaN;
 			}
 		}
 

--- a/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
+++ b/Xwt.WPF/Xwt.WPFBackend/TreeViewBackend.cs
@@ -238,7 +238,13 @@ namespace Xwt.WPFBackend
 
 		public object AddColumn (ListViewColumn column)
 		{
-			var col = new GridViewColumn ();
+			if (column.Expands && column.CanResize)
+				column.CanResize = false;
+
+			var col = new ExGridViewColumn (Tree.UpdateColumnWidths) {
+				Expands = column.Expands,
+				CanResize = column.CanResize,
+			};
 
 			UpdateColumn (column, col, ListViewColumnChange.Title);
 
@@ -251,7 +257,7 @@ namespace Xwt.WPFBackend
 
 		public void UpdateColumn (ListViewColumn column, object handle, ListViewColumnChange change)
 		{
-			var col = ((GridViewColumn) handle);
+			var col = (ExGridViewColumn) handle;
 			switch (change) {
 			case ListViewColumnChange.Title:
 				col.Header = column.Title;
@@ -271,12 +277,24 @@ namespace Xwt.WPFBackend
 				}
 
 				MapColumn (column, col);
-
 				break;
+
 			case ListViewColumnChange.Alignment:
 				var style = new Style(typeof(GridViewColumnHeader));
 				style.Setters.Add(new Setter(Control.HorizontalContentAlignmentProperty, Util.ToWpfHorizontalAlignment(column.Alignment)));
 				col.HeaderContainerStyle = style;
+				break;
+
+			case ListViewColumnChange.Expanding:
+				if (column.Expands && column.CanResize)
+					column.CanResize = false;
+				col.Expands = column.Expands;
+				break;
+
+			case ListViewColumnChange.CanResize:
+				if (column.CanResize && column.Expands)
+					column.Expands = false;
+				col.CanResize = column.CanResize;
 				break;
 			}
 		}


### PR DESCRIPTION
`Expand` and `CanResize` column properties support for the WPF backend of TreeView

This functionality was mentioned as TODO here: https://github.com/mono/xwt/pull/662

Here https://github.com/mono/xwt/pull/938 was an attempt to implement it. Unlike that PR, this one tries to simulate behavior what GTK TreeView has (according to this [doc](https://developer.gnome.org/gtk3/stable/GtkTreeViewColumn.html)) for WPF. It's achieved by manual column width calculations since `GridView` (and its columns) has no direct support for `Expand` / `CanResize`