### PR TITLE
Fixes hang trying to move modal dialog in a secondary monitor

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -178,11 +178,6 @@ namespace Xwt.Mac
 			// This matches behavior in MonoDevelop.Ide.MessageService.RunCustomDialog.
 			MakeKeyAndOrderFront(NSApplication.SharedApplication);
 
-			if (nsParent != null && nsParent.IsVisible)
-			{
-				nsParent.AddChildWindow(this, NSWindowOrderingMode.Above);
-			}
-
 			Visible = true;
 			modalSessionRunning = true;
 
@@ -194,8 +189,7 @@ namespace Xwt.Mac
 		{
 			modalSessionRunning = false;
 			var parent = ParentWindow;
-			if (parent != null)
-				parent.RemoveChildWindow (this);
+		
 			OrderOut (this);
 			Close();
 			NSApplication.SharedApplication.StopModal ();


### PR DESCRIPTION
Use AddChildWindow function introduces a problem with multimonitor when try to move any child window on a different monitor than the parent. I have the feeling that it is a cocoa bug but since it crashes the application, the workaround is to
simply open it with MakeKeyAndOrderFront and/or making it modal. I've done my research and all the apps I've tried use this pattern