### PR TITLE
[Mac] Fix ArgumentNullException when drawing Chinese characters

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/TextLayoutBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/TextLayoutBackendHandler.cs
@@ -206,8 +206,9 @@ namespace Xwt.Mac
 					NSRange er;
 					// get the effective font to modify for the given range
 					var ft = TextStorage.GetAttribute (NSStringAttributeKey.Font, attribute.StartIndex, out er, r) as NSFont;
-					ft = ft.WithWeight (xa.Weight);
-					TextStorage.AddAttribute (NSStringAttributeKey.Font, ft, r);
+					ft = ft?.WithWeight (xa.Weight);
+					if (ft != null)
+						TextStorage.AddAttribute (NSStringAttributeKey.Font, ft, r);
 				}
 				else if (attribute is LinkTextAttribute)
 				{
@@ -225,8 +226,9 @@ namespace Xwt.Mac
 					var xa = (FontSizeTextAttribute)attribute;
 					NSRange er;
 					var ft = TextStorage.GetAttribute (NSStringAttributeKey.Font, attribute.StartIndex, out er, r) as NSFont;
-					ft = ft.WithSize (xa.Size);
-					TextStorage.AddAttribute (NSStringAttributeKey.Font, ft, r);
+					ft = ft?.WithSize (xa.Size);
+					if (ft != null)
+						TextStorage.AddAttribute (NSStringAttributeKey.Font, ft, r);
 				} 
 				else if (attribute is FontTextAttribute)
 				{


### PR DESCRIPTION
The TextLayoutBackendHandler did not handle NSFont returning null
when trying to get a different weight or size for an NSFont.

System.ArgumentNullException: Value cannot be null. (Parameter
'value')
   at ObjCRuntime.ThrowHelper.ThrowArgumentNullException(
String argumentName) in xamarin-macios/src/ObjCRuntime/
ThrowHelper.cs:line 28
   at Foundation.NSMutableAttributedString.AddAttribute(
NSString attributeName, NSObject value, NSRange range) in
xamarin-macios/src/build/dotnet/macos/generated-sources/Foundation/
NSMutableAttributedString.g.cs:line 187
   at Xwt.Mac.MacTextLayoutBackendHandler.LayoutInfo.
AddAttributeInternal(TextAttribute attribute) in Xwt.XamMac/
Xwt.Mac/TextLayoutBackendHandler.cs:line 210
   at Xwt.Mac.MacTextLayoutBackendHandler.LayoutInfo.AddAttribute(
TextAttribute attribute) in Xwt.XamMac/Xwt.Mac/
TextLayoutBackendHandler.cs:line 125
   at Xwt.Mac.MacTextLayoutBackendHandler.AddAttribute(Object backend,
TextAttribute attribute) in Xwt.XamMac/Xwt.Mac/
TextLayoutBackendHandler.cs:line 405
   at Xwt.Drawing.TextLayout.set_Markup(String value) Xwt.Drawing/
TextLayout.cs:line 260