### PR TITLE
Sets a default parent in dialogs with empty parent

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -167,14 +167,21 @@ namespace Xwt.Mac
 
 		public void RunLoop (IWindowFrameBackend parent)
 		{
-			Visible = true;
-			modalSessionRunning = true;
+			NSWindow nsParent = parent?.Window as NSWindow;
+			if (nsParent == null)
+			{
+				//a modal dialog needs parent window so we try take the current key
+				nsParent = NSApplication.SharedApplication.ModalWindow ?? NSApplication.SharedApplication.KeyWindow;
+			}
 
-			NSWindow nsParent = parent.Window as NSWindow;
 			if (nsParent != null && nsParent.IsVisible)
 			{
 				nsParent.AddChildWindow(this, NSWindowOrderingMode.Above);
 			}
+
+			Visible = true;
+			modalSessionRunning = true;
+
 			Util.CenterWindow(this, nsParent);
 			NSApplication.SharedApplication.RunModalForWindow (this);
 		}


### PR DESCRIPTION
Ensures our new modal dialog is going to use the current focused window as a parent in case of null

![XDN1COSixb-1](https://user-images.githubusercontent.com/1587480/160673217-b00dc5c1-5d5e-4088-9535-1b5e1a8bf108.gif)

