### PR TITLE
Fix appveyor

### DIFF
--- a/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
+++ b/Xwt.XamMac/Xwt.Mac/FontBackendHandler.cs
@@ -39,10 +39,10 @@ namespace Xwt
 	public static class FontExtensions
 	{
 		static bool IsSystemFont(this NSFont font)
-			=> !font.FontDescriptor.FontAttributes.TryGetValue(NSFont.NameAttribute, out var nsoName)
-				|| nsoName is not NSString name
-				|| name.Length == 0
-				|| name[0] == '.';
+			=> !(font.FontDescriptor.FontAttributes.TryGetValue(NSFont.NameAttribute, out var nsoName)
+				&& nsoName is NSString name
+				&& name.Length != 0
+				&& name[0] != '.');
 
 		public static Font ToXwt(this NSFont font)
 			=> font.IsSystemFont()

--- a/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
+++ b/Xwt.XamMac/Xwt.Mac/OutlineViewBackend.cs
@@ -26,7 +26,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-global using ObjCRuntime;
+using ObjCRuntime;
 
 using System;
 using System.Linq;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,13 +19,13 @@ assembly_info:
   assembly_informational_version: '{version}'
 
 install:
-- if not exist gtk-sharp-2.12.42.msi appveyor DownloadFile https://dl.xamarin.com/GTKforWindows/Windows/gtk-sharp-2.12.42.msi
-- msiexec /i gtk-sharp-2.12.42.msi /qn /norestart
+- if not exist gtk-sharp-2.12.45.msi appveyor DownloadFile https://github.com/mono/gtk-sharp/releases/download/2.12.45/gtk-sharp-2.12.45.msi
+- msiexec /i gtk-sharp-2.12.45.msi /qn /norestart
 - if not exist gtk-sharp-2.99.3.msi appveyor DownloadFile https://download.gnome.org/binaries/win32/gtk-sharp/2.99/gtk-sharp-2.99.3.msi
 - msiexec /i gtk-sharp-2.99.3.msi /qn /norestart
 
 cache:
-- gtk-sharp-2.12.42.msi
+- gtk-sharp-2.12.45.msi
 - gtk-sharp-2.99.3.msi
 - packages
 


### PR DESCRIPTION
Bump to a newer gtk-sharp download and fix the errors in code when doing so:

> "C:\projects\xwt\Xwt.XamMac\Xwt.XamMac.csproj" (Build target) (1) ->
> (CoreCompile target) -> 
>   C:\projects\xwt\Xwt.XamMac\Xwt.Mac\FontBackendHandler.cs(43,19): error CS8370: Feature 'not pattern' is not available in C# 7.3. Please use language version 9.0 or greater. [C:\projects\xwt\Xwt.XamMac\Xwt.XamMac.csproj]
>   C:\projects\xwt\Xwt.XamMac\Xwt.Mac\OutlineViewBackend.cs(29,1): error CS8652: The feature 'global using directive' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version. [C:\projects\xwt\Xwt.XamMac\Xwt.XamMac.csproj]