### PR TITLE
[Mac] Fire ComboBox.SelectionChanged when item selected in code

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ComboBoxBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ComboBoxBackend.cs
@@ -49,6 +49,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+using System;
 using AppKit;
 using Xwt.Backends;
 
@@ -165,7 +166,6 @@ namespace Xwt.Mac
 			}
 			set {
 				Widget.SelectItem (value);
-				ApplicationContext.InvokeUserCode (EventSink.OnSelectionChanged);
 				Widget.SynchronizeTitleAndSelectedItem ();
 				ResetFittingSize ();
 			}
@@ -206,6 +206,12 @@ namespace Xwt.Mac
 					return false;
 				return base.AllowsVibrancy;
 			}
+		}
+
+		public override void SelectItem (nint index)
+		{
+			base.SelectItem (index);
+			Backend.ApplicationContext.InvokeUserCode (((IComboBoxEventSink)(Backend.EventSink)).OnSelectionChanged);
 		}
 	}
 }


### PR DESCRIPTION
When the NSPopUpButton.SelectItem(nint index) is called the
ComboBox.SelectionChanged event is now fired. This allows UI automation
tools to select the combo box item programatically and still allow the
XWT SelectionChanged event to be triggered.