### PR TITLE
Copy image properties when copying CustomImage

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
@@ -361,12 +361,12 @@ namespace Xwt.Mac
 
 		public CustomImage Clone ()
 		{
-			return new CustomImage (actx, drawCallback);
+			return new CustomImage(actx, drawCallback) { Image = Image, Size = Size };
 		}
 
 		public override NSObject Copy (NSZone zone)
 		{
-			return new CustomImage (actx, drawCallback);
+			return new CustomImage (actx, drawCallback) { Image = Image, Size = Size };
 		}
 	}
 }


### PR DESCRIPTION
Cocoa sometimes creates a copy of an NSImage to cache it,
in that case we also need to copy all custom image properties
and settings.