### PR TITLE
[GTK] Unsubscribe Popover from Hidden event on hiding

### DIFF
--- a/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
@@ -341,6 +341,8 @@ namespace Xwt.GtkBackend
 			if (popover.TransientFor != null)
 				popover.TransientFor.FocusInEvent -= HandleParentFocusInEvent;
 
+			popover.Hidden -= PopoverHidden;
+
 			popover.Destroy ();
 			popover.Dispose ();
 		}

--- a/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/PopoverBackend.cs
@@ -269,7 +269,7 @@ namespace Xwt.GtkBackend
 				popover.TransientFor.FocusInEvent += HandleParentFocusInEvent;
 			}
 
-			popover.Hidden += (o, args) => sink.OnClosed ();
+			popover.Hidden += PopoverHidden;
 
 			var screenBounds = reference.ScreenBounds;
 			if (positionRect == Rectangle.Zero)
@@ -286,6 +286,12 @@ namespace Xwt.GtkBackend
 				UpdatePopoverPosition (positionRect, args.Allocation.Width, args.Allocation.Height);
 				popover.GrabFocus ();
 			};
+		}
+
+		void PopoverHidden (object sender, EventArgs e)
+		{
+			sink.OnClosed ();
+			popover.Hidden -= PopoverHidden;
 		}
 
 		void UpdatePopoverPosition (Rectangle positionRect, int width, int height)


### PR DESCRIPTION
In order to test replace
```
		void PopoverHidden (object sender, EventArgs e)
		{
			sink.OnClosed ();
			popover.Hidden -= PopoverHidden;
		}
```
with
```
		void PopoverHidden (object sender, EventArgs e)
		{
			Console.WriteLine ("Backend  Popover_Hidden event");
			sink.OnClosed ();
			//popover.Hidden -= PopoverHidden;
		}
```
then open Sample -> Popover page and open and close a button to trigger Popover, observe how console accumulates the messages with each Show