### PR TITLE
Allow specifying an exit code when exiting the application

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/MacEngine.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacEngine.cs
@@ -155,6 +155,14 @@ namespace Xwt.Mac
 			NSApplication.SharedApplication.Terminate(appDelegate);
 		}
 
+		public override void ExitApplication(int exitCode)
+		{
+			if (exitCode == 0)
+				NSApplication.SharedApplication.Terminate(appDelegate);
+			else
+				Environment.Exit(exitCode);
+		}
+
 		static Selector hijackedSel = new Selector ("hijacked_loadNibNamed:owner:");
 		static Selector originalSel = new Selector ("loadNibNamed:owner:");
 		

--- a/Xwt/Xwt.Backends/ToolkitEngineBackend.cs
+++ b/Xwt/Xwt.Backends/ToolkitEngineBackend.cs
@@ -123,6 +123,14 @@ namespace Xwt.Backends
 		public abstract void ExitApplication ();
 
 		/// <summary>
+		/// Exits the main GUI loop with an exit code
+		/// </summary>
+		public virtual void ExitApplication(int exitCode)
+		{
+			ExitApplication();
+		}
+
+		/// <summary>
 		/// Releases all resource used by the <see cref="Xwt.Backends.ToolkitEngineBackend"/> object.
 		/// </summary>
 		public virtual void Dispose ()

--- a/Xwt/Xwt/Application.cs
+++ b/Xwt/Xwt/Application.cs
@@ -174,6 +174,17 @@ namespace Xwt
 		}
 
 		/// <summary>
+		/// Exits the Xwt application.
+		/// </summary>
+		public static void Exit(int exitCode)
+		{
+			toolkit.InvokePlatformCode(() => engine.ExitApplication(exitCode));
+
+			if (SynchronizationContext.Current is XwtSynchronizationContext)
+				XwtSynchronizationContext.Uninstall();
+		}
+
+		/// <summary>
 		/// Releases all resources used by the application
 		/// </summary>
 		/// <remarks>This method must be called before the application process ends</remarks>


### PR DESCRIPTION
NSApplication.Main never returns. The only way to return an exit code is to call exit(code).