### PR TITLE
Allow application to specify whether to initialize parent toolkit or not

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacEngine.cs
@@ -47,20 +47,29 @@ namespace Xwt.Mac
 		
 		public override void InitializeApplication ()
 		{
-			NSApplicationInitializer.Initialize ();
+			if (InitializeToolkit)
+			{
+				NSApplicationInitializer.Initialize();
 
-			//Hijack ();
-			if (pool != null)
-				pool.Dispose ();
-			pool = new NSAutoreleasePool ();
-			appDelegate = AppDelegateFactory?.Invoke(IsGuest) ?? new AppDelegate (IsGuest);
-			NSApplication.SharedApplication.Delegate = appDelegate;
+				//Hijack ();
+				if (pool != null)
+					pool.Dispose();
+				pool = new NSAutoreleasePool();
+				appDelegate = AppDelegateFactory?.Invoke(IsGuest) ?? new AppDelegate(IsGuest);
+				NSApplication.SharedApplication.Delegate = appDelegate;
 
-			// If NSPrincipalClass is not set, set it now. This allows running
-			// the application without a bundle
-			var info = NSBundle.MainBundle.InfoDictionary;
-			if (info.ValueForKey ((NSString)"NSPrincipalClass") == null)
-				info.SetValueForKey ((NSString)"NSApplication", (NSString)"NSPrincipalClass");
+				// If NSPrincipalClass is not set, set it now. This allows running
+				// the application without a bundle
+				var info = NSBundle.MainBundle.InfoDictionary;
+				if (info.ValueForKey((NSString)"NSPrincipalClass") == null)
+					info.SetValueForKey((NSString)"NSApplication", (NSString)"NSPrincipalClass");
+			}
+			else
+			{
+				// Although the AppDelegate does not need to be hijacked, keep this allocated
+				// as there are some non-NSApplicationDelegate methods still used by Xwt
+				appDelegate = new AppDelegate(IsGuest);
+			}
 		}
 
 		public override void InitializeBackends ()

--- a/Xwt/Xwt.Backends/ToolkitEngineBackend.cs
+++ b/Xwt/Xwt.Backends/ToolkitEngineBackend.cs
@@ -40,16 +40,19 @@ namespace Xwt.Backends
 		Dictionary<Type,Type> backendTypesByFrontend;
 		Toolkit toolkit;
 		bool isGuest;
+		bool initializeToolkit;
 
 		/// <summary>
 		/// Initialize the specified toolkit.
 		/// </summary>
 		/// <param name="toolkit">Toolkit to initialize.</param>
 		/// <param name="isGuest">If set to <c>true</c> the toolkit will be initialized as guest of another toolkit.</param>
-		internal void Initialize (Toolkit toolkit, bool isGuest)
+		internal void Initialize (Toolkit toolkit, bool isGuest, bool initializeToolkit)
 		{
 			this.toolkit = toolkit;
 			this.isGuest = isGuest;
+			this.initializeToolkit = initializeToolkit;
+
 			if (backendTypes == null) {
 				backendTypes = new Dictionary<Type, Type> ();
 				backendTypesByFrontend = new Dictionary<Type, Type> ();
@@ -84,6 +87,11 @@ namespace Xwt.Backends
 		/// </remarks>
 		public bool IsGuest {
 			get { return isGuest; }
+		}
+
+		public bool InitializeToolkit
+		{
+			get { return initializeToolkit; }
 		}
 
 		/// <summary>

--- a/Xwt/Xwt/Application.cs
+++ b/Xwt/Xwt/Application.cs
@@ -90,7 +90,12 @@ namespace Xwt
 		/// <param name="type">The toolkit type.</param>
 		public static void Initialize (ToolkitType type)
 		{
-			Initialize (Toolkit.GetBackendType (type));
+			Initialize (Toolkit.GetBackendType (type), true);
+		}
+
+		public static void Initialize(ToolkitType type, bool initializeToolkit)
+		{
+			Initialize(Toolkit.GetBackendType(type), initializeToolkit);
 			toolkit.Type = type;
 		}
 
@@ -99,11 +104,16 @@ namespace Xwt
 		/// </summary>
 		/// <param name="backendType">The <see cref="Type.FullName"/> of the backend type.</param>
 		public static void Initialize (string backendType)
+		{
+			Initialize(backendType, true);
+		}
+
+		public static void Initialize (string backendType, bool initializeToolkit)
 		{			
 			if (engine != null)
 				return;
 
-			toolkit = Toolkit.Load (backendType, false);
+			toolkit = Toolkit.Load (backendType, false, initializeToolkit);
 			toolkit.SetActive ();
 			engine = toolkit.Backend;
 			mainLoop = new UILoop (toolkit);


### PR DESCRIPTION
If Xwt.Mac is initialized inside a Cocoa application then
NSApplication.Initialize cannot be called twice.