### PR TITLE
Fix Cocoa link labels to properly launch the browser

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/LinkLabelBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/LinkLabelBackend.cs
@@ -102,7 +102,7 @@ namespace Xwt.Mac
 		void HandleClicked (object sender, EventArgs e)
 		{
 			ApplicationContext.InvokeUserCode (() => {
-				EventSink.OnNavigateToUrl (uri);
+				NSWorkspace.SharedWorkspace.OpenUrl (uri);
 			});
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/LinkLabelBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/LinkLabelBackend.cs
@@ -102,7 +102,7 @@ namespace Xwt.Mac
 		void HandleClicked (object sender, EventArgs e)
 		{
 			ApplicationContext.InvokeUserCode (() => {
-				NSWorkspace.SharedWorkspace.OpenUrl (uri);
+				EventSink.OnNavigateToUrl (uri);
 			});
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/MacDesktopBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/MacDesktopBackend.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Generic;
 using AppKit;
 using CoreGraphics;
+using Foundation;
 using ObjCRuntime;
 using Xwt.Backends;
 
@@ -74,6 +75,11 @@ namespace Xwt.Mac
 		public override bool IsPrimaryScreen (object backend)
 		{
 			return NSScreen.Screens[0] == (NSScreen) backend;
+		}
+
+		public override void OpenUrl (string url)
+		{
+			NSWorkspace.SharedWorkspace.OpenUrl (new NSUrl (url));
 		}
 
 		public static Point ToDesktopPoint (CGPoint loc)


### PR DESCRIPTION
Update XamMac link labels to launch the browser directly,
in the standard way we do it elsewhere in VSMac.

Fixes  https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1484767

This behavior worked before with the Gtk backend, but
I don't think it ever worked properly with the Cocoa