### PR TITLE
Fix password autofill and wrapping

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/PasswordEntryBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/PasswordEntryBackend.cs
@@ -40,7 +40,12 @@ namespace Xwt.Mac
 		public override void Initialize ()
 		{
 			base.Initialize ();
+
 			var view = new CustomSecureTextField (EventSink, ApplicationContext);
+			view.Cell.UsesSingleLineMode = true;
+			view.Cell.Scrollable = true;
+			view.Cell.Wraps = false;
+
 			ViewObject = new CustomAlignedContainer (EventSink, ApplicationContext, (NSView)view) { DrawsBackground = false };
 		}
 
@@ -109,6 +114,7 @@ namespace Xwt.Mac
 			this.context = context;
 			this.eventSink = eventSink;
 			Activated += (sender, e) => context.InvokeUserCode (eventSink.OnActivated);
+			Changed += (sender, e) => context.InvokeUserCode (eventSink.OnChanged);
 		}
 
 		public NSView View {
@@ -118,12 +124,6 @@ namespace Xwt.Mac
 		}
 
 		public ViewBackend Backend { get; set; }
-
-		public override void DidChange (NSNotification notification)
-		{
-			base.DidChange (notification);
-			context.InvokeUserCode (eventSink.OnChanged);
-		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes the following issues with the VSM add apple developer account dialog:
 -autofill password does not enable the sign in button because the password from Apple Keychain is not being detected by the change handler
-long passwords wrap onto multiple lines