### PR TITLE
[16.5] [Mac] Fix Table Accessible support

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
@@ -46,8 +46,8 @@ namespace Xwt.Mac
 
 		public void Initialize (IWidgetBackend parentWidget, IAccessibleEventSink eventSink)
 		{
-			var parentBackend = parentWidget as ViewBackend;
-			Initialize (parentBackend?.Widget, eventSink);
+			var widget = (parentWidget as ICellSource)?.TableView ?? (parentWidget as ViewBackend)?.Widget;
+			Initialize (widget, eventSink);
 		}
 
 		public void Initialize (IPopoverBackend parentPopover, IAccessibleEventSink eventSink)


### PR DESCRIPTION
Accessible should operate on the actual table and not
its parent scroll view.

Backport of #1024