### PR TITLE
Mac: Make dialog window key when showing

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -174,6 +174,10 @@ namespace Xwt.Mac
 				nsParent = NSApplication.SharedApplication.ModalWindow ?? NSApplication.SharedApplication.KeyWindow;
 			}
 
+			// Next, make this window key before adding it as a child.
+			// This matches behavior in MonoDevelop.Ide.MessageService.RunCustomDialog.
+			MakeKeyAndOrderFront(NSApplication.SharedApplication);
+
 			if (nsParent != null && nsParent.IsVisible)
 			{
 				nsParent.AddChildWindow(this, NSWindowOrderingMode.Above);


### PR DESCRIPTION
Fixes scenarios where a dialog is shown but a background window
continues receiving input.