### PR TITLE
Keep a local ref of the NSImage so it doesn't try to get reconstructed

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/ImageViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageViewBackend.cs
@@ -53,16 +53,21 @@ namespace Xwt.Mac
 			NSImage img = Widget.Image;
 			return img == null ? Size.Zero : img.Size.ToXwtSize ();
 		}
+		
+		NSImage nsImage; // Needed to keep a ref, otherwise Xam.Mac might GC it and try to resurrect it
 
 		public void SetImage (ImageDescription image)
 		{
 			if (image.IsNull) {
 				Widget.Image = null;
+				nsImage = null;
 				return;
 			}
+			
+			nsImage = image.ToNSImage ();
 
-			Widget.Image = image.ToNSImage ();
-			Widget.SetFrameSize (Widget.Image.Size);
+			Widget.Image = nsImage;
+			Widget.SetFrameSize (nsImage.Size);
 		}
 	}
 }

--- a/Xwt.XamMac/Xwt.Mac/ImageViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/ImageViewBackend.cs
@@ -65,7 +65,6 @@ namespace Xwt.Mac
 			}
 			
 			nsImage = image.ToNSImage ();
-
 			Widget.Image = nsImage;
 			Widget.SetFrameSize (nsImage.Size);
 		}


### PR DESCRIPTION
VSMac is getting some exceptions that we are trying to resurrect the image in this code, so keep a local copy of the NSImage... 

Here is the part of the exception callstack:

"ObjCRuntime.Runtime.MissingCtor(IntPtr,IntPtr,Type,MissingCtorResolution)", "ObjCRuntime.Runtime.ConstructNSObject\[T\](IntPtr,Type,MissingCtorResolution)", 
"ObjCRuntime.Runtime.GetNSObject\[T\](IntPtr)",
"AppKit.NSImageView.get_Image()",
"Xwt.Mac.ImageViewBackend.SetImage(ImageDescription)", "Xwt.ImageView.set_Image(Image)",