### PR TITLE
[Mac] Fix ImageView accessibility

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/AccessibleBackend.cs
@@ -73,6 +73,8 @@ namespace Xwt.Mac
 				widget = ((EmbedNativeWidgetBackend)parentWidget).EmbeddedView;
 			else if (parentWidget is CustomAlignedContainer) // bypass alignment containers
 				widget = ((CustomAlignedContainer)parentWidget).Child;
+			if (widget is NSImageView imageView)
+				widget = imageView.Cell;
 			if (widget == null)
 				widget = parentWidget as INSAccessibility;
 			if (widget == null)


### PR DESCRIPTION
The ImageView.Accessible was using the INSAccessibility implementation from the NSImageView when it should have been using the NSImageView's Cell.

Change the AccessibleBackend to use the NSImageView's Cell. The ImageViewBackend puts the NSImageView inside an CustomAlignedContainer so the AccessibleBackend.Initialize method checks for an NSImageView after the CustomAlignedContainer.Child has been found.