### PR TITLE
Fix drag/drop support

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -620,7 +620,7 @@ namespace Xwt.Mac
 
 			var di = Runtime.GetINativeObject<INSDraggingInfo> (dragInfo, owns: false);
 			var types = di.DraggingPasteboard.Types.Select (ToXwtDragType).ToArray ();
-			var pos = new Point (di.DraggingLocation.X, di.DraggingLocation.Y);
+			var pos = backend.Widget.ConvertPointFromView (di.DraggingLocation, null).ToXwtPoint ();
 			
 			if ((backend.currentEvents & WidgetEvent.DragOverCheck) != 0) {
 				var args = new DragOverCheckEventArgs (pos, types, ConvertAction (di.DraggingSourceOperationMask));

--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -618,8 +618,7 @@ namespace Xwt.Mac
 				return NSDragOperation.None;
 			var backend = ob.Backend;
 
-			//INSDraggingInfo di = (INSDraggingInfo) Runtime.GetNSObject (dragInfo);
-			var di = Runtime.GetINativeObject<INSDraggingInfo>(dragInfo, owns: false);
+			var di = Runtime.GetINativeObject<INSDraggingInfo> (dragInfo, owns: false);
 			var types = di.DraggingPasteboard.Types.Select (ToXwtDragType).ToArray ();
 			var pos = new Point (di.DraggingLocation.X, di.DraggingLocation.Y);
 			
@@ -664,8 +663,8 @@ namespace Xwt.Mac
 				return false;
 			
 			var backend = ob.Backend;
-			
-			INSDraggingInfo di = (INSDraggingInfo) Runtime.GetNSObject (dragInfo);
+
+			var di = Runtime.GetINativeObject<INSDraggingInfo> (dragInfo, owns: false);
 			var types = di.DraggingPasteboard.Types.Select (ToXwtDragType).ToArray ();
 			var pos = new Point (di.DraggingLocation.X, di.DraggingLocation.Y);
 			
@@ -688,7 +687,7 @@ namespace Xwt.Mac
 			
 			var backend = ob.Backend;
 			
-			INSDraggingInfo di = (INSDraggingInfo) Runtime.GetNSObject (dragInfo);
+			var di = Runtime.GetINativeObject<INSDraggingInfo> (dragInfo, owns: false);
 			var pos = new Point (di.DraggingLocation.X, di.DraggingLocation.Y);
 			
 			if ((backend.currentEvents & WidgetEvent.DragDrop) != 0) {
@@ -734,10 +733,10 @@ namespace Xwt.Mac
 				// For other well known types, we don't currently support dragging them externally
 				else if (t == TransferDataType.Uri || t == TransferDataType.Image || t == TransferDataType.Rtf || t == TransferDataType.Html)
 					;
-				// For internal types, 
+				// For internal types, set the data to something arbitrary, which isn't actually used
 				else {
 					pb.AddTypes(new string[] { t.Id }, null);
-					pb.SetStringForType("internal data", NSPasteboard.NSStringType);
+					pb.SetStringForType("internal drag", NSPasteboard.NSStringType);
 				}
 			}
 		}

--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -617,8 +617,9 @@ namespace Xwt.Mac
 			if (ob == null)
 				return NSDragOperation.None;
 			var backend = ob.Backend;
-			
-			INSDraggingInfo di = (INSDraggingInfo) Runtime.GetNSObject (dragInfo);
+
+			//INSDraggingInfo di = (INSDraggingInfo) Runtime.GetNSObject (dragInfo);
+			var di = Runtime.GetINativeObject<INSDraggingInfo>(dragInfo, owns: false);
 			var types = di.DraggingPasteboard.Types.Select (ToXwtDragType).ToArray ();
 			var pos = new Point (di.DraggingLocation.X, di.DraggingLocation.Y);
 			

--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -723,18 +723,20 @@ namespace Xwt.Mac
 		
 		void InitPasteboard (NSPasteboard pb, TransferDataSource data)
 		{
-			bool addedSomething = false;
-
 			pb.ClearContents ();
 			foreach (var t in data.DataTypes) {
+				// Support dragging text internally and externally
 				if (t == TransferDataType.Text) {
-					pb.AddTypes (new string[] { NSPasteboard.NSStringType }, null);
-					pb.SetStringForType ((string)data.GetValue (t), NSPasteboard.NSStringType);
-				}
-				else
-				{
-					pb.AddTypes(new string[] { ToNSDragType(t) }, null);
+					pb.AddTypes(new string[] { NSPasteboard.NSStringType }, null);
 					pb.SetStringForType((string)data.GetValue(t), NSPasteboard.NSStringType);
+				}
+				// For other well known types, we don't currently support dragging them externally
+				else if (t == TransferDataType.Uri || t == TransferDataType.Image || t == TransferDataType.Rtf || t == TransferDataType.Html)
+					;
+				// For internal types, 
+				else {
+					pb.AddTypes(new string[] { t.Id }, null);
+					pb.SetStringForType("internal data", NSPasteboard.NSStringType);
 				}
 			}
 		}

--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -953,7 +953,7 @@ namespace Xwt.Mac
 		TransferDataSource dataSource;
 
 		public PasteboardDataProvider(TransferDataSource dataSource)
-        {
+		{
 			this.dataSource = dataSource;
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -723,11 +723,18 @@ namespace Xwt.Mac
 		
 		void InitPasteboard (NSPasteboard pb, TransferDataSource data)
 		{
+			bool addedSomething = false;
+
 			pb.ClearContents ();
 			foreach (var t in data.DataTypes) {
 				if (t == TransferDataType.Text) {
 					pb.AddTypes (new string[] { NSPasteboard.NSStringType }, null);
 					pb.SetStringForType ((string)data.GetValue (t), NSPasteboard.NSStringType);
+				}
+				else
+				{
+					pb.AddTypes(new string[] { ToNSDragType(t) }, null);
+					pb.SetStringForType((string)data.GetValue(t), NSPasteboard.NSStringType);
 				}
 			}
 		}

--- a/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ViewBackend.cs
@@ -586,17 +586,10 @@ namespace Xwt.Mac
 
 			NSPasteboardItem pasteboardItem = CreatePasteboardItem(sdata.Data);
 
-#if false
-			var lo = Widget.ConvertPointToBase(new CGPoint(Widget.Bounds.X, Widget.Bounds.Y));
-			lo = Widget.Window.ConvertBaseToScreen(lo);
-			var ml = NSEvent.CurrentMouseLocation;
-
-			var pos = new CGPoint (ml.X - lo.X - (float)sdata.HotX, lo.Y - ml.Y - (float)sdata.HotY + img.Size.Height);
-			Widget.DragImage (img, pos, new CGSize (0, 0), NSApplication.SharedApplication.CurrentEvent, pb, Widget, true);
-#endif
-
 			var dragItem = new NSDraggingItem(pasteboardItem);
 
+			// Note that the hotspot (sdata.HotX, sdata.HotY) isn't currently supported here, but
+			// current users of this API don't use that anyway
 			var img = (NSImage)sdata.ImageBackend;
 			var frame = new CGRect(0, 0, img.Size.Width, img.Size.Height);
 			dragItem.SetDraggingFrame(frame, img);
@@ -928,7 +921,7 @@ namespace Xwt.Mac
 		}
 	}
 
-	class DraggingSource : NSDraggingSource
+	class DraggingSource : NSObject, INSDraggingSource
 	{
 		WeakReference<ViewBackend> weakViewBackend;
 
@@ -936,7 +929,7 @@ namespace Xwt.Mac
 		{
 			weakViewBackend = new WeakReference<ViewBackend>(viewBackend);
 		}
-
+		
 		[Export("draggingSession:willBeginAtPoint:")]
 		public void DraggingSessionWillBeginAtPoint(NSDraggingSession session, CGPoint screenPoint)
 		{


### PR DESCRIPTION
Fix so that drag/drop support works properly with the Cocoa backend.
This PR includes these fixes:

1. DraggingUpdate passed the wrong coordinates. Now do the proper conversion from view coordinates to window coordinates, as expected by the Xwt client.
2. Get the INSDraggingInfo object in the proper way, with `Runtime.GetINativeObject<INSDraggingInfo> (dragInfo, owns: false)`, same as we do in other code now.
3. Use the newer NSView.BeginDraggingSession API instead of the deprecated NSView.DragImage. This is needed so that we can provide a DraggingSource object in order to be notified when the drag/drop is over (no matter if successful or not) and call the Finished callback, as expected by Xwt client code.
4. Populate the pasteboard item used for the drag properly, supporting text drag/drop and internal formats (normally a serialized object where the Id is the assembly qualified type name).

To my knowledge the Android Designer is the only client that still uses this drag/drop code. All of these fixes were to make Android Designer drag/drop work properly.