### PR TITLE
[Mac] Manually register assemblies for Xamarin.Mac

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
+++ b/Xwt.XamMac/Xwt.Mac/NSApplicationInitializer.cs
@@ -52,9 +52,9 @@ namespace Xwt.Mac
 
 				// Manually register all the currently loaded assemblies.
 				foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-                {
+				{
 					Runtime.RegisterAssembly(assembly);
-                }
+				}
 			}
 		}
 


### PR DESCRIPTION
This patch allows for two main improvements:

* The entry assembly and its dependencies are no longer force-loaded
* We register assemblies that are not referenced by the entry assembly
  and are loaded later on by the app