### PR TITLE
[Gtk][Mac] Add native tooltip support on macOS

### DIFF
--- a/Xwt.Gtk.Mac/MacPlatformBackend.cs
+++ b/Xwt.Gtk.Mac/MacPlatformBackend.cs
@@ -27,7 +27,9 @@ using System;
 using Xwt.GtkBackend;
 using Xwt.Backends;
 using AppKit;
-using Xwt.Mac;
+using GtkWidget = Gtk.Widget;
+using System.Collections.Generic;
+using CoreGraphics;
 
 namespace Xwt.Gtk.Mac
 {
@@ -55,6 +57,130 @@ namespace Xwt.Gtk.Mac
 				Xwt.Mac.NSApplicationInitializer.Initialize ();
 			return base.GetBackendImplementationType (backendType);
 		}
+
+        public override void EnableNativeTooltip(GtkWidget widget)
+        {
+            Xwt.Mac.NSApplicationInitializer.Initialize();
+
+            if (nativeTooltips == null)
+                nativeTooltips = new Dictionary<GtkWidget, TooltipData>();
+
+            if (nativeTooltips.ContainsKey(widget))
+                return;
+
+            widget.AddNotification("tooltip-text", HandleTooltipTextChanged);
+            widget.SizeAllocated += UpdateNativeTooltipText;
+            widget.Realized += UpdateNativeTooltipText;
+            widget.Unrealized += RemoveNativeTooltipOnUnrealized;
+            widget.Destroyed += HandleWidgetDestroyed;
+            if (!string.IsNullOrEmpty(widget.TooltipText))
+                HandleTooltipTextChanged(widget, EventArgs.Empty);
+        }
+
+        class TooltipData
+        {
+            // NSView.AddToolTip needs us to keep the NSString object alive until it gets removed
+            public Foundation.NSString Tooltip;
+            // keep a weak ref to the NSView, to be able to remove or realign the tooltip 
+            public WeakReference<NSView> View;
+            // Id returned by NSView.AddToolTip that needs to be passed to NSView.RemoveToolTip
+            public nint? TooltipId;
+        }
+
+        static Dictionary<GtkWidget, TooltipData> nativeTooltips;
+
+        static void HandleTooltipTextChanged(object sender, EventArgs args)
+        {
+            if (sender is GtkWidget)
+            {
+                var widget = (GtkWidget)sender;
+                TooltipData tData;
+                if (!nativeTooltips.TryGetValue(widget, out tData))
+                {
+                    if (string.IsNullOrEmpty(widget.TooltipText))
+                    {
+                        // previous tooltip has been removed or never existed, so no point in queuing another empty tooltip.
+                        return;
+                    }
+
+                    tData = new TooltipData {
+                        Tooltip = new Foundation.NSString(widget.TooltipText),
+                        View = new WeakReference<NSView>(null),
+                        TooltipId = null
+                    };
+                    nativeTooltips[widget] = tData;
+                }
+                else
+                {
+                    tData.Tooltip = new Foundation.NSString(widget.TooltipText ?? string.Empty);
+                }
+
+                // disable the GTK tooltip, this needs to be done every time because Gtk resets it when TooltipText is updated
+                widget.HasTooltip = false;
+                if (widget.IsRealized)
+                {
+                    UpdateNativeTooltipText(widget, EventArgs.Empty);
+                }
+            }
+        }
+
+        private static void UpdateNativeTooltipText(object sender, EventArgs e)
+        {
+            if (sender is GtkWidget)
+            {
+                var widget = (GtkWidget)sender;
+                TooltipData tData;
+                if (!widget.IsRealized || !nativeTooltips.TryGetValue(widget, out tData))
+                {
+                    return;
+                }
+
+                var nsv = GtkQuartz.GetView(widget);
+
+                if (tData.TooltipId != null)
+                {
+                    nsv.RemoveToolTip(tData.TooltipId.Value);
+                    tData.TooltipId = null;
+                }
+
+                if (string.IsNullOrEmpty (tData.Tooltip))
+                {
+                    return;
+                }
+                int x, y;
+                widget.TranslateCoordinates(widget.Toplevel, 0, 0, out x, out y);
+                var id = nsv.AddToolTip(new CGRect(x, y, widget.Allocation.Width, widget.Allocation.Height), tData.Tooltip, IntPtr.Zero);
+
+                // update the cache
+                tData.View.SetTarget(nsv);
+                tData.TooltipId = id;
+            }
+        }
+
+        private static void RemoveNativeTooltipOnUnrealized(object sender, EventArgs e)
+        {
+            var widget = sender as GtkWidget;
+            TooltipData tData;
+            NSView nsv;
+            if (widget != null && nativeTooltips.TryGetValue(widget, out tData))
+            {
+                if (tData.TooltipId != null && tData.View.TryGetTarget(out nsv))
+                {
+                    nsv.RemoveToolTip(tData.TooltipId.Value);
+                }          
+            }
+        }
+
+        private static void HandleWidgetDestroyed(object sender, EventArgs e)
+        {
+            var widget = sender as GtkWidget;
+            TooltipData tData;
+            if (widget != null && nativeTooltips.TryGetValue(widget, out tData))
+            {
+                nativeTooltips.Remove(widget);
+                widget.RemoveNotification("tooltip-text", HandleTooltipTextChanged);
+            }
+        }
 	}
 }
 

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkEngine.cs
@@ -38,6 +38,8 @@ namespace Xwt.GtkBackend
 	{
 		GtkPlatformBackend platformBackend;
 
+		internal GtkPlatformBackend PlatformBackend { get { return platformBackend; } }
+
 		public override void InitializeApplication ()
 		{
 			Gtk.Application.Init ();

--- a/Xwt.Gtk/Xwt.GtkBackend/GtkPlatformBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/GtkPlatformBackend.cs
@@ -38,6 +38,11 @@ namespace Xwt.GtkBackend
 		{
 			return null;
 		}
+
+		public virtual void EnableNativeTooltip (Gtk.Widget widget)
+        {
+
+        }
 	}
 }
 

--- a/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
+++ b/Xwt.Gtk/Xwt.GtkBackend/WidgetBackend.cs
@@ -171,6 +171,8 @@ namespace Xwt.GtkBackend
 			}
 			set {
 				Widget.TooltipText = value;
+				var engine = Toolkit.GetBackend(Frontend.Surface.ToolkitEngine) as GtkEngine;
+				engine?.PlatformBackend?.EnableNativeTooltip(Widget);
 			}
 		}
 		


### PR DESCRIPTION
This replaces Gtk tooltips with native ones. When Widget.TooltipText is set, a new native tooltip area is being added to the native NSView of the the Gtk.Widget, which gets updated automatically on text or allocation changes. 