### PR TITLE
[WindowFrameBackend] Only add parenting when dialog is preparing it be shown

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
@@ -336,8 +336,16 @@ namespace Xwt.Mac
 				Window.StyleMask &= ~NSWindowStyle.Miniaturizable;
 
 			//we try to get the native object from the parameter if not we fallback into the real parent
-			NSWindow nParent = (ApplicationContext.Toolkit.GetNativeWindow(parent) as NSWindow) ?? Window.ParentWindow;
-			if (nParent != Window.ParentWindow) {
+			if (ApplicationContext.Toolkit.GetNativeWindow(parent) is NSWindow nParent && nParent != Window.ParentWindow)
+            {
+				// remove from the previous parent
+				if (Window.ParentWindow != null)
+					Window.ParentWindow.RemoveChildWindow(Window);
+
+				// new parent has any associed window we remove it
+				if (nParent.ParentWindow != null)
+					nParent.ParentWindow.RemoveChildWindow(nParent);
+
 				Window.ParentWindow = nParent;
 			}
 		}

--- a/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
@@ -107,7 +107,6 @@ namespace Xwt.Mac
         {
 			if (parentWindow != null && Visible)
 			{
-				//if there is any child window we remove it
 				if (!parentWindow.ChildWindows.Contains(window))
 					parentWindow.AddChildWindow(window, NSWindowOrderingMode.Above);
 			}

--- a/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
@@ -96,20 +96,17 @@ namespace Xwt.Mac
 		internal void InternalShow ()
 		{
 			Window.MakeKeyAndOrderFront (MacEngine.App);
-			if (Window.ParentWindow != null) {
-				if (!Window.ParentWindow.ChildWindows.Contains (Window))
-					Window.ParentWindow.AddChildWindow (Window, NSWindowOrderingMode.Above);
+			var parentWindow = Window.ParentWindow;
 
-				// always use NSWindow for alignment when running in guest mode and
-				// don't rely on AddChildWindow to position the window correctly
-				if (!(Window.ParentWindow is WindowBackend)) {
-					var parentBounds = MacDesktopBackend.ToDesktopRect (Window.ParentWindow.ContentRectFor (Window.ParentWindow.Frame));
-					var bounds = ((IWindowFrameBackend)this).Bounds;
-					bounds.X = parentBounds.Center.X - (Window.Frame.Width / 2);
-					bounds.Y = parentBounds.Center.Y - (Window.Frame.Height / 2);
-					((IWindowFrameBackend)this).Bounds = bounds;
-				}
+			if (parentWindow != null && Visible)
+			{
+				//if there is any child window we remove it
+				if (!parentWindow.ChildWindows.Contains (Window))
+					parentWindow.AddChildWindow (Window, NSWindowOrderingMode.Above);
 			}
+
+			//we center in any case
+			Util.CenterWindow(Window, parentWindow);
 		}
 
 		public void Present ()

--- a/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
@@ -334,20 +334,14 @@ namespace Xwt.Mac
 
 		void IWindowFrameBackend.SetTransientFor (IWindowFrameBackend parent)
 		{
+			//TODO: why this?
 			if (!((IWindowFrameBackend)this).ShowInTaskbar)
 				Window.StyleMask &= ~NSWindowStyle.Miniaturizable;
 
-			var win = Window as NSWindow ?? ApplicationContext.Toolkit.GetNativeWindow (parent) as NSWindow;
-
-			if (Window.ParentWindow != win) {
-				// remove from the previous parent
-				if (Window.ParentWindow != null)
-					Window.ParentWindow.RemoveChildWindow (Window);
-
-				Window.ParentWindow = win;
-				// A window must be visible to be added to a parent. See InternalShow().
-				if (Visible)
-					Window.ParentWindow.AddChildWindow (Window, NSWindowOrderingMode.Above);
+			//we try to get the native object from the parameter if not we fallback into the real parent
+			NSWindow nParent = (ApplicationContext.Toolkit.GetNativeWindow(parent) as NSWindow) ?? Window.ParentWindow;
+			if (nParent != Window.ParentWindow) {
+				Window.ParentWindow = nParent;
 			}
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
@@ -104,7 +104,7 @@ namespace Xwt.Mac
 		}
 
 		void TryAddChildWindowIfVisible(NSWindow parentWindow, NSWindow window)
-        {
+		{
 			if (parentWindow != null && Visible)
 			{
 				if (!parentWindow.ChildWindows.Contains(window))
@@ -340,7 +340,7 @@ namespace Xwt.Mac
 
 			//we try to get the native object from the parameter if not we fallback into the real parent
 			if (ApplicationContext.Toolkit.GetNativeWindow(parent) is NSWindow nParent && nParent != Window.ParentWindow)
-            {
+  			{
 				// remove from the previous parent
 				if (Window.ParentWindow != null)
 					Window.ParentWindow.RemoveChildWindow(Window);

--- a/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
@@ -96,17 +96,21 @@ namespace Xwt.Mac
 		internal void InternalShow ()
 		{
 			Window.MakeKeyAndOrderFront (MacEngine.App);
-			var parentWindow = Window.ParentWindow;
 
+			var parentWindow = Window.ParentWindow;
+			TryAddChildWindowIfVisible(parentWindow, Window);
+			//we center in any case
+			Util.CenterWindow(Window, parentWindow);
+		}
+
+		void TryAddChildWindowIfVisible(NSWindow parentWindow, NSWindow window)
+        {
 			if (parentWindow != null && Visible)
 			{
 				//if there is any child window we remove it
-				if (!parentWindow.ChildWindows.Contains (Window))
-					parentWindow.AddChildWindow (Window, NSWindowOrderingMode.Above);
+				if (!parentWindow.ChildWindows.Contains(window))
+					parentWindow.AddChildWindow(window, NSWindowOrderingMode.Above);
 			}
-
-			//we center in any case
-			Util.CenterWindow(Window, parentWindow);
 		}
 
 		public void Present ()
@@ -347,6 +351,8 @@ namespace Xwt.Mac
 					nParent.ParentWindow.RemoveChildWindow(nParent);
 
 				Window.ParentWindow = nParent;
+
+				TryAddChildWindowIfVisible(nParent, Window);
 			}
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowFrameBackend.cs
@@ -346,10 +346,6 @@ namespace Xwt.Mac
 				if (Window.ParentWindow != null)
 					Window.ParentWindow.RemoveChildWindow(Window);
 
-				// new parent has any associed window we remove it
-				if (nParent.ParentWindow != null)
-					nParent.ParentWindow.RemoveChildWindow(nParent);
-
 				Window.ParentWindow = nParent;
 
 				TryAddChildWindowIfVisible(nParent, Window);

--- a/Xwt/Xwt/WindowFrame.cs
+++ b/Xwt/Xwt/WindowFrame.cs
@@ -260,7 +260,7 @@ namespace Xwt
 			get { return transientFor; }
 			set {
 				transientFor = value;
-				Backend.SetTransientFor ((IWindowFrameBackend)(value as IFrontend).Backend);
+				Backend.SetTransientFor ((IWindowFrameBackend)(value as IFrontend)?.Backend);
 			}
 		}
 


### PR DESCRIPTION
This PR fixes some issues in WindowFrameBackend:
* NRE whe transientFor is null (we added to cover this scenario)
* SetTransientFor tries to set the window passed as a parameter in the funcion and in case is not the current one it sets the value.
* Simplifies InternalShow() now takes the parent window and if is Visible and not contains the Window it adds as a children.

![SoN1wTqqfr](https://user-images.githubusercontent.com/1587480/162047200-9adc1f21-d641-48ed-b5f3-11c9c9232ebc.gif)
