### PR TITLE
Fix incorrect alternative images being used

### DIFF
--- a/Xwt/Xwt.Drawing/Image.cs
+++ b/Xwt/Xwt.Drawing/Image.cs
@@ -252,7 +252,7 @@ namespace Xwt.Drawing
 			tags = ImageTagSet.Empty;
 			var firstDelimiter = fileName.IndexOfAny (tagDelimiters);
 
-			if (firstDelimiter <= 0 || fileName.Length <= baseName.Length + 1 || !fileName.StartsWith (baseName, StringComparison.Ordinal))
+			if (firstDelimiter <= 0 || fileName.Length <= baseName.Length + 1 || !fileName.Substring(0, firstDelimiter).Equals(baseName, StringComparison.Ordinal))
 				return false;
 
 			fileName = fileName.Substring (0, fileName.Length - ext.Length);


### PR DESCRIPTION
With embedded resources:

gtc-solution.png
gtc-solution@2x.png
gtc-solution~contrast.png

gtc-solution-filter.png
gtc-solution-filter@2x.png
gtc-solution-filter~contrast.png

The ParseImageHints method would find an image match when the
baseName was gtc-solution and the fileName was gtc-solution@2x.png
or gtc-solution~contrast.png. The problem was the original check
used fileName.StartsWith(baseName) which allowed this mismatch.
Changing the check to compare the fileName before the first
delimiter found with the baseName avoids an incorrect image being
used.