### PR TITLE
[Xwt.Mac] Fixes some parent window issues in cocoa backend

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/DialogBackend.cs
@@ -174,6 +174,8 @@ namespace Xwt.Mac
 				nsParent = NSApplication.SharedApplication.ModalWindow ?? NSApplication.SharedApplication.KeyWindow;
 			}
 
+			weakParentWindow = new WeakReference<NSWindow>(nsParent);
+
 			// Next, make this window key before adding it as a child.
 			// This matches behavior in MonoDevelop.Ide.MessageService.RunCustomDialog.
 			MakeKeyAndOrderFront(NSApplication.SharedApplication);
@@ -188,8 +190,10 @@ namespace Xwt.Mac
 		public void EndLoop ()
 		{
 			modalSessionRunning = false;
-			var parent = ParentWindow;
-		
+
+			NSWindow parent = null;
+			weakParentWindow?.TryGetTarget(out parent);
+
 			OrderOut (this);
 			Close();
 			NSApplication.SharedApplication.StopModal ();

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -115,11 +115,13 @@ namespace Xwt.Mac
 		internal void InternalShow ()
 		{
 			MakeKeyAndOrderFront (MacEngine.App);
-			if (ParentWindow != null)
+
+			if (weakParentWindow?.TryGetTarget(out var nsWindow) ?? false)
 			{
 				// always use NSWindow for alignment when running in guest mode and
 				// don't rely on AddChildWindow to position the window correctly
-				if (frontend.InitialLocation == WindowLocation.CenterParent && !(ParentWindow is WindowBackend))
+
+				if (frontend.InitialLocation == WindowLocation.CenterParent && !(nsWindow is WindowBackend))
 				{
 					var parentBounds = MacDesktopBackend.ToDesktopRect(ParentWindow.ContentRectFor(ParentWindow.Frame));
 					var bounds = ((IWindowFrameBackend)this).Bounds;
@@ -127,7 +129,9 @@ namespace Xwt.Mac
 					bounds.Y = parentBounds.Center.Y - (Frame.Height / 2);
 					((IWindowFrameBackend)this).Bounds = bounds;
 				}
-				if (AccessibilityFocusedWindow == ParentWindow) {
+
+				if (AccessibilityFocusedWindow == nsWindow)
+				{
 					AccessibilityFocusedWindow = this;
 				}
 			}
@@ -380,10 +384,21 @@ namespace Xwt.Mac
 			}
 		}
 
+		protected WeakReference<NSWindow> weakParentWindow;
+
 		void IWindowFrameBackend.SetTransientFor (IWindowFrameBackend window)
 		{
 			if (!((IWindowFrameBackend)this).ShowInTaskbar)
 				StyleMask &= ~NSWindowStyle.Miniaturizable;
+
+			if (window is NSWindow nsWindow)
+			{
+				weakParentWindow = new WeakReference<NSWindow>(nsWindow);
+			}
+			else
+			{
+				weakParentWindow = null;
+			}
 		}
 
 		bool IWindowFrameBackend.Resizable {

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -117,9 +117,6 @@ namespace Xwt.Mac
 			MakeKeyAndOrderFront (MacEngine.App);
 			if (ParentWindow != null)
 			{
-				if (!ParentWindow.ChildWindows.Contains(this))
-					ParentWindow.AddChildWindow(this, NSWindowOrderingMode.Above);
-
 				// always use NSWindow for alignment when running in guest mode and
 				// don't rely on AddChildWindow to position the window correctly
 				if (frontend.InitialLocation == WindowLocation.CenterParent && !(ParentWindow is WindowBackend))
@@ -272,8 +269,6 @@ namespace Xwt.Mac
 				PerformClose(this);
 			else
 				Close ();
-			if (ParentWindow != null)
-				ParentWindow.RemoveChildWindow(this);
 			return closePerformed;
 		}
 		
@@ -393,14 +388,7 @@ namespace Xwt.Mac
 			var win = window as NSWindow ?? ApplicationContext.Toolkit.GetNativeWindow(window) as NSWindow;
 
 			if (ParentWindow != win) {
-				// remove from the previous parent
-				if (ParentWindow != null)
-					ParentWindow.RemoveChildWindow(this);
-
 				ParentWindow = win;
-				// A window must be visible to be added to a parent. See InternalShow().
-				if (Visible)
-					ParentWindow.AddChildWindow(this, NSWindowOrderingMode.Above);
 			}
 		}
 

--- a/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/WindowBackend.cs
@@ -384,12 +384,6 @@ namespace Xwt.Mac
 		{
 			if (!((IWindowFrameBackend)this).ShowInTaskbar)
 				StyleMask &= ~NSWindowStyle.Miniaturizable;
-
-			var win = window as NSWindow ?? ApplicationContext.Toolkit.GetNativeWindow(window) as NSWindow;
-
-			if (ParentWindow != win) {
-				ParentWindow = win;
-			}
 		}
 
 		bool IWindowFrameBackend.Resizable {


### PR DESCRIPTION
This PR completes https://github.com/mono/xwt/pull/1112 fix, DialogBackend inherits from WindowBackend and this was also usingAdd/RemoveChildWindow, so we cleaned it.

After remove Add/RemoveChildWindow we got into another issue when we were setting ParentWindow property, this is not recommend by Apple and should not be done in modal dialogs, also it broke some system popups like the NSComboBox search in dialogs like scaffolding. I fixed this using a WeakReference cached element.