### PR TITLE
[Xam.Mac] Fixes parenting in DialogBackend

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -169,6 +169,13 @@ namespace Xwt.Mac
 		{
 			Visible = true;
 			modalSessionRunning = true;
+
+			NSWindow nsParent = parent.Window as NSWindow;
+			if (nsParent != null && nsParent.IsVisible)
+			{
+				nsParent.AddChildWindow(this, NSWindowOrderingMode.Above);
+			}
+			Util.CenterWindow(this, nsParent);
 			NSApplication.SharedApplication.RunModalForWindow (this);
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/Util.cs
+++ b/Xwt.XamMac/Xwt.Mac/Util.cs
@@ -108,6 +108,20 @@ namespace Xwt.Mac
 			v.Frame = new CGRect ((nfloat)rect.X, y, (nfloat)rect.Width, (nfloat)rect.Height);
 		}
 
+		public static void CenterWindow(NSWindow nsChild, NSWindow nsParent)
+		{
+			if (nsParent != null && nsParent.IsVisible)
+			{
+				int x = (int)(nsParent.Frame.Left + (nsParent.Frame.Width - nsChild.Frame.Width) / 2);
+				int y = (int)(nsParent.Frame.Top + (nsParent.Frame.Height - nsChild.Frame.Height) / 2);
+				nsChild.SetFrameOrigin(new CGPoint(x, y));
+			}
+			else
+			{
+				nsChild.Center();
+			}
+		}
+
 		public static Alignment ToAlignment (this NSTextAlignment align)
 		{
 			switch (align) {


### PR DESCRIPTION
This PR fixes set the correct parent when a dialog is shown in modal in the CocoaBackend and it also ensures it's centered to it.

 