### PR TITLE
Properly handle escaping of markup text

### DIFF
--- a/Xwt/Xwt/FormattedText.cs
+++ b/Xwt/Xwt/FormattedText.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using Xwt.Drawing;
 using System.Text;
 using System.Globalization;
+using System.Net;
 
 namespace Xwt
 {
@@ -62,7 +63,7 @@ namespace Xwt
 			int last = 0;
 			int i = markup.IndexOf ('<');
 			while (i != -1) {
-				sb.Append (markup, last, i - last);
+				sb.Append (WebUtility.HtmlDecode (markup.Substring (last, i - last)));
 				if (PushSpan (formatStack, markup, sb.Length, ref i)) {
 					last = i;
 					i = markup.IndexOf ('<', i);
@@ -76,7 +77,7 @@ namespace Xwt
 				last = i;
 				i = markup.IndexOf ('<', i + 1);
 			}
-			sb.Append (markup, last, markup.Length - last);
+			sb.Append (WebUtility.HtmlDecode (markup.Substring (last, markup.Length - last)));
 			Text = sb.ToString ();
 		}
 


### PR DESCRIPTION
Previously, Xwt assumed that the platform (Gtk) handled
encoding/decoding of markup text that contains special
characters. GLib.Markup.EscapeText would do the escaping
and then Gtk itself would unescape when displayed.

Since we switched from the Gtk to the Cocoa backend, that
has two problems - GLib.Markup.EscapeText crashes if
Gtk isn't there and even if it does work, there's nothing on
the Cocoa side to unescape the text.

Instead we now handle all escaping/unescaping in a backend
independent way. WebUtility.HtmlEncode does the escaping
and cross platform Xwt markup parsing code does the match
WebUtility.HtmlDecode to unescape.

For this to fully work the Xwt change and VSMac change need
to both be present, but the VSMac update is the most important
as it removes the crash.