### PR TITLE
[AlertDialogBackend] Ensures parent is set using the active window if there are not any window specified 

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/AlertDialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AlertDialogBackend.cs
@@ -112,6 +112,19 @@ namespace Xwt.Mac
 			Window.ReleasedWhenClosed = true;
 			if (win != null)
 				return sortedButtons [(int)this.RunSheetModal (win) - 1000];
+
+			if (win == null)
+			{
+				//a modal dialog needs parent window so we try take the current key
+				win = NSApplication.SharedApplication.ModalWindow ?? NSApplication.SharedApplication.KeyWindow;
+			}
+			
+			if (win != null)
+			{
+				win.AddChildWindow(this.Window, NSWindowOrderingMode.Above);
+			}
+
+			Util.CenterWindow(this.Window, win);
 			return sortedButtons [(int)this.RunModal () - 1000];
 		}
 


### PR DESCRIPTION
In cocoa backend when opening an modal AlertBox we need specify a parent and center to it for a correct positioning and avoid odd behaviours.