### PR TITLE
Optimize some image API usages

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
@@ -56,7 +56,7 @@ namespace Xwt.Mac
 		
 		public override object LoadFromFile (string file)
 		{
-			return new NSImage (file, lazy: true);
+			return new NSImage (file);
 		}
 
 		public override object CreateMultiResolutionImage (IEnumerable<object> images)

--- a/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageHandler.cs
@@ -51,14 +51,12 @@ namespace Xwt.Mac
 
 		public override object LoadFromStream (Stream stream)
 		{
-			using (NSData data = NSData.FromStream (stream)) {
-				return new NSImage (data);
-			}
+			return NSImage.FromStream (stream);
 		}
 		
 		public override object LoadFromFile (string file)
 		{
-			return new NSImage (file);
+			return new NSImage (file, lazy: true);
 		}
 
 		public override object CreateMultiResolutionImage (IEnumerable<object> images)
@@ -71,8 +69,9 @@ namespace Xwt.Mac
 
 		public override object CreateMultiSizeIcon (IEnumerable<object> images)
 		{
-			if (images.Count () == 1)
-				return images.First ();
+			var singleImage = images.SingleOrDefault ();
+			if (singleImage != null)
+				return singleImage;
 
 			NSImage res = new NSImage ();
 			foreach (NSImage img in images)
@@ -251,10 +250,8 @@ namespace Xwt.Mac
 		
 		static NSImage FromResource (string res)
 		{
-			var stream = typeof(ImageHandler).Assembly.GetManifestResourceStream (res);
-			using (stream)
-			using (NSData data = NSData.FromStream (stream)) {
-				return new NSImage (data);
+			using (var stream = typeof(ImageHandler).Assembly.GetManifestResourceStream (res)) {
+				return NSImage.FromStream (stream);
 			}
 		}
 


### PR DESCRIPTION
Also optimize a multiple IEnumerable enumeration path and switch to NSImage.FromStream.